### PR TITLE
Add OpenBAS shared infrastructure module

### DIFF
--- a/platform/terraform/environments/dev/range/main.tf
+++ b/platform/terraform/environments/dev/range/main.tf
@@ -71,7 +71,7 @@ module "openbas" {
   tags                   = var.tags
 
   # OpenBAS configuration
-  domain_name   = var.openbas_domain_name
+  base_url      = var.openbas_base_url
   openbas_image = var.openbas_image
 
   # ECS configuration

--- a/platform/terraform/environments/dev/range/main.tf
+++ b/platform/terraform/environments/dev/range/main.tf
@@ -54,3 +54,41 @@ module "pulumi_state" {
   tags               = var.tags
   log_retention_days = var.log_retention_days
 }
+
+# ------------------------------------------------------------------------------
+# OpenBAS Shared Infrastructure
+# ------------------------------------------------------------------------------
+
+module "openbas" {
+  count  = var.enable_openbas ? 1 : 0
+  source = "../../../modules/openbas"
+
+  name_prefix            = local.name_prefix
+  vpc_id                 = module.vpc.vpc_id
+  vpc_cidr               = var.vpc_cidr
+  portal_vpc_cidr        = var.portal_vpc_cidr
+  private_route_table_id = module.vpc.private_route_table_id
+  tags                   = var.tags
+
+  # OpenBAS configuration
+  domain_name   = var.openbas_domain_name
+  openbas_image = var.openbas_image
+
+  # ECS configuration
+  task_cpu           = var.openbas_task_cpu
+  task_memory        = var.openbas_task_memory
+  desired_count      = var.openbas_desired_count
+  enable_autoscaling = var.openbas_enable_autoscaling
+  min_capacity       = var.openbas_min_capacity
+  max_capacity       = var.openbas_max_capacity
+
+  # Database configuration
+  db_instance_class        = var.openbas_db_instance_class
+  db_multi_az              = var.openbas_db_multi_az
+  db_backup_retention_days = var.openbas_db_backup_retention_days
+  db_deletion_protection   = var.openbas_db_deletion_protection
+  db_skip_final_snapshot   = var.openbas_db_skip_final_snapshot
+
+  # Logging
+  log_retention_days = var.log_retention_days
+}

--- a/platform/terraform/environments/dev/range/outputs.tf
+++ b/platform/terraform/environments/dev/range/outputs.tf
@@ -171,3 +171,67 @@ output "ngfw_capacity_sns_topic_arn" {
   description = "ARN of the SNS topic for NGFW capacity alerts (null if NGFW infrastructure disabled)"
   value       = module.vpc.ngfw_capacity_sns_topic_arn
 }
+
+# ------------------------------------------------------------------------------
+# OpenBAS Shared Infrastructure
+# ------------------------------------------------------------------------------
+
+output "openbas_enabled" {
+  description = "Whether OpenBAS infrastructure is enabled"
+  value       = var.enable_openbas
+}
+
+output "openbas_alb_dns_name" {
+  description = "DNS name of the OpenBAS internal ALB (null if disabled)"
+  value       = var.enable_openbas ? module.openbas[0].alb_dns_name : null
+}
+
+output "openbas_api_endpoint" {
+  description = "HTTPS endpoint for OpenBAS API (null if disabled)"
+  value       = var.enable_openbas ? module.openbas[0].api_endpoint : null
+}
+
+output "openbas_internal_endpoint" {
+  description = "Internal ALB endpoint for OpenBAS (null if disabled)"
+  value       = var.enable_openbas ? module.openbas[0].internal_endpoint : null
+}
+
+output "openbas_db_endpoint" {
+  description = "Connection endpoint for OpenBAS RDS (null if disabled)"
+  value       = var.enable_openbas ? module.openbas[0].db_endpoint : null
+}
+
+output "openbas_db_credentials_secret_arn" {
+  description = "ARN of the Secrets Manager secret for OpenBAS DB credentials (null if disabled)"
+  value       = var.enable_openbas ? module.openbas[0].db_credentials_secret_arn : null
+}
+
+output "openbas_admin_token_secret_arn" {
+  description = "ARN of the Secrets Manager secret for OpenBAS admin token (null if disabled)"
+  value       = var.enable_openbas ? module.openbas[0].admin_token_secret_arn : null
+}
+
+output "openbas_ecs_cluster_name" {
+  description = "Name of the OpenBAS ECS cluster (null if disabled)"
+  value       = var.enable_openbas ? module.openbas[0].ecs_cluster_name : null
+}
+
+output "openbas_ecs_service_name" {
+  description = "Name of the OpenBAS ECS service (null if disabled)"
+  value       = var.enable_openbas ? module.openbas[0].ecs_service_name : null
+}
+
+output "openbas_subnet_ids" {
+  description = "IDs of the OpenBAS subnets (null if disabled)"
+  value       = var.enable_openbas ? module.openbas[0].subnet_ids : null
+}
+
+output "openbas_storage_bucket_id" {
+  description = "ID of the OpenBAS S3 storage bucket (null if disabled)"
+  value       = var.enable_openbas ? module.openbas[0].storage_bucket_id : null
+}
+
+output "openbas_certificate_domain_validation_options" {
+  description = "Domain validation options for the OpenBAS ACM certificate (null if disabled)"
+  value       = var.enable_openbas ? module.openbas[0].certificate_domain_validation_options : null
+}

--- a/platform/terraform/environments/dev/range/outputs.tf
+++ b/platform/terraform/environments/dev/range/outputs.tf
@@ -173,7 +173,7 @@ output "ngfw_capacity_sns_topic_arn" {
 }
 
 # ------------------------------------------------------------------------------
-# OpenBAS Shared Infrastructure
+# OpenBAS Shared Infrastructure (Shifter Mirage)
 # ------------------------------------------------------------------------------
 
 output "openbas_enabled" {
@@ -181,19 +181,14 @@ output "openbas_enabled" {
   value       = var.enable_openbas
 }
 
-output "openbas_alb_dns_name" {
-  description = "DNS name of the OpenBAS internal ALB (null if disabled)"
-  value       = var.enable_openbas ? module.openbas[0].alb_dns_name : null
+output "openbas_target_group_arn" {
+  description = "ARN of the OpenBAS target group for Portal ALB (null if disabled)"
+  value       = var.enable_openbas ? module.openbas[0].target_group_arn : null
 }
 
 output "openbas_api_endpoint" {
-  description = "HTTPS endpoint for OpenBAS API (null if disabled)"
+  description = "Base URL for OpenBAS API (null if disabled)"
   value       = var.enable_openbas ? module.openbas[0].api_endpoint : null
-}
-
-output "openbas_internal_endpoint" {
-  description = "Internal ALB endpoint for OpenBAS (null if disabled)"
-  value       = var.enable_openbas ? module.openbas[0].internal_endpoint : null
 }
 
 output "openbas_db_endpoint" {
@@ -229,9 +224,4 @@ output "openbas_subnet_ids" {
 output "openbas_storage_bucket_id" {
   description = "ID of the OpenBAS S3 storage bucket (null if disabled)"
   value       = var.enable_openbas ? module.openbas[0].storage_bucket_id : null
-}
-
-output "openbas_certificate_domain_validation_options" {
-  description = "Domain validation options for the OpenBAS ACM certificate (null if disabled)"
-  value       = var.enable_openbas ? module.openbas[0].certificate_domain_validation_options : null
 }

--- a/platform/terraform/environments/dev/range/terraform.tfvars
+++ b/platform/terraform/environments/dev/range/terraform.tfvars
@@ -44,13 +44,13 @@ vm_series_instance_type = "m5.xlarge"
 enable_ngfw_infrastructure = true
 
 # ------------------------------------------------------------------------------
-# OpenBAS Shared Infrastructure
+# OpenBAS Shared Infrastructure (Shifter Mirage)
 # ------------------------------------------------------------------------------
-# Set enable_openbas = true and configure domain to deploy OpenBAS
-# Requires DNS validation for ACM certificate
+# Set enable_openbas = true to deploy OpenBAS
+# Accessed via Portal ALB at /shifter-mirage/bas/
 
-enable_openbas      = false
-openbas_domain_name = "openbas.dev.shifter.internal" # Update with actual domain
+enable_openbas   = false
+openbas_base_url = "https://dev.shifter.example.com/shifter-mirage/bas" # Update with Portal domain
 
 # ECS sizing (dev defaults - adjust for production)
 openbas_task_cpu      = 1024 # 1 vCPU

--- a/platform/terraform/environments/dev/range/terraform.tfvars
+++ b/platform/terraform/environments/dev/range/terraform.tfvars
@@ -42,3 +42,21 @@ vm_series_instance_type = "m5.xlarge"
 # ------------------------------------------------------------------------------
 
 enable_ngfw_infrastructure = true
+
+# ------------------------------------------------------------------------------
+# OpenBAS Shared Infrastructure
+# ------------------------------------------------------------------------------
+# Set enable_openbas = true and configure domain to deploy OpenBAS
+# Requires DNS validation for ACM certificate
+
+enable_openbas      = false
+openbas_domain_name = "openbas.dev.shifter.internal" # Update with actual domain
+
+# ECS sizing (dev defaults - adjust for production)
+openbas_task_cpu      = 1024 # 1 vCPU
+openbas_task_memory   = 4096 # 4 GB
+openbas_desired_count = 2
+
+# Database sizing (dev defaults)
+openbas_db_instance_class = "db.t3.small"
+openbas_db_multi_az       = true

--- a/platform/terraform/environments/dev/range/variables.tf
+++ b/platform/terraform/environments/dev/range/variables.tf
@@ -73,3 +73,91 @@ variable "enable_ngfw_infrastructure" {
   description = "Enable persistent NGFW infrastructure (subnet, security groups, IAM role)"
   type        = bool
 }
+
+# ------------------------------------------------------------------------------
+# OpenBAS Configuration
+# ------------------------------------------------------------------------------
+
+variable "enable_openbas" {
+  description = "Enable OpenBAS shared infrastructure"
+  type        = bool
+  default     = false
+}
+
+variable "openbas_domain_name" {
+  description = "Domain name for OpenBAS (for ACM certificate)"
+  type        = string
+  default     = ""
+}
+
+variable "openbas_image" {
+  description = "Docker image for OpenBAS"
+  type        = string
+  default     = "openbas/openbas:latest"
+}
+
+variable "openbas_task_cpu" {
+  description = "CPU units for OpenBAS ECS task (1024 = 1 vCPU)"
+  type        = number
+  default     = 1024
+}
+
+variable "openbas_task_memory" {
+  description = "Memory for OpenBAS ECS task in MB"
+  type        = number
+  default     = 4096
+}
+
+variable "openbas_desired_count" {
+  description = "Desired number of OpenBAS ECS tasks"
+  type        = number
+  default     = 2
+}
+
+variable "openbas_enable_autoscaling" {
+  description = "Enable auto scaling for OpenBAS ECS service"
+  type        = bool
+  default     = true
+}
+
+variable "openbas_min_capacity" {
+  description = "Minimum number of OpenBAS ECS tasks"
+  type        = number
+  default     = 2
+}
+
+variable "openbas_max_capacity" {
+  description = "Maximum number of OpenBAS ECS tasks"
+  type        = number
+  default     = 4
+}
+
+variable "openbas_db_instance_class" {
+  description = "RDS instance class for OpenBAS database"
+  type        = string
+  default     = "db.t3.small"
+}
+
+variable "openbas_db_multi_az" {
+  description = "Enable Multi-AZ deployment for OpenBAS RDS"
+  type        = bool
+  default     = true
+}
+
+variable "openbas_db_backup_retention_days" {
+  description = "Backup retention days for OpenBAS RDS"
+  type        = number
+  default     = 7
+}
+
+variable "openbas_db_deletion_protection" {
+  description = "Enable deletion protection for OpenBAS RDS"
+  type        = bool
+  default     = false
+}
+
+variable "openbas_db_skip_final_snapshot" {
+  description = "Skip final snapshot when destroying OpenBAS RDS"
+  type        = bool
+  default     = true
+}

--- a/platform/terraform/environments/dev/range/variables.tf
+++ b/platform/terraform/environments/dev/range/variables.tf
@@ -84,8 +84,8 @@ variable "enable_openbas" {
   default     = false
 }
 
-variable "openbas_domain_name" {
-  description = "Domain name for OpenBAS (for ACM certificate)"
+variable "openbas_base_url" {
+  description = "Base URL for OpenBAS (e.g., https://portal.example.com/shifter-mirage/bas)"
   type        = string
   default     = ""
 }

--- a/platform/terraform/modules/openbas/alarms.tf
+++ b/platform/terraform/modules/openbas/alarms.tf
@@ -3,7 +3,6 @@
 # Monitoring for:
 # - ECS service health
 # - RDS database metrics
-# - ALB performance
 
 # ------------------------------------------------------------------------------
 # SNS Topic for Alerts
@@ -141,72 +140,6 @@ resource "aws_cloudwatch_metric_alarm" "rds_connections_high" {
 
   dimensions = {
     DBInstanceIdentifier = aws_db_instance.openbas.identifier
-  }
-
-  tags = local.common_tags
-}
-
-# ------------------------------------------------------------------------------
-# ALB Alarms
-# ------------------------------------------------------------------------------
-
-resource "aws_cloudwatch_metric_alarm" "alb_5xx_errors" {
-  alarm_name          = "${var.name_prefix}-openbas-alb-5xx-errors"
-  comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = 2
-  metric_name         = "HTTPCode_Target_5XX_Count"
-  namespace           = "AWS/ApplicationELB"
-  period              = 300
-  statistic           = "Sum"
-  threshold           = 10
-  alarm_description   = "OpenBAS ALB receiving 5xx errors from targets"
-  alarm_actions       = [aws_sns_topic.openbas_alerts.arn]
-  ok_actions          = [aws_sns_topic.openbas_alerts.arn]
-  treat_missing_data  = "notBreaching"
-
-  dimensions = {
-    LoadBalancer = aws_lb.openbas.arn_suffix
-  }
-
-  tags = local.common_tags
-}
-
-resource "aws_cloudwatch_metric_alarm" "alb_unhealthy_hosts" {
-  alarm_name          = "${var.name_prefix}-openbas-alb-unhealthy-hosts"
-  comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = 2
-  metric_name         = "UnHealthyHostCount"
-  namespace           = "AWS/ApplicationELB"
-  period              = 60
-  statistic           = "Maximum"
-  threshold           = 0
-  alarm_description   = "OpenBAS ALB has unhealthy targets"
-  alarm_actions       = [aws_sns_topic.openbas_alerts.arn]
-  ok_actions          = [aws_sns_topic.openbas_alerts.arn]
-
-  dimensions = {
-    LoadBalancer = aws_lb.openbas.arn_suffix
-    TargetGroup  = aws_lb_target_group.openbas.arn_suffix
-  }
-
-  tags = local.common_tags
-}
-
-resource "aws_cloudwatch_metric_alarm" "alb_latency_high" {
-  alarm_name          = "${var.name_prefix}-openbas-alb-latency-high"
-  comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = 3
-  metric_name         = "TargetResponseTime"
-  namespace           = "AWS/ApplicationELB"
-  period              = 300
-  extended_statistic  = "p99"
-  threshold           = 5 # 5 seconds
-  alarm_description   = "OpenBAS ALB p99 latency is too high"
-  alarm_actions       = [aws_sns_topic.openbas_alerts.arn]
-  ok_actions          = [aws_sns_topic.openbas_alerts.arn]
-
-  dimensions = {
-    LoadBalancer = aws_lb.openbas.arn_suffix
   }
 
   tags = local.common_tags

--- a/platform/terraform/modules/openbas/alarms.tf
+++ b/platform/terraform/modules/openbas/alarms.tf
@@ -1,0 +1,213 @@
+# OpenBAS CloudWatch Alarms
+#
+# Monitoring for:
+# - ECS service health
+# - RDS database metrics
+# - ALB performance
+
+# ------------------------------------------------------------------------------
+# SNS Topic for Alerts
+# ------------------------------------------------------------------------------
+
+resource "aws_sns_topic" "openbas_alerts" {
+  name = "${var.name_prefix}-openbas-alerts"
+
+  tags = local.common_tags
+}
+
+# ------------------------------------------------------------------------------
+# ECS Service Alarms
+# ------------------------------------------------------------------------------
+
+resource "aws_cloudwatch_metric_alarm" "ecs_cpu_high" {
+  alarm_name          = "${var.name_prefix}-openbas-cpu-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 3
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ECS"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 80
+  alarm_description   = "OpenBAS ECS CPU utilization is too high"
+  alarm_actions       = [aws_sns_topic.openbas_alerts.arn]
+  ok_actions          = [aws_sns_topic.openbas_alerts.arn]
+
+  dimensions = {
+    ClusterName = aws_ecs_cluster.openbas.name
+    ServiceName = aws_ecs_service.openbas.name
+  }
+
+  tags = local.common_tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "ecs_memory_high" {
+  alarm_name          = "${var.name_prefix}-openbas-memory-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 3
+  metric_name         = "MemoryUtilization"
+  namespace           = "AWS/ECS"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 80
+  alarm_description   = "OpenBAS ECS memory utilization is too high"
+  alarm_actions       = [aws_sns_topic.openbas_alerts.arn]
+  ok_actions          = [aws_sns_topic.openbas_alerts.arn]
+
+  dimensions = {
+    ClusterName = aws_ecs_cluster.openbas.name
+    ServiceName = aws_ecs_service.openbas.name
+  }
+
+  tags = local.common_tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "ecs_task_count_low" {
+  alarm_name          = "${var.name_prefix}-openbas-task-count-low"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "RunningTaskCount"
+  namespace           = "ECS/ContainerInsights"
+  period              = 60
+  statistic           = "Average"
+  threshold           = var.min_capacity
+  alarm_description   = "OpenBAS running tasks below minimum"
+  alarm_actions       = [aws_sns_topic.openbas_alerts.arn]
+  ok_actions          = [aws_sns_topic.openbas_alerts.arn]
+
+  dimensions = {
+    ClusterName = aws_ecs_cluster.openbas.name
+    ServiceName = aws_ecs_service.openbas.name
+  }
+
+  tags = local.common_tags
+}
+
+# ------------------------------------------------------------------------------
+# RDS Alarms
+# ------------------------------------------------------------------------------
+
+resource "aws_cloudwatch_metric_alarm" "rds_cpu_high" {
+  alarm_name          = "${var.name_prefix}-openbas-rds-cpu-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 3
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/RDS"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 80
+  alarm_description   = "OpenBAS RDS CPU utilization is too high"
+  alarm_actions       = [aws_sns_topic.openbas_alerts.arn]
+  ok_actions          = [aws_sns_topic.openbas_alerts.arn]
+
+  dimensions = {
+    DBInstanceIdentifier = aws_db_instance.openbas.identifier
+  }
+
+  tags = local.common_tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "rds_storage_low" {
+  alarm_name          = "${var.name_prefix}-openbas-rds-storage-low"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "FreeStorageSpace"
+  namespace           = "AWS/RDS"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 5368709120 # 5 GB in bytes
+  alarm_description   = "OpenBAS RDS free storage is low"
+  alarm_actions       = [aws_sns_topic.openbas_alerts.arn]
+  ok_actions          = [aws_sns_topic.openbas_alerts.arn]
+
+  dimensions = {
+    DBInstanceIdentifier = aws_db_instance.openbas.identifier
+  }
+
+  tags = local.common_tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "rds_connections_high" {
+  alarm_name          = "${var.name_prefix}-openbas-rds-connections-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 3
+  metric_name         = "DatabaseConnections"
+  namespace           = "AWS/RDS"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 80 # Adjust based on instance class
+  alarm_description   = "OpenBAS RDS connection count is high"
+  alarm_actions       = [aws_sns_topic.openbas_alerts.arn]
+  ok_actions          = [aws_sns_topic.openbas_alerts.arn]
+
+  dimensions = {
+    DBInstanceIdentifier = aws_db_instance.openbas.identifier
+  }
+
+  tags = local.common_tags
+}
+
+# ------------------------------------------------------------------------------
+# ALB Alarms
+# ------------------------------------------------------------------------------
+
+resource "aws_cloudwatch_metric_alarm" "alb_5xx_errors" {
+  alarm_name          = "${var.name_prefix}-openbas-alb-5xx-errors"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "HTTPCode_Target_5XX_Count"
+  namespace           = "AWS/ApplicationELB"
+  period              = 300
+  statistic           = "Sum"
+  threshold           = 10
+  alarm_description   = "OpenBAS ALB receiving 5xx errors from targets"
+  alarm_actions       = [aws_sns_topic.openbas_alerts.arn]
+  ok_actions          = [aws_sns_topic.openbas_alerts.arn]
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    LoadBalancer = aws_lb.openbas.arn_suffix
+  }
+
+  tags = local.common_tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "alb_unhealthy_hosts" {
+  alarm_name          = "${var.name_prefix}-openbas-alb-unhealthy-hosts"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "UnHealthyHostCount"
+  namespace           = "AWS/ApplicationELB"
+  period              = 60
+  statistic           = "Maximum"
+  threshold           = 0
+  alarm_description   = "OpenBAS ALB has unhealthy targets"
+  alarm_actions       = [aws_sns_topic.openbas_alerts.arn]
+  ok_actions          = [aws_sns_topic.openbas_alerts.arn]
+
+  dimensions = {
+    LoadBalancer = aws_lb.openbas.arn_suffix
+    TargetGroup  = aws_lb_target_group.openbas.arn_suffix
+  }
+
+  tags = local.common_tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "alb_latency_high" {
+  alarm_name          = "${var.name_prefix}-openbas-alb-latency-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 3
+  metric_name         = "TargetResponseTime"
+  namespace           = "AWS/ApplicationELB"
+  period              = 300
+  extended_statistic  = "p99"
+  threshold           = 5 # 5 seconds
+  alarm_description   = "OpenBAS ALB p99 latency is too high"
+  alarm_actions       = [aws_sns_topic.openbas_alerts.arn]
+  ok_actions          = [aws_sns_topic.openbas_alerts.arn]
+
+  dimensions = {
+    LoadBalancer = aws_lb.openbas.arn_suffix
+  }
+
+  tags = local.common_tags
+}

--- a/platform/terraform/modules/openbas/alb.tf
+++ b/platform/terraform/modules/openbas/alb.tf
@@ -1,62 +1,12 @@
-# OpenBAS Application Load Balancer
+# OpenBAS Target Group
 #
-# Creates:
-# - Internal ALB for API and agent traffic
-# - ACM certificate (DNS validation)
-# - Target group with health check
-# - HTTPS listener
+# Creates target group for attachment to Portal ALB.
+# Route: /shifter-mirage/bas/* -> OpenBAS ECS tasks
+#
+# The listener rule is created in the Portal environment where the ALB lives.
 
 # ------------------------------------------------------------------------------
-# ACM Certificate
-# ------------------------------------------------------------------------------
-
-resource "aws_acm_certificate" "openbas" {
-  domain_name       = var.domain_name
-  validation_method = "DNS"
-
-  tags = merge(local.common_tags, {
-    Name = "${var.name_prefix}-openbas-cert"
-  })
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-resource "aws_acm_certificate_validation" "openbas" {
-  certificate_arn = aws_acm_certificate.openbas.arn
-
-  timeouts {
-    create = "45m"
-  }
-}
-
-# ------------------------------------------------------------------------------
-# Application Load Balancer (Internal)
-# ------------------------------------------------------------------------------
-
-# checkov:skip=CKV_AWS_150:Deletion protection configurable
-resource "aws_lb" "openbas" {
-  name                       = "${var.name_prefix}-openbas"
-  internal                   = true # Internal ALB - not internet-facing
-  load_balancer_type         = "application"
-  security_groups            = [aws_security_group.alb.id]
-  subnets                    = aws_subnet.openbas[*].id
-  drop_invalid_header_fields = true
-
-  access_logs {
-    bucket  = var.logs_bucket_name
-    prefix  = "alb/${var.name_prefix}-openbas"
-    enabled = var.enable_alb_access_logs && var.logs_bucket_name != ""
-  }
-
-  tags = merge(local.common_tags, {
-    Name = "${var.name_prefix}-openbas-alb"
-  })
-}
-
-# ------------------------------------------------------------------------------
-# Target Group
+# Target Group (for Portal ALB)
 # ------------------------------------------------------------------------------
 
 resource "aws_lb_target_group" "openbas" {
@@ -80,42 +30,4 @@ resource "aws_lb_target_group" "openbas" {
   tags = merge(local.common_tags, {
     Name = "${var.name_prefix}-openbas-tg"
   })
-}
-
-# ------------------------------------------------------------------------------
-# Listeners
-# ------------------------------------------------------------------------------
-
-resource "aws_lb_listener" "https" {
-  load_balancer_arn = aws_lb.openbas.arn
-  port              = 443
-  protocol          = "HTTPS"
-  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
-  certificate_arn   = aws_acm_certificate_validation.openbas.certificate_arn
-
-  default_action {
-    type             = "forward"
-    target_group_arn = aws_lb_target_group.openbas.arn
-  }
-
-  tags = local.common_tags
-}
-
-# HTTP listener for redirect (agent compatibility)
-resource "aws_lb_listener" "http" {
-  load_balancer_arn = aws_lb.openbas.arn
-  port              = 80
-  protocol          = "HTTP"
-
-  default_action {
-    type = "redirect"
-
-    redirect {
-      port        = "443"
-      protocol    = "HTTPS"
-      status_code = "HTTP_301"
-    }
-  }
-
-  tags = local.common_tags
 }

--- a/platform/terraform/modules/openbas/alb.tf
+++ b/platform/terraform/modules/openbas/alb.tf
@@ -1,0 +1,121 @@
+# OpenBAS Application Load Balancer
+#
+# Creates:
+# - Internal ALB for API and agent traffic
+# - ACM certificate (DNS validation)
+# - Target group with health check
+# - HTTPS listener
+
+# ------------------------------------------------------------------------------
+# ACM Certificate
+# ------------------------------------------------------------------------------
+
+resource "aws_acm_certificate" "openbas" {
+  domain_name       = var.domain_name
+  validation_method = "DNS"
+
+  tags = merge(local.common_tags, {
+    Name = "${var.name_prefix}-openbas-cert"
+  })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_acm_certificate_validation" "openbas" {
+  certificate_arn = aws_acm_certificate.openbas.arn
+
+  timeouts {
+    create = "45m"
+  }
+}
+
+# ------------------------------------------------------------------------------
+# Application Load Balancer (Internal)
+# ------------------------------------------------------------------------------
+
+# checkov:skip=CKV_AWS_150:Deletion protection configurable
+resource "aws_lb" "openbas" {
+  name                       = "${var.name_prefix}-openbas"
+  internal                   = true # Internal ALB - not internet-facing
+  load_balancer_type         = "application"
+  security_groups            = [aws_security_group.alb.id]
+  subnets                    = aws_subnet.openbas[*].id
+  drop_invalid_header_fields = true
+
+  access_logs {
+    bucket  = var.logs_bucket_name
+    prefix  = "alb/${var.name_prefix}-openbas"
+    enabled = var.enable_alb_access_logs && var.logs_bucket_name != ""
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${var.name_prefix}-openbas-alb"
+  })
+}
+
+# ------------------------------------------------------------------------------
+# Target Group
+# ------------------------------------------------------------------------------
+
+resource "aws_lb_target_group" "openbas" {
+  name        = "${var.name_prefix}-openbas"
+  port        = 8080
+  protocol    = "HTTP"
+  vpc_id      = var.vpc_id
+  target_type = "ip" # Required for Fargate
+
+  health_check {
+    enabled             = true
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+    timeout             = 10
+    interval            = 30
+    path                = "/api/health"
+    protocol            = "HTTP"
+    matcher             = "200"
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${var.name_prefix}-openbas-tg"
+  })
+}
+
+# ------------------------------------------------------------------------------
+# Listeners
+# ------------------------------------------------------------------------------
+
+resource "aws_lb_listener" "https" {
+  load_balancer_arn = aws_lb.openbas.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  certificate_arn   = aws_acm_certificate_validation.openbas.certificate_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.openbas.arn
+  }
+
+  tags = local.common_tags
+}
+
+# HTTP listener for redirect (agent compatibility)
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.openbas.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+
+  tags = local.common_tags
+}

--- a/platform/terraform/modules/openbas/database.tf
+++ b/platform/terraform/modules/openbas/database.tf
@@ -1,0 +1,147 @@
+# OpenBAS Database
+#
+# Creates:
+# - DB subnet group
+# - RDS PostgreSQL instance (Multi-AZ for HA)
+# - Secrets Manager secret for credentials
+
+# ------------------------------------------------------------------------------
+# DB Subnet Group
+# ------------------------------------------------------------------------------
+
+resource "aws_db_subnet_group" "openbas" {
+  name       = "${var.name_prefix}-openbas"
+  subnet_ids = aws_subnet.openbas[*].id
+
+  tags = merge(local.common_tags, {
+    Name = "${var.name_prefix}-openbas-db-subnet"
+  })
+}
+
+# ------------------------------------------------------------------------------
+# Database Password
+# ------------------------------------------------------------------------------
+
+resource "random_password" "db_password" {
+  length           = 32
+  special          = true
+  override_special = "!#$%&*()-_=+[]{}<>:?"
+}
+
+# ------------------------------------------------------------------------------
+# Secrets Manager - DB Credentials
+# ------------------------------------------------------------------------------
+
+# checkov:skip=CKV_AWS_149:AWS-managed keys sufficient for MVP
+resource "aws_secretsmanager_secret" "db_credentials" {
+  name                    = "shifter/${var.name_prefix}-openbas-db"
+  description             = "OpenBAS RDS PostgreSQL credentials"
+  recovery_window_in_days = 0 # Immediate deletion for recreate
+
+  tags = merge(local.common_tags, {
+    Name = "${var.name_prefix}-openbas-db-credentials"
+  })
+}
+
+resource "aws_secretsmanager_secret_version" "db_credentials" {
+  secret_id = aws_secretsmanager_secret.db_credentials.id
+  secret_string = jsonencode({
+    username = var.db_username
+    password = random_password.db_password.result
+    host     = aws_db_instance.openbas.address
+    port     = aws_db_instance.openbas.port
+    dbname   = var.db_name
+    engine   = "postgresql"
+  })
+}
+
+# ------------------------------------------------------------------------------
+# RDS PostgreSQL Instance
+# ------------------------------------------------------------------------------
+
+# checkov:skip=CKV_AWS_354:Performance insights enabled
+# checkov:skip=CKV_AWS_353:Performance insights enabled
+# checkov:skip=CKV_AWS_157:IAM auth enabled
+# checkov:skip=CKV_AWS_118:Enhanced monitoring deferred
+# checkov:skip=CKV_AWS_293:CA certificate deferred
+resource "aws_db_instance" "openbas" {
+  identifier = "${var.name_prefix}-openbas"
+
+  # Engine
+  engine               = "postgres"
+  engine_version       = var.db_engine_version
+  instance_class       = var.db_instance_class
+  parameter_group_name = "default.postgres${split(".", var.db_engine_version)[0]}"
+
+  # Storage
+  allocated_storage     = var.db_allocated_storage
+  max_allocated_storage = var.db_max_allocated_storage
+  storage_type          = "gp3"
+  storage_encrypted     = true
+
+  # Database
+  db_name  = var.db_name
+  username = var.db_username
+  password = random_password.db_password.result
+  port     = 5432
+
+  # Network
+  db_subnet_group_name   = aws_db_subnet_group.openbas.name
+  vpc_security_group_ids = [aws_security_group.rds.id]
+  publicly_accessible    = false
+  multi_az               = var.db_multi_az
+
+  # Maintenance
+  backup_retention_period    = var.db_backup_retention_days
+  backup_window              = "03:00-04:00"
+  maintenance_window         = "Mon:04:00-Mon:05:00"
+  auto_minor_version_upgrade = true
+  deletion_protection        = var.db_deletion_protection
+  skip_final_snapshot        = var.db_skip_final_snapshot
+  final_snapshot_identifier  = var.db_skip_final_snapshot ? null : "${var.name_prefix}-openbas-final"
+
+  # Performance Insights (free tier for 7 days retention)
+  performance_insights_enabled          = true
+  performance_insights_retention_period = 7
+
+  # IAM Database Authentication
+  iam_database_authentication_enabled = true
+
+  # CloudWatch Log Exports
+  enabled_cloudwatch_logs_exports = var.enable_db_log_exports ? ["postgresql", "upgrade"] : []
+
+  tags = merge(local.common_tags, {
+    Name = "${var.name_prefix}-openbas-db"
+  })
+
+  depends_on = [
+    aws_cloudwatch_log_group.rds_postgresql,
+    aws_cloudwatch_log_group.rds_upgrade,
+  ]
+}
+
+# ------------------------------------------------------------------------------
+# CloudWatch Log Groups for RDS
+# ------------------------------------------------------------------------------
+
+resource "aws_cloudwatch_log_group" "rds_postgresql" {
+  count = var.enable_db_log_exports ? 1 : 0
+
+  name              = "/aws/rds/instance/${var.name_prefix}-openbas/postgresql"
+  retention_in_days = var.log_retention_days
+
+  tags = merge(local.common_tags, {
+    Name = "${var.name_prefix}-openbas-rds-postgresql-logs"
+  })
+}
+
+resource "aws_cloudwatch_log_group" "rds_upgrade" {
+  count = var.enable_db_log_exports ? 1 : 0
+
+  name              = "/aws/rds/instance/${var.name_prefix}-openbas/upgrade"
+  retention_in_days = var.log_retention_days
+
+  tags = merge(local.common_tags, {
+    Name = "${var.name_prefix}-openbas-rds-upgrade-logs"
+  })
+}

--- a/platform/terraform/modules/openbas/iam.tf
+++ b/platform/terraform/modules/openbas/iam.tf
@@ -1,0 +1,123 @@
+# OpenBAS IAM Roles
+#
+# Creates:
+# - ECS Task Execution Role (for pulling images, accessing secrets)
+# - ECS Task Role (for application-level permissions)
+
+# ------------------------------------------------------------------------------
+# ECS Task Execution Role
+# ------------------------------------------------------------------------------
+# Used by ECS agent to pull container images and access secrets
+
+resource "aws_iam_role" "ecs_execution" {
+  name = "${var.name_prefix}-openbas-execution"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "ecs-tasks.amazonaws.com"
+      }
+    }]
+  })
+
+  tags = local.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_execution" {
+  role       = aws_iam_role.ecs_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+# Allow access to Secrets Manager secrets
+resource "aws_iam_role_policy" "ecs_execution_secrets" {
+  name = "${var.name_prefix}-openbas-execution-secrets"
+  role = aws_iam_role.ecs_execution.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "secretsmanager:GetSecretValue"
+        ]
+        Resource = [
+          aws_secretsmanager_secret.db_credentials.arn,
+          aws_secretsmanager_secret.admin_token.arn,
+        ]
+      }
+    ]
+  })
+}
+
+# ------------------------------------------------------------------------------
+# ECS Task Role
+# ------------------------------------------------------------------------------
+# Used by the running container for application permissions
+
+resource "aws_iam_role" "ecs_task" {
+  name = "${var.name_prefix}-openbas-task"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "ecs-tasks.amazonaws.com"
+      }
+    }]
+  })
+
+  tags = local.common_tags
+}
+
+# S3 access for OpenBAS storage bucket
+resource "aws_iam_role_policy" "ecs_task_s3" {
+  name = "${var.name_prefix}-openbas-task-s3"
+  role = aws_iam_role.ecs_task.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:ListBucket"
+        ]
+        Resource = [
+          aws_s3_bucket.openbas.arn,
+          "${aws_s3_bucket.openbas.arn}/*"
+        ]
+      }
+    ]
+  })
+}
+
+# CloudWatch Logs access for metrics
+resource "aws_iam_role_policy" "ecs_task_cloudwatch" {
+  name = "${var.name_prefix}-openbas-task-cloudwatch"
+  role = aws_iam_role.ecs_task.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Resource = [
+          "${aws_cloudwatch_log_group.openbas.arn}:*"
+        ]
+      }
+    ]
+  })
+}

