### PR TITLE
Add Cortex BYOT template without XDR agents

### DIFF
--- a/shifter/shifter_platform/cms/scenarios/templates/cortex_byot_no_xdr.yaml
+++ b/shifter/shifter_platform/cms/scenarios/templates/cortex_byot_no_xdr.yaml
@@ -1,0 +1,66 @@
+id: cortex_byot_no_xdr
+name: Cortex BYOT (No XDR)
+description: Cortex BYOT range without XDR agents. Includes NGFW, domain controller, Ubuntu server in DC subnet, two workstations, a server, and an attacker. No agent installation required.
+enabled: true
+ngfw: true
+
+instances:
+  - name: Attacker
+    role: attacker
+    os_type: kali
+    xdr_agent: false
+    join_domain: false
+    ai_agent: true
+
+  - name: Domain Controller
+    role: dc
+    os_type: windows
+    domain_controller: true
+    xdr_agent: false
+    ai_agent: true
+    dc_config:
+      domain_name: cortexbyot.lab
+      netbios_name: CORTEXBYOT
+
+  - name: DC Ubuntu Server
+    role: victim
+    os_type: ubuntu
+    xdr_agent: false
+    join_domain: true
+    ai_agent: true
+
+  - name: Workstation 1
+    role: victim
+    os_type: windows
+    xdr_agent: false
+    join_domain: true
+    ai_agent: true
+
+  - name: Workstation 2
+    role: victim
+    os_type: windows
+    xdr_agent: false
+    join_domain: true
+    ai_agent: true
+
+  - name: Server
+    role: victim
+    os_type: ubuntu
+    xdr_agent: false
+    join_domain: true
+    ai_agent: true
+
+subnets:
+  - name: dc_network
+    instances: [Domain Controller, DC Ubuntu Server]
+    connected_to: [workstation_network, server_network]
+
+  - name: workstation_network
+    instances: [Workstation 1, Workstation 2]
+    connected_to: [attacker_network]
+
+  - name: server_network
+    instances: [Server]
+
+  - name: attacker_network
+    instances: [Attacker]

--- a/shifter/shifter_platform/mission_control/views.py
+++ b/shifter/shifter_platform/mission_control/views.py
@@ -408,16 +408,19 @@ def launch_range(request: HttpRequest) -> JsonResponse:
     Request body (JSON):
         New format:
         - agents: Dict mapping OS type to agent ID, e.g. {"windows": 123}
-        - scenario: Scenario type (basic, ad_attack_lab). Defaults to basic.
+                  Can be empty {} for scenarios that don't require agents.
+        - scenario: Scenario type (basic, cortex_byot_no_xdr). Defaults to basic.
 
         Legacy format (backward compatible):
         - agent_id: ID of agent to use for victim instances
-        - scenario: Scenario type (basic, ad_attack_lab). Defaults to basic.
+        - scenario: Scenario type. Defaults to basic.
 
     Response (JSON):
         - success: true
         - range: Range object
     """
+    from cms import get_scenario as cms_get_scenario
+
     user = _get_user(request)
     try:
         data = json.loads(request.body)
@@ -425,14 +428,24 @@ def launch_range(request: HttpRequest) -> JsonResponse:
         return JsonResponse({"error": "Invalid JSON"}, status=400)
 
     scenario = data.get("scenario", "basic")
-    valid_scenarios = {s["id"] for s in cms_list_scenarios(user)}
+    scenarios_list = cms_list_scenarios(user)
+    valid_scenarios = {s["id"] for s in scenarios_list}
     if scenario not in valid_scenarios:
         return JsonResponse({"error": "Invalid scenario"}, status=400)
+
+    # Get scenario requirements to determine if agents are needed
+    scenario_data = next((s for s in scenarios_list if s["id"] == scenario), None)
+    agent_requirements = scenario_data.get("agent_requirements", {}) if scenario_data else {}
+    scenario_requires_agents = (
+        agent_requirements.get("requires_windows", False)
+        or agent_requirements.get("requires_linux", False)
+        or agent_requirements.get("has_from_agent", False)
+    )
 
     # Support both new (agents) and legacy (agent_id) formats
     agents_by_os: dict[str, int] = {}
     if "agents" in data:
-        # New format: {"windows": 123, "linux": 456}
+        # New format: {"windows": 123, "linux": 456} or {} for no-agent scenarios
         agents_by_os = data["agents"]
     elif "agent_id" in data:
         # Legacy format: single agent - determine OS from agent
@@ -445,11 +458,13 @@ def launch_range(request: HttpRequest) -> JsonResponse:
             agents_by_os[os_type] = agent_id
         except CMSError as e:
             return JsonResponse({"error": str(e)}, status=400)
-    else:
+    elif scenario_requires_agents:
+        # Only require agents if scenario needs them
         return JsonResponse(
-            {"error": "Either 'agents' or 'agent_id' is required"},
+            {"error": "Either 'agents' or 'agent_id' is required for this scenario"},
             status=400,
         )
+    # If scenario doesn't require agents and none provided, agents_by_os stays {}
 
     try:
         range_ctx = cms_create_range(

--- a/shifter/shifter_platform/static/js/dashboard.js
+++ b/shifter/shifter_platform/static/js/dashboard.js
@@ -649,6 +649,9 @@ class DashboardManager {
         const scenario = this.scenarioSelect?.value || 'basic';
         const req = this.scenarioRequirements[scenario] || {};
 
+        // Check if scenario requires any agents
+        const scenarioRequiresAgents = req.requires_windows || req.requires_linux || req.has_from_agent;
+
         // Build agents dict based on scenario requirements
         const agents = {};
 
@@ -668,8 +671,8 @@ class DashboardManager {
             agents.linux = Number.parseInt(this.linuxAgentSelect.value, 10);
         }
 
-        // Validate we have at least one agent
-        if (Object.keys(agents).length === 0) {
+        // Only require agents if scenario needs them
+        if (scenarioRequiresAgents && Object.keys(agents).length === 0) {
             return;
         }
 


### PR DESCRIPTION
Adds a new scenario variant that provisions the Cortex BYOT range without any XDR agents installed on victims. This enables users to demo NGFW and AD environments without requiring agent uploads.

Changes:
- Add cortex_byot_no_xdr.yaml template with 6 instances:
  - Attacker (Kali), DC (Windows), DC Ubuntu Server (new),
  - Workstation 1 & 2 (Windows), Server (Ubuntu)
  - All instances have xdr_agent: false
  - Extra Ubuntu server added to dc_network subnet

- Update Mission Control launch_range view to check scenario requirements before requiring agents - allows empty agents dict for scenarios that don't need them

- Update dashboard.js launchRange() to only require agent selection if the scenario has agent requirements

The existing CMS services, hydrator, and provisioner already handle scenarios without agents correctly:
- Hydrator skips agent validation when no xdr_agent: true instances
- Provisioner skips XDR install steps when agent_presigned_url is None