### PR TITLE
Fix Cognito secret key: issuer -> issuer_url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.14] - 2025-12-07
+
+### Fixed
+- Cognito secret retrieval from Secrets Manager
+
 ## [0.1.12] - 2025-12-07
 
 ### Added

--- a/mcp/aptl-mcp-common/package.json
+++ b/mcp/aptl-mcp-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "aptl-mcp-common",
-    "version": "0.1.10",
+    "version": "0.1.14",
     "description": "Common library extracted from APTL MCP servers",
     "type": "module",
     "main": "./build/index.js",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 sonar.projectKey=Brad-Edwards_shifter
 sonar.organization=brad-edwards
 sonar.projectName=Shifter
-sonar.projectVersion=0.1.10
+sonar.projectVersion=0.1.14
 
 # Source paths
 sonar.sources=mcp

--- a/terraform/modules/portal/cognito/main.tf
+++ b/terraform/modules/portal/cognito/main.tf
@@ -201,6 +201,6 @@ resource "aws_secretsmanager_secret_version" "cognito_client" {
     client_secret = aws_cognito_user_pool_client.portal.client_secret
     user_pool_id  = aws_cognito_user_pool.main.id
     domain        = "https://${aws_cognito_user_pool_domain.main.domain}.auth.${var.aws_region}.amazoncognito.com"
-    issuer        = "https://cognito-idp.${var.aws_region}.amazonaws.com/${aws_cognito_user_pool.main.id}"
+    issuer_url    = "https://cognito-idp.${var.aws_region}.amazonaws.com/${aws_cognito_user_pool.main.id}"
   })
 }


### PR DESCRIPTION
The entrypoint.sh reads 'issuer_url' from the secret but Terraform
was creating it as 'issuer'. This mismatch caused OIDC_ISSUER_URL
to be empty, breaking the authentication redirect.