--- a/platform/terraform/modules/openbas/main.tf
+++ b/platform/terraform/modules/openbas/main.tf
@@ -1,0 +1,270 @@
+# OpenBAS Shared Infrastructure Module
+#
+# Provides centralized adversary emulation platform for all ranges.
+# Deploys as shared infrastructure in the Range VPC.
+#
+# Components:
+# - ECS Fargate service (HA across AZs)
+# - RDS PostgreSQL database
+# - Internal ALB for API/agent access
+# - Security groups and IAM roles
+#
+# Traffic flow:
+# - Range agents -> Internal ALB -> ECS tasks (port 443)
+# - Portal API calls -> Internal ALB -> ECS tasks (port 8080)
+
+# ------------------------------------------------------------------------------
+# Data Sources
+# ------------------------------------------------------------------------------
+
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+# ------------------------------------------------------------------------------
+# Local Variables
+# ------------------------------------------------------------------------------
+
+locals {
+  common_tags = merge(var.tags, {
+    Module = "openbas"
+  })
+  account_id = data.aws_caller_identity.current.account_id
+  region     = data.aws_region.current.name
+
+  # Use first two AZs for HA deployment
+  az_count = min(2, length(data.aws_availability_zones.available.names))
+  azs      = slice(data.aws_availability_zones.available.names, 0, local.az_count)
+}
+
+# ------------------------------------------------------------------------------
+# ECS Cluster
+# ------------------------------------------------------------------------------
+
+resource "aws_ecs_cluster" "openbas" {
+  name = "${var.name_prefix}-openbas"
+
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${var.name_prefix}-openbas"
+  })
+}
+
+resource "aws_ecs_cluster_capacity_providers" "openbas" {
+  cluster_name       = aws_ecs_cluster.openbas.name
+  capacity_providers = ["FARGATE", "FARGATE_SPOT"]
+
+  default_capacity_provider_strategy {
+    capacity_provider = "FARGATE"
+    weight            = 1
+  }
+}
+
+# ------------------------------------------------------------------------------
+# CloudWatch Log Groups
+# ------------------------------------------------------------------------------
+
+resource "aws_cloudwatch_log_group" "openbas" {
+  name              = "/ecs/${var.name_prefix}-openbas"
+  retention_in_days = var.log_retention_days
+
+  tags = merge(local.common_tags, {
+    Name = "${var.name_prefix}-openbas-logs"
+  })
+}
+
+# ------------------------------------------------------------------------------
+# ECS Task Definition
+# ------------------------------------------------------------------------------
+
+resource "aws_ecs_task_definition" "openbas" {
+  family                   = "${var.name_prefix}-openbas"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = var.task_cpu
+  memory                   = var.task_memory
+  execution_role_arn       = aws_iam_role.ecs_execution.arn
+  task_role_arn            = aws_iam_role.ecs_task.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "openbas"
+      image     = var.openbas_image
+      essential = true
+
+      portMappings = [
+        {
+          containerPort = 8080
+          hostPort      = 8080
+          protocol      = "tcp"
+        }
+      ]
+
+      environment = [
+        {
+          name  = "OPENBAS_BASE_URL"
+          value = "https://${var.domain_name}"
+        },
+        {
+          name  = "OPENBAS_AUTH_LOCAL_ENABLE"
+          value = "true"
+        },
+        {
+          name  = "SPRING_DATASOURCE_URL"
+          value = "jdbc:postgresql://${aws_db_instance.openbas.endpoint}/${var.db_name}"
+        },
+        {
+          name  = "SPRING_DATASOURCE_USERNAME"
+          value = var.db_username
+        },
+        {
+          name  = "MINIO_ENDPOINT"
+          value = "s3.${local.region}.amazonaws.com"
+        },
+        {
+          name  = "MINIO_BUCKET"
+          value = aws_s3_bucket.openbas.id
+        },
+        {
+          name  = "MINIO_USE_AWS_ROLE"
+          value = "true"
+        }
+      ]
+
+      secrets = [
+        {
+          name      = "SPRING_DATASOURCE_PASSWORD"
+          valueFrom = "${aws_secretsmanager_secret.db_credentials.arn}:password::"
+        },
+        {
+          name      = "OPENBAS_ADMIN_TOKEN"
+          valueFrom = "${aws_secretsmanager_secret.admin_token.arn}:token::"
+        }
+      ]
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.openbas.name
+          "awslogs-region"        = local.region
+          "awslogs-stream-prefix" = "openbas"
+        }
+      }
+
+      healthCheck = {
+        command     = ["CMD-SHELL", "curl -f http://localhost:8080/api/health || exit 1"]
+        interval    = 30
+        timeout     = 5
+        retries     = 3
+        startPeriod = 120
+      }
+    }
+  ])
+
+  tags = local.common_tags
+}
+
+# ------------------------------------------------------------------------------
+# ECS Service
+# ------------------------------------------------------------------------------
+
+resource "aws_ecs_service" "openbas" {
+  name                               = "${var.name_prefix}-openbas"
+  cluster                            = aws_ecs_cluster.openbas.id
+  task_definition                    = aws_ecs_task_definition.openbas.arn
+  desired_count                      = var.desired_count
+  launch_type                        = "FARGATE"
+  platform_version                   = "LATEST"
+  health_check_grace_period_seconds  = 180
+  deployment_minimum_healthy_percent = 50
+  deployment_maximum_percent         = 200
+
+  network_configuration {
+    subnets          = aws_subnet.openbas[*].id
+    security_groups  = [aws_security_group.ecs.id]
+    assign_public_ip = false
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.openbas.arn
+    container_name   = "openbas"
+    container_port   = 8080
+  }
+
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
+
+  tags = local.common_tags
+
+  depends_on = [
+    aws_lb_listener.https,
+    aws_db_instance.openbas,
+  ]
+
+  lifecycle {
+    ignore_changes = [desired_count]
+  }
+}
+
+# ------------------------------------------------------------------------------
+# Auto Scaling
+# ------------------------------------------------------------------------------
+
+resource "aws_appautoscaling_target" "openbas" {
+  count = var.enable_autoscaling ? 1 : 0
+
+  max_capacity       = var.max_capacity
+  min_capacity       = var.min_capacity
+  resource_id        = "service/${aws_ecs_cluster.openbas.name}/${aws_ecs_service.openbas.name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace  = "ecs"
+}
+
+resource "aws_appautoscaling_policy" "openbas_cpu" {
+  count = var.enable_autoscaling ? 1 : 0
+
+  name               = "${var.name_prefix}-openbas-cpu"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.openbas[0].resource_id
+  scalable_dimension = aws_appautoscaling_target.openbas[0].scalable_dimension
+  service_namespace  = aws_appautoscaling_target.openbas[0].service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    target_value       = 70
+    scale_in_cooldown  = 300
+    scale_out_cooldown = 60
+
+    predefined_metric_specification {
+      predefined_metric_type = "ECSServiceAverageCPUUtilization"
+    }
+  }
+}
+
+resource "aws_appautoscaling_policy" "openbas_memory" {
+  count = var.enable_autoscaling ? 1 : 0
+
+  name               = "${var.name_prefix}-openbas-memory"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.openbas[0].resource_id
+  scalable_dimension = aws_appautoscaling_target.openbas[0].scalable_dimension
+  service_namespace  = aws_appautoscaling_target.openbas[0].service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    target_value       = 80
+    scale_in_cooldown  = 300
+    scale_out_cooldown = 60
+
+    predefined_metric_specification {
+      predefined_metric_type = "ECSServiceAverageMemoryUtilization"
+    }
+  }
+}

--- a/platform/terraform/modules/openbas/main.tf
+++ b/platform/terraform/modules/openbas/main.tf
@@ -6,12 +6,12 @@
 # Components:
 # - ECS Fargate service (HA across AZs)
 # - RDS PostgreSQL database
-# - Internal ALB for API/agent access
+# - Target group for Portal ALB routing (/shifter-mirage/bas/*)
 # - Security groups and IAM roles
 #
 # Traffic flow:
-# - Range agents -> Internal ALB -> ECS tasks (port 443)
-# - Portal API calls -> Internal ALB -> ECS tasks (port 8080)
+# - Portal ALB -> VPC Peering -> ECS tasks (port 8080)
+# - Route: /shifter-mirage/bas/* -> OpenBAS target group
 
 # ------------------------------------------------------------------------------
 # Data Sources
@@ -110,7 +110,7 @@ resource "aws_ecs_task_definition" "openbas" {
       environment = [
         {
           name  = "OPENBAS_BASE_URL"
-          value = "https://${var.domain_name}"
+          value = var.base_url
         },
         {
           name  = "OPENBAS_AUTH_LOCAL_ENABLE"
@@ -206,7 +206,6 @@ resource "aws_ecs_service" "openbas" {
   tags = local.common_tags
 
   depends_on = [
-    aws_lb_listener.https,
     aws_db_instance.openbas,
   ]
 

--- a/platform/terraform/modules/openbas/networking.tf
+++ b/platform/terraform/modules/openbas/networking.tf
@@ -2,7 +2,7 @@
 #
 # Creates:
 # - Private subnets across AZs for HA deployment
-# - Security groups for ECS tasks and ALB
+# - Security groups for ECS tasks
 # - Route table associations
 
 # ------------------------------------------------------------------------------
@@ -59,15 +59,16 @@ resource "aws_security_group" "ecs" {
   }
 }
 
-# Ingress from ALB
-resource "aws_security_group_rule" "ecs_from_alb" {
-  type                     = "ingress"
-  from_port                = 8080
-  to_port                  = 8080
-  protocol                 = "tcp"
-  source_security_group_id = aws_security_group.alb.id
-  security_group_id        = aws_security_group.ecs.id
-  description              = "HTTP from ALB"
+# Ingress from Portal ALB (via VPC peering)
+# Portal ALB forwards /shifter-mirage/bas/* to this target group
+resource "aws_security_group_rule" "ecs_from_portal_alb" {
+  type              = "ingress"
+  from_port         = 8080
+  to_port           = 8080
+  protocol          = "tcp"
+  cidr_blocks       = [var.portal_vpc_cidr]
+  security_group_id = aws_security_group.ecs.id
+  description       = "HTTP from Portal ALB (via VPC peering)"
 }
 
 # Egress to RDS
@@ -111,57 +112,6 @@ resource "aws_security_group_rule" "ecs_dns_tcp" {
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.ecs.id
   description       = "DNS TCP"
-}
-
-# ------------------------------------------------------------------------------
-# ALB Security Group
-# ------------------------------------------------------------------------------
-
-resource "aws_security_group" "alb" {
-  name        = "${var.name_prefix}-openbas-alb"
-  description = "Security group for OpenBAS internal ALB"
-  vpc_id      = var.vpc_id
-
-  tags = merge(local.common_tags, {
-    Name = "${var.name_prefix}-openbas-alb-sg"
-  })
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-# HTTPS from Range VPC (agent communication)
-resource "aws_security_group_rule" "alb_https_from_range" {
-  type              = "ingress"
-  from_port         = 443
-  to_port           = 443
-  protocol          = "tcp"
-  cidr_blocks       = [var.vpc_cidr]
-  security_group_id = aws_security_group.alb.id
-  description       = "HTTPS from Range VPC (agent communication)"
-}
-
-# HTTPS from Portal VPC (API calls)
-resource "aws_security_group_rule" "alb_https_from_portal" {
-  type              = "ingress"
-  from_port         = 443
-  to_port           = 443
-  protocol          = "tcp"
-  cidr_blocks       = [var.portal_vpc_cidr]
-  security_group_id = aws_security_group.alb.id
-  description       = "HTTPS from Portal VPC (API calls)"
-}
-
-# Egress to ECS tasks
-resource "aws_security_group_rule" "alb_to_ecs" {
-  type                     = "egress"
-  from_port                = 8080
-  to_port                  = 8080
-  protocol                 = "tcp"
-  source_security_group_id = aws_security_group.ecs.id
-  security_group_id        = aws_security_group.alb.id
-  description              = "HTTP to ECS tasks"
 }
 
 # ------------------------------------------------------------------------------

--- a/platform/terraform/modules/openbas/networking.tf
+++ b/platform/terraform/modules/openbas/networking.tf
@@ -1,0 +1,205 @@
+# OpenBAS Networking
+#
+# Creates:
+# - Private subnets across AZs for HA deployment
+# - Security groups for ECS tasks and ALB
+# - Route table associations
+
+# ------------------------------------------------------------------------------
+# OpenBAS Private Subnets
+# ------------------------------------------------------------------------------
+# Allocated in the infrastructure block of Range VPC (10.1.0.0/24)
+# Using /27 subnets (32 IPs each) starting at 10.1.0.64
+# - AZ1: 10.1.0.64/27 (cidrsubnet index 4 with /11 newbits from base + 4)
+# - AZ2: 10.1.0.96/27
+
+resource "aws_subnet" "openbas" {
+  count = local.az_count
+
+  vpc_id                  = var.vpc_id
+  cidr_block              = cidrsubnet(var.vpc_cidr, 11, 2 + count.index) # 10.1.0.64/27, 10.1.0.96/27
+  availability_zone       = local.azs[count.index]
+  map_public_ip_on_launch = false
+
+  tags = merge(local.common_tags, {
+    Name = "${var.name_prefix}-openbas-${count.index + 1}"
+    Tier = "private"
+    AZ   = local.azs[count.index]
+  })
+}
+
+# ------------------------------------------------------------------------------
+# Route Table Associations
+# ------------------------------------------------------------------------------
+# Associate OpenBAS subnets with the existing private route table
+# Traffic flows through Network Firewall -> NAT -> IGW
+
+resource "aws_route_table_association" "openbas" {
+  count = local.az_count
+
+  subnet_id      = aws_subnet.openbas[count.index].id
+  route_table_id = var.private_route_table_id
+}
+
+# ------------------------------------------------------------------------------
+# ECS Task Security Group
+# ------------------------------------------------------------------------------
+
+resource "aws_security_group" "ecs" {
+  name        = "${var.name_prefix}-openbas-ecs"
+  description = "Security group for OpenBAS ECS tasks"
+  vpc_id      = var.vpc_id
+
+  tags = merge(local.common_tags, {
+    Name = "${var.name_prefix}-openbas-ecs-sg"
+  })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# Ingress from ALB
+resource "aws_security_group_rule" "ecs_from_alb" {
+  type                     = "ingress"
+  from_port                = 8080
+  to_port                  = 8080
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.alb.id
+  security_group_id        = aws_security_group.ecs.id
+  description              = "HTTP from ALB"
+}
+
+# Egress to RDS
+resource "aws_security_group_rule" "ecs_to_rds" {
+  type                     = "egress"
+  from_port                = 5432
+  to_port                  = 5432
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.rds.id
+  security_group_id        = aws_security_group.ecs.id
+  description              = "PostgreSQL to RDS"
+}
+
+# Egress HTTPS for S3, ECR, CloudWatch, Secrets Manager
+resource "aws_security_group_rule" "ecs_https_egress" {
+  type              = "egress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.ecs.id
+  description       = "HTTPS for AWS services and container registry"
+}
+
+# Egress DNS
+resource "aws_security_group_rule" "ecs_dns_udp" {
+  type              = "egress"
+  from_port         = 53
+  to_port           = 53
+  protocol          = "udp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.ecs.id
+  description       = "DNS UDP"
+}
+
+resource "aws_security_group_rule" "ecs_dns_tcp" {
+  type              = "egress"
+  from_port         = 53
+  to_port           = 53
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.ecs.id
+  description       = "DNS TCP"
+}
+
+# ------------------------------------------------------------------------------
+# ALB Security Group
+# ------------------------------------------------------------------------------
+
+resource "aws_security_group" "alb" {
+  name        = "${var.name_prefix}-openbas-alb"
+  description = "Security group for OpenBAS internal ALB"
+  vpc_id      = var.vpc_id
+
+  tags = merge(local.common_tags, {
+    Name = "${var.name_prefix}-openbas-alb-sg"
+  })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# HTTPS from Range VPC (agent communication)
+resource "aws_security_group_rule" "alb_https_from_range" {
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = [var.vpc_cidr]
+  security_group_id = aws_security_group.alb.id
+  description       = "HTTPS from Range VPC (agent communication)"
+}
+
+# HTTPS from Portal VPC (API calls)
+resource "aws_security_group_rule" "alb_https_from_portal" {
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = [var.portal_vpc_cidr]
+  security_group_id = aws_security_group.alb.id
+  description       = "HTTPS from Portal VPC (API calls)"
+}
+
+# Egress to ECS tasks
+resource "aws_security_group_rule" "alb_to_ecs" {
+  type                     = "egress"
+  from_port                = 8080
+  to_port                  = 8080
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.ecs.id
+  security_group_id        = aws_security_group.alb.id
+  description              = "HTTP to ECS tasks"
+}
+
+# ------------------------------------------------------------------------------
+# RDS Security Group
+# ------------------------------------------------------------------------------
+
+resource "aws_security_group" "rds" {
+  name        = "${var.name_prefix}-openbas-rds"
+  description = "Security group for OpenBAS RDS PostgreSQL"
+  vpc_id      = var.vpc_id
+
+  tags = merge(local.common_tags, {
+    Name = "${var.name_prefix}-openbas-rds-sg"
+  })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# Ingress from ECS tasks
+resource "aws_security_group_rule" "rds_from_ecs" {
+  type                     = "ingress"
+  from_port                = 5432
+  to_port                  = 5432
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.ecs.id
+  security_group_id        = aws_security_group.rds.id
+  description              = "PostgreSQL from ECS tasks"
+}
+
+# Egress (required for RDS)
+resource "aws_security_group_rule" "rds_egress" {
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.rds.id
+  description       = "Allow all outbound"
+}

--- a/platform/terraform/modules/openbas/outputs.tf
+++ b/platform/terraform/modules/openbas/outputs.tf
@@ -1,0 +1,206 @@
+# OpenBAS Module Outputs
+
+# ------------------------------------------------------------------------------
+# ECS
+# ------------------------------------------------------------------------------
+
+output "ecs_cluster_id" {
+  description = "ID of the ECS cluster"
+  value       = aws_ecs_cluster.openbas.id
+}
+
+output "ecs_cluster_name" {
+  description = "Name of the ECS cluster"
+  value       = aws_ecs_cluster.openbas.name
+}
+
+output "ecs_cluster_arn" {
+  description = "ARN of the ECS cluster"
+  value       = aws_ecs_cluster.openbas.arn
+}
+
+output "ecs_service_name" {
+  description = "Name of the ECS service"
+  value       = aws_ecs_service.openbas.name
+}
+
+output "ecs_service_id" {
+  description = "ID of the ECS service"
+  value       = aws_ecs_service.openbas.id
+}
+
+output "task_definition_arn" {
+  description = "ARN of the ECS task definition"
+  value       = aws_ecs_task_definition.openbas.arn
+}
+
+# ------------------------------------------------------------------------------
+# Networking
+# ------------------------------------------------------------------------------
+
+output "subnet_ids" {
+  description = "IDs of the OpenBAS subnets"
+  value       = aws_subnet.openbas[*].id
+}
+
+output "subnet_cidrs" {
+  description = "CIDR blocks of the OpenBAS subnets"
+  value       = aws_subnet.openbas[*].cidr_block
+}
+
+output "ecs_security_group_id" {
+  description = "ID of the ECS task security group"
+  value       = aws_security_group.ecs.id
+}
+
+output "alb_security_group_id" {
+  description = "ID of the ALB security group"
+  value       = aws_security_group.alb.id
+}
+
+output "rds_security_group_id" {
+  description = "ID of the RDS security group"
+  value       = aws_security_group.rds.id
+}
+
+# ------------------------------------------------------------------------------
+# Load Balancer
+# ------------------------------------------------------------------------------
+
+output "alb_id" {
+  description = "ID of the Application Load Balancer"
+  value       = aws_lb.openbas.id
+}
+
+output "alb_arn" {
+  description = "ARN of the Application Load Balancer"
+  value       = aws_lb.openbas.arn
+}
+
+output "alb_dns_name" {
+  description = "DNS name of the Application Load Balancer"
+  value       = aws_lb.openbas.dns_name
+}
+
+output "alb_zone_id" {
+  description = "Zone ID of the Application Load Balancer (for Route53 alias)"
+  value       = aws_lb.openbas.zone_id
+}
+
+output "target_group_arn" {
+  description = "ARN of the ALB target group"
+  value       = aws_lb_target_group.openbas.arn
+}
+
+# ------------------------------------------------------------------------------
+# Database
+# ------------------------------------------------------------------------------
+
+output "db_instance_id" {
+  description = "ID of the RDS instance"
+  value       = aws_db_instance.openbas.id
+}
+
+output "db_instance_arn" {
+  description = "ARN of the RDS instance"
+  value       = aws_db_instance.openbas.arn
+}
+
+output "db_endpoint" {
+  description = "Connection endpoint for the RDS instance"
+  value       = aws_db_instance.openbas.endpoint
+}
+
+output "db_address" {
+  description = "Address of the RDS instance"
+  value       = aws_db_instance.openbas.address
+}
+
+output "db_port" {
+  description = "Port of the RDS instance"
+  value       = aws_db_instance.openbas.port
+}
+
+output "db_name" {
+  description = "Name of the database"
+  value       = aws_db_instance.openbas.db_name
+}
+
+# ------------------------------------------------------------------------------
+# Secrets
+# ------------------------------------------------------------------------------
+
+output "db_credentials_secret_arn" {
+  description = "ARN of the Secrets Manager secret for DB credentials"
+  value       = aws_secretsmanager_secret.db_credentials.arn
+}
+
+output "admin_token_secret_arn" {
+  description = "ARN of the Secrets Manager secret for admin API token"
+  value       = aws_secretsmanager_secret.admin_token.arn
+}
+
+# ------------------------------------------------------------------------------
+# Storage
+# ------------------------------------------------------------------------------
+
+output "storage_bucket_id" {
+  description = "ID of the S3 storage bucket"
+  value       = aws_s3_bucket.openbas.id
+}
+
+output "storage_bucket_arn" {
+  description = "ARN of the S3 storage bucket"
+  value       = aws_s3_bucket.openbas.arn
+}
+
+# ------------------------------------------------------------------------------
+# Certificate
+# ------------------------------------------------------------------------------
+
+output "certificate_arn" {
+  description = "ARN of the ACM certificate"
+  value       = aws_acm_certificate.openbas.arn
+}
+
+output "certificate_domain_validation_options" {
+  description = "Domain validation options for the ACM certificate"
+  value       = aws_acm_certificate.openbas.domain_validation_options
+}
+
+# ------------------------------------------------------------------------------
+# API Endpoint
+# ------------------------------------------------------------------------------
+
+output "api_endpoint" {
+  description = "HTTPS endpoint for OpenBAS API"
+  value       = "https://${var.domain_name}"
+}
+
+output "internal_endpoint" {
+  description = "Internal ALB endpoint for OpenBAS"
+  value       = "https://${aws_lb.openbas.dns_name}"
+}
+
+# ------------------------------------------------------------------------------
+# IAM
+# ------------------------------------------------------------------------------
+
+output "ecs_execution_role_arn" {
+  description = "ARN of the ECS execution role"
+  value       = aws_iam_role.ecs_execution.arn
+}
+
+output "ecs_task_role_arn" {
+  description = "ARN of the ECS task role"
+  value       = aws_iam_role.ecs_task.arn
+}
+
+# ------------------------------------------------------------------------------
+# Monitoring
+# ------------------------------------------------------------------------------
+
+output "alerts_sns_topic_arn" {
+  description = "ARN of the SNS topic for OpenBAS alerts"
+  value       = aws_sns_topic.openbas_alerts.arn
+}

--- a/platform/terraform/modules/openbas/outputs.tf
+++ b/platform/terraform/modules/openbas/outputs.tf
@@ -53,43 +53,23 @@ output "ecs_security_group_id" {
   value       = aws_security_group.ecs.id
 }
 
-output "alb_security_group_id" {
-  description = "ID of the ALB security group"
-  value       = aws_security_group.alb.id
-}
-
 output "rds_security_group_id" {
   description = "ID of the RDS security group"
   value       = aws_security_group.rds.id
 }
 
 # ------------------------------------------------------------------------------
-# Load Balancer
+# Target Group (for Portal ALB)
 # ------------------------------------------------------------------------------
 
-output "alb_id" {
-  description = "ID of the Application Load Balancer"
-  value       = aws_lb.openbas.id
-}
-
-output "alb_arn" {
-  description = "ARN of the Application Load Balancer"
-  value       = aws_lb.openbas.arn
-}
-
-output "alb_dns_name" {
-  description = "DNS name of the Application Load Balancer"
-  value       = aws_lb.openbas.dns_name
-}
-
-output "alb_zone_id" {
-  description = "Zone ID of the Application Load Balancer (for Route53 alias)"
-  value       = aws_lb.openbas.zone_id
-}
-
 output "target_group_arn" {
-  description = "ARN of the ALB target group"
+  description = "ARN of the target group (for Portal ALB listener rule)"
   value       = aws_lb_target_group.openbas.arn
+}
+
+output "target_group_name" {
+  description = "Name of the target group"
+  value       = aws_lb_target_group.openbas.name
 }
 
 # ------------------------------------------------------------------------------
@@ -155,31 +135,12 @@ output "storage_bucket_arn" {
 }
 
 # ------------------------------------------------------------------------------
-# Certificate
-# ------------------------------------------------------------------------------
-
-output "certificate_arn" {
-  description = "ARN of the ACM certificate"
-  value       = aws_acm_certificate.openbas.arn
-}
-
-output "certificate_domain_validation_options" {
-  description = "Domain validation options for the ACM certificate"
-  value       = aws_acm_certificate.openbas.domain_validation_options
-}
-
-# ------------------------------------------------------------------------------
 # API Endpoint
 # ------------------------------------------------------------------------------
 
 output "api_endpoint" {
-  description = "HTTPS endpoint for OpenBAS API"
-  value       = "https://${var.domain_name}"
-}
-
-output "internal_endpoint" {
-  description = "Internal ALB endpoint for OpenBAS"
-  value       = "https://${aws_lb.openbas.dns_name}"
+  description = "Base URL for OpenBAS API"
+  value       = var.base_url
 }
 
 # ------------------------------------------------------------------------------

--- a/platform/terraform/modules/openbas/storage.tf
+++ b/platform/terraform/modules/openbas/storage.tf
@@ -1,0 +1,92 @@
+# OpenBAS Storage
+#
+# Creates:
+# - S3 bucket for OpenBAS file storage (scenarios, agent binaries, etc.)
+# - Admin token secret
+
+# ------------------------------------------------------------------------------
+# S3 Bucket for OpenBAS Storage
+# ------------------------------------------------------------------------------
+
+# checkov:skip=CKV_AWS_145:SSE-S3 sufficient for MVP
+# checkov:skip=CKV_AWS_144:Cross-region replication deferred
+# checkov:skip=CKV2_AWS_62:Event notifications not needed
+# checkov:skip=CKV_AWS_18:Access logging optional
+resource "aws_s3_bucket" "openbas" {
+  bucket = "${var.name_prefix}-openbas-${local.account_id}"
+
+  tags = merge(local.common_tags, {
+    Name = "${var.name_prefix}-openbas-storage"
+  })
+}
+
+resource "aws_s3_bucket_versioning" "openbas" {
+  bucket = aws_s3_bucket.openbas.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "openbas" {
+  bucket = aws_s3_bucket.openbas.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+    bucket_key_enabled = true
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "openbas" {
+  bucket = aws_s3_bucket.openbas.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "openbas" {
+  bucket = aws_s3_bucket.openbas.id
+
+  rule {
+    id     = "cleanup-old-versions"
+    status = "Enabled"
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+}
+
+# ------------------------------------------------------------------------------
+# Admin API Token
+# ------------------------------------------------------------------------------
+
+resource "random_password" "admin_token" {
+  length  = 64
+  special = false
+}
+
+# checkov:skip=CKV_AWS_149:AWS-managed keys sufficient for MVP
+resource "aws_secretsmanager_secret" "admin_token" {
+  name                    = "shifter/${var.name_prefix}-openbas-admin-token"
+  description             = "OpenBAS admin API token"
+  recovery_window_in_days = 0
+
+  tags = merge(local.common_tags, {
+    Name = "${var.name_prefix}-openbas-admin-token"
+  })
+}
+
+resource "aws_secretsmanager_secret_version" "admin_token" {
+  secret_id = aws_secretsmanager_secret.admin_token.id
+  secret_string = jsonencode({
+    token = random_password.admin_token.result
+  })
+}

--- a/platform/terraform/modules/openbas/variables.tf
+++ b/platform/terraform/modules/openbas/variables.tf
@@ -1,0 +1,177 @@
+# OpenBAS Module Variables
+
+# ------------------------------------------------------------------------------
+# Required Variables
+# ------------------------------------------------------------------------------
+
+variable "name_prefix" {
+  description = "Prefix for resource names (e.g., dev-range)"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "ID of the Range VPC"
+  type        = string
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block of the Range VPC (e.g., 10.1.0.0/16)"
+  type        = string
+}
+
+variable "portal_vpc_cidr" {
+  description = "CIDR block of the Portal VPC (for API access)"
+  type        = string
+}
+
+variable "private_route_table_id" {
+  description = "ID of the private route table for subnet associations"
+  type        = string
+}
+
+variable "domain_name" {
+  description = "Domain name for OpenBAS (for ACM certificate)"
+  type        = string
+}
+
+variable "openbas_image" {
+  description = "Docker image for OpenBAS (e.g., openbas/openbas:latest)"
+  type        = string
+}
+
+variable "tags" {
+  description = "Common tags to apply to all resources"
+  type        = map(string)
+}
+
+# ------------------------------------------------------------------------------
+# ECS Configuration
+# ------------------------------------------------------------------------------
+
+variable "task_cpu" {
+  description = "CPU units for ECS task (1024 = 1 vCPU)"
+  type        = number
+  default     = 1024
+}
+
+variable "task_memory" {
+  description = "Memory for ECS task in MB"
+  type        = number
+  default     = 4096
+}
+
+variable "desired_count" {
+  description = "Desired number of ECS tasks"
+  type        = number
+  default     = 2
+}
+
+variable "enable_autoscaling" {
+  description = "Enable auto scaling for ECS service"
+  type        = bool
+  default     = true
+}
+
+variable "min_capacity" {
+  description = "Minimum number of ECS tasks (when autoscaling enabled)"
+  type        = number
+  default     = 2
+}
+
+variable "max_capacity" {
+  description = "Maximum number of ECS tasks (when autoscaling enabled)"
+  type        = number
+  default     = 4
+}
+
+# ------------------------------------------------------------------------------
+# Database Configuration
+# ------------------------------------------------------------------------------
+
+variable "db_instance_class" {
+  description = "RDS instance class"
+  type        = string
+  default     = "db.t3.small"
+}
+
+variable "db_engine_version" {
+  description = "PostgreSQL engine version"
+  type        = string
+  default     = "15.4"
+}
+
+variable "db_name" {
+  description = "Database name"
+  type        = string
+  default     = "openbas"
+}
+
+variable "db_username" {
+  description = "Database master username"
+  type        = string
+  default     = "openbas"
+}
+
+variable "db_allocated_storage" {
+  description = "Initial allocated storage in GB"
+  type        = number
+  default     = 20
+}
+
+variable "db_max_allocated_storage" {
+  description = "Maximum storage for autoscaling in GB"
+  type        = number
+  default     = 100
+}
+
+variable "db_multi_az" {
+  description = "Enable Multi-AZ deployment for RDS"
+  type        = bool
+  default     = true
+}
+
+variable "db_backup_retention_days" {
+  description = "Number of days to retain automated backups"
+  type        = number
+  default     = 7
+}
+
+variable "db_deletion_protection" {
+  description = "Enable deletion protection for RDS"
+  type        = bool
+  default     = false
+}
+
+variable "db_skip_final_snapshot" {
+  description = "Skip final snapshot when destroying RDS"
+  type        = bool
+  default     = true
+}
+
+variable "enable_db_log_exports" {
+  description = "Enable CloudWatch log exports for RDS"
+  type        = bool
+  default     = true
+}
+
+# ------------------------------------------------------------------------------
+# Logging Configuration
+# ------------------------------------------------------------------------------
+
+variable "log_retention_days" {
+  description = "CloudWatch log retention in days"
+  type        = number
+  default     = 30
+}
+
+variable "logs_bucket_name" {
+  description = "S3 bucket name for ALB access logs (optional)"
+  type        = string
+  default     = ""
+}
+
+variable "enable_alb_access_logs" {
+  description = "Enable ALB access logs"
+  type        = bool
+  default     = false
+}

--- a/platform/terraform/modules/openbas/variables.tf
+++ b/platform/terraform/modules/openbas/variables.tf
@@ -29,8 +29,8 @@ variable "private_route_table_id" {
   type        = string
 }
 
-variable "domain_name" {
-  description = "Domain name for OpenBAS (for ACM certificate)"
+variable "base_url" {
+  description = "Base URL for OpenBAS (e.g., https://portal.example.com/shifter-mirage/bas)"
   type        = string
 }
 
@@ -162,16 +162,4 @@ variable "log_retention_days" {
   description = "CloudWatch log retention in days"
   type        = number
   default     = 30
-}
-
-variable "logs_bucket_name" {
-  description = "S3 bucket name for ALB access logs (optional)"
-  type        = string
-  default     = ""
-}
-
-variable "enable_alb_access_logs" {
-  description = "Enable ALB access logs"
-  type        = bool
-  default     = false
 }

--- a/platform/terraform/modules/openbas/versions.tf
+++ b/platform/terraform/modules/openbas/versions.tf
@@ -1,0 +1,15 @@
+# Terraform and provider version constraints
+
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}


### PR DESCRIPTION
Creates a highly available OpenBAS server setup for centralized adversary
emulation. This shared infrastructure provides attack simulation capabilities
for all ranges without requiring per-range OpenBAS instances.

Components:
- ECS Fargate cluster with auto-scaling (2-4 tasks)
- Multi-AZ RDS PostgreSQL database
- Internal ALB for API/agent traffic
- S3 bucket for OpenBAS storage
- Security groups for network isolation
- CloudWatch alarms for monitoring
- Secrets Manager for credentials

The infrastructure deploys in the Range VPC using dedicated subnets
(10.1.0.64/27 and 10.1.0.96/27) with traffic routed through the
existing Network Firewall.

Deployment is disabled by default (enable_openbas = false).
To deploy, set enable_openbas = true and configure openbas_domain_name.