### PR TITLE
Add NGFW management access for CLI and web portal

### DIFF
--- a/shifter/shifter_platform/engine/services.py
+++ b/shifter/shifter_platform/engine/services.py
@@ -1027,3 +1027,93 @@ def complete_ngfw_setup(request_id: UUID) -> bool:
         )
 
     return task_arn is not None
+
+
+def get_ngfw_connection_info(user: User, app_id: str) -> dict[str, Any]:
+    """Get connection info for management access to an NGFW.
+
+    Args:
+        user: Authenticated user requesting connection
+        app_id: UUID of the NGFW App to connect to
+
+    Returns:
+        Dict with keys: management_ip, ssh_key, connection_name, status
+
+    Raises:
+        ValueError: If NGFW not found, not owned by user, or not ready
+        PermissionError: If user doesn't own the NGFW
+    """
+    from uuid import UUID
+
+    from cms.models import App
+    from engine.models import Instance, Request
+    from engine.secrets import get_ssh_key
+
+    if user is None:
+        raise ValueError("user is required")
+    if not app_id:
+        raise ValueError("app_id is required")
+
+    # Parse UUID
+    try:
+        app_uuid = UUID(app_id) if isinstance(app_id, str) else app_id
+    except ValueError:
+        raise ValueError(f"Invalid app_id: {app_id}") from None
+
+    logger.debug("get_ngfw_connection_info: user=%s app_id=%s", user.id, app_id)
+
+    # Look up CMS App to verify ownership
+    try:
+        cms_app = App.objects.select_related("instance", "instance__request").get(
+            id=app_uuid,
+            instance__request__user=user,
+            app_type__slug="panw-ngfw",
+            deleted_at__isnull=True,
+        )
+    except App.DoesNotExist:
+        raise ValueError("NGFW not found or not owned by user") from None
+
+    # Get request_id from CMS app's instance's request
+    request_id = cms_app.instance.request.request_id
+
+    # Find Engine Instance by request
+    try:
+        engine_request = Request.objects.get(request_id=request_id)
+    except Request.DoesNotExist:
+        raise ValueError("NGFW infrastructure not found") from None
+
+    engine_instance = Instance.objects.filter(request=engine_request, role="ngfw").first()
+    if not engine_instance:
+        raise ValueError("NGFW instance not found")
+
+    # Verify NGFW is in a connectable state
+    connectable_statuses = ["ready", "awaiting_association", "configuring"]
+    if engine_instance.status not in connectable_statuses:
+        raise ValueError(
+            f"NGFW is not accessible (status: {engine_instance.status}). "
+            f"NGFW must be in one of: {', '.join(connectable_statuses)}"
+        )
+
+    # Get state data from engine instance
+    state = engine_instance.state or {}
+    management_ip = state.get("management_ip")
+    ssh_key_arn = state.get("ssh_key_secret_arn")
+
+    if not management_ip:
+        raise ValueError("NGFW management IP not available")
+
+    # Get SSH key from Secrets Manager
+    ssh_key = None
+    if ssh_key_arn:
+        try:
+            ssh_key = get_ssh_key(ssh_key_arn)
+        except Exception as e:
+            logger.warning("Failed to get SSH key for NGFW: %s", e)
+            raise ValueError("Failed to retrieve NGFW SSH key") from e
+
+    return {
+        "management_ip": management_ip,
+        "ssh_key": ssh_key,
+        "connection_name": cms_app.name,
+        "status": engine_instance.status,
+    }

--- a/shifter/shifter_platform/mission_control/guacamole.py
+++ b/shifter/shifter_platform/mission_control/guacamole.py
@@ -282,3 +282,113 @@ def create_guacamole_rdp_url(
     # Return public URL for browser
     base_url = base_url.rstrip("/")
     return f"{base_url}/#/client/{client_id}?token={auth_token}"
+
+
+def create_ssh_connection_params(
+    hostname: str,
+    port: int = 22,
+    username: str | None = None,
+    private_key: str | None = None,
+    color_scheme: str = "green-black",
+    font_size: int = 12,
+    scrollback: int = 1000,
+) -> dict[str, str]:
+    """Create SSH connection parameters for Guacamole.
+
+    Args:
+        hostname: Target host IP or hostname
+        port: SSH port (default 22)
+        username: SSH username (default 'admin' for PAN-OS)
+        private_key: PEM-encoded private key for authentication
+        color_scheme: Terminal color scheme (default 'green-black')
+        font_size: Terminal font size in points
+        scrollback: Number of lines in scrollback buffer
+
+    Returns:
+        Dictionary of SSH parameters for Guacamole
+    """
+    params: dict[str, str] = {
+        "hostname": hostname,
+        "port": str(port),
+        # Terminal appearance
+        "color-scheme": color_scheme,
+        "font-size": str(font_size),
+        "scrollback": str(scrollback),
+        # Enable clipboard
+        "disable-copy": "false",
+        "disable-paste": "false",
+    }
+
+    if username:
+        params["username"] = username
+    if private_key:
+        params["private-key"] = private_key
+
+    return params
+
+
+def create_guacamole_ssh_url(
+    base_url: str,
+    secret_key: str,
+    username: str,
+    connection_name: str,
+    hostname: str,
+    port: int = 22,
+    expires_minutes: int = 5,
+    ssh_username: str = "admin",
+    ssh_private_key: str | None = None,
+    api_base_url: str | None = None,
+) -> str:
+    """Create a signed Guacamole URL for SSH access.
+
+    This function:
+    1. Creates an encrypted JSON payload with connection details
+    2. POSTs to Guacamole's /api/tokens to get an auth token
+    3. Returns a URL that auto-connects to the SSH session
+
+    Args:
+        base_url: Public Guacamole URL for browser (e.g., 'https://portal.example.com/guacamole')
+        secret_key: 32-character hex string (128-bit key)
+        username: User's email/username for Guacamole session
+        connection_name: Identifier for this connection
+        hostname: Target host IP for SSH
+        port: SSH port (default 22)
+        expires_minutes: Minutes until URL expires
+        ssh_username: Username for SSH login (default 'admin' for PAN-OS)
+        ssh_private_key: PEM-encoded private key for SSH authentication
+        api_base_url: Internal URL for server-to-server API calls (defaults to base_url)
+
+    Returns:
+        Full Guacamole URL with auth token that auto-connects to SSH
+
+    Raises:
+        ValueError: If secret key is invalid or token request fails
+    """
+    # Create connection definition
+    connections = {
+        connection_name: {
+            "protocol": "ssh",
+            "parameters": create_ssh_connection_params(
+                hostname,
+                port,
+                username=ssh_username,
+                private_key=ssh_private_key,
+            ),
+        }
+    }
+
+    # Create and sign payload
+    payload = create_guacamole_auth_payload(username, connections, expires_minutes)
+    encrypted_data = sign_and_encrypt_payload(payload, secret_key)
+
+    # Get auth token from Guacamole API (use internal URL if provided)
+    api_url = (api_base_url or base_url).rstrip("/")
+    auth_token = get_guacamole_auth_token(api_url, encrypted_data)
+
+    # Build client identifier: connection_name + NULL + "c" + NULL + "json"
+    # This tells Guacamole to auto-connect to the specified connection from JSON auth
+    client_id = base64.b64encode(f"{connection_name}\0c\0json".encode()).decode().rstrip("=")
+
+    # Return public URL for browser
+    base_url = base_url.rstrip("/")
+    return f"{base_url}/#/client/{client_id}?token={auth_token}"

--- a/shifter/shifter_platform/mission_control/urls.py
+++ b/shifter/shifter_platform/mission_control/urls.py
@@ -38,6 +38,8 @@ urlpatterns = [
     path("api/ngfw/list/", views.api_ngfw_list, name="api_ngfw_list"),
     path("api/ngfw/<uuid:app_id>/destroy/", views.api_ngfw_destroy, name="api_ngfw_destroy"),
     path("api/ngfw/<uuid:app_id>/complete-setup/", views.api_ngfw_complete_setup, name="api_ngfw_complete_setup"),
+    path("api/ngfw/<uuid:app_id>/ssh-url/", views.api_ngfw_ssh_url, name="api_ngfw_ssh_url"),
+    path("api/ngfw/<uuid:app_id>/management-info/", views.api_ngfw_management_info, name="api_ngfw_management_info"),
     # Credential views
     path("credentials/", views.credentials_list, name="credentials_list"),
     path("credentials/add/", views.credential_add, name="credential_add"),

--- a/shifter/shifter_platform/mission_control/views.py
+++ b/shifter/shifter_platform/mission_control/views.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 from typing import cast
+from uuid import UUID
 
 from django.conf import settings as django_settings
 from django.contrib import messages
@@ -890,6 +891,105 @@ def api_ngfw_complete_setup(request: HttpRequest, app_id: str) -> JsonResponse:
             "instance_id": str(result.instance_id),
         }
     )
+
+
+@login_required
+@require_POST
+def api_ngfw_ssh_url(request: HttpRequest, app_id: UUID) -> JsonResponse:
+    """Generate a signed Guacamole URL for SSH access to NGFW CLI.
+
+    Request body (JSON): None required
+
+    Response (JSON):
+        - url: Signed Guacamole URL that opens SSH session to NGFW
+
+    Security:
+        - User must own the NGFW
+        - NGFW must be in a connectable state (ready, awaiting_association, configuring)
+        - URL is signed with HMAC-SHA256 and expires in 5 minutes
+    """
+    from engine.services import get_ngfw_connection_info
+    from mission_control.guacamole import create_guacamole_ssh_url
+
+    user = _get_user(request)
+
+    try:
+        conn_info = get_ngfw_connection_info(user, str(app_id))
+    except ValueError as e:
+        return JsonResponse({"error": str(e)}, status=400)
+    except PermissionError as e:
+        return JsonResponse({"error": str(e)}, status=403)
+
+    # Get Guacamole configuration from settings
+    guacamole_base_url = django_settings.GUACAMOLE_URL
+    guacamole_api_url = getattr(django_settings, "GUACAMOLE_API_URL", None)
+    secret_key = django_settings.GUACAMOLE_SECRET_KEY
+
+    if not guacamole_base_url or not secret_key:
+        logger.error("Guacamole not configured")
+        return JsonResponse({"error": "Remote access not configured"}, status=503)
+
+    try:
+        url = create_guacamole_ssh_url(
+            base_url=guacamole_base_url,
+            secret_key=secret_key,
+            username=request.user.email,
+            connection_name=f"NGFW-{conn_info['connection_name']}",
+            hostname=conn_info["management_ip"],
+            port=22,
+            expires_minutes=5,
+            ssh_username="admin",  # PAN-OS admin user
+            ssh_private_key=conn_info.get("ssh_key"),
+            api_base_url=guacamole_api_url,
+        )
+    except ValueError as e:
+        logger.error("Failed to create Guacamole SSH URL: %s", e)
+        return JsonResponse({"error": "Failed to generate access URL"}, status=500)
+
+    logger.info("NGFW SSH URL generated: user=%s app_id=%s", user.email, app_id)
+    return JsonResponse({"url": url})
+
+
+@login_required
+@require_GET
+def api_ngfw_management_info(request: HttpRequest, app_id: UUID) -> JsonResponse:
+    """Get NGFW management connection information.
+
+    Returns the management IP and port for the NGFW web interface.
+    The web interface is accessible via HTTPS on port 443.
+
+    Response (JSON):
+        - management_ip: NGFW management interface IP address
+        - web_url: URL for NGFW web management interface (via proxy)
+        - status: Current NGFW status
+        - accessible: Boolean indicating if NGFW is currently accessible
+    """
+    from engine.services import get_ngfw_connection_info
+
+    user = _get_user(request)
+
+    try:
+        conn_info = get_ngfw_connection_info(user, str(app_id))
+        accessible = True
+    except ValueError as e:
+        # Return partial info even if not fully accessible
+        return JsonResponse({
+            "accessible": False,
+            "error": str(e),
+        })
+    except PermissionError as e:
+        return JsonResponse({"error": str(e)}, status=403)
+
+    # Build web management URL - the NGFW web interface runs on HTTPS port 443
+    # Users access it via Guacamole's VNC/browser or direct HTTPS if network allows
+    management_ip = conn_info["management_ip"]
+
+    return JsonResponse({
+        "management_ip": management_ip,
+        "web_url": f"https://{management_ip}",
+        "status": conn_info["status"],
+        "accessible": accessible,
+    })
 
 
 # -----------------------------------------------------------------------------

--- a/shifter/shifter_platform/templates/mission_control/ngfw/detail.html
+++ b/shifter/shifter_platform/templates/mission_control/ngfw/detail.html
@@ -182,6 +182,78 @@
         fill: currentColor;
         stroke: currentColor;
     }
+
+    /* Management Access section */
+    .management-access-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        gap: 16px;
+    }
+
+    .access-card {
+        background: var(--xdr-bg-tertiary);
+        border-radius: 8px;
+        padding: 16px;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+    }
+
+    .access-card-header {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+    }
+
+    .access-card-icon {
+        width: 40px;
+        height: 40px;
+        border-radius: 8px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: var(--xdr-bg-secondary);
+    }
+
+    .access-card-icon svg {
+        width: 20px;
+        height: 20px;
+        color: var(--xdr-text-secondary);
+    }
+
+    .access-card-title {
+        font-size: 14px;
+        font-weight: 600;
+        color: var(--xdr-text);
+    }
+
+    .access-card-description {
+        font-size: 13px;
+        color: var(--xdr-text-secondary);
+        margin: 0;
+        line-height: 1.4;
+    }
+
+    .access-card .btn {
+        align-self: flex-start;
+        margin-top: auto;
+    }
+
+    .management-ip-display {
+        font-family: monospace;
+        background: var(--xdr-bg-secondary);
+        padding: 8px 12px;
+        border-radius: 4px;
+        font-size: 13px;
+        color: var(--xdr-text);
+        margin-top: 8px;
+    }
+
+    .access-unavailable {
+        color: var(--xdr-text-tertiary);
+        font-style: italic;
+        font-size: 13px;
+    }
 </style>
 {% endblock %}
 
@@ -240,6 +312,66 @@
             <span class="detail-label">Created</span>
             <span class="detail-value">{{ ngfw.created_at|date:"M d, Y H:i" }}</span>
         </div>
+    </div>
+</div>
+
+<!-- Management Access Section -->
+<div class="card" id="management-access-card">
+    <h2 class="section-title">Management Access</h2>
+    <p style="color: var(--xdr-text-secondary); margin: 0 0 16px; font-size: 13px;">
+        Direct access to your NGFW for fine-grained configuration control.
+    </p>
+
+    <div class="management-access-grid">
+        <!-- CLI Access -->
+        <div class="access-card">
+            <div class="access-card-header">
+                <div class="access-card-icon">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <polyline points="4 17 10 11 4 5"></polyline>
+                        <line x1="12" y1="19" x2="20" y2="19"></line>
+                    </svg>
+                </div>
+                <span class="access-card-title">CLI Access</span>
+            </div>
+            <p class="access-card-description">
+                Open a terminal session to the NGFW command line interface.
+                Use PAN-OS CLI commands for advanced configuration.
+            </p>
+            <button type="button" class="btn btn-primary btn-small" id="cli-access-btn" data-app-id="{{ ngfw.app_id }}">
+                Open CLI
+            </button>
+        </div>
+
+        <!-- Web Portal -->
+        <div class="access-card">
+            <div class="access-card-header">
+                <div class="access-card-icon">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <circle cx="12" cy="12" r="10"></circle>
+                        <line x1="2" y1="12" x2="22" y2="12"></line>
+                        <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"></path>
+                    </svg>
+                </div>
+                <span class="access-card-title">Web Portal</span>
+            </div>
+            <p class="access-card-description">
+                Access the PAN-OS web management interface for visual configuration
+                of policies, objects, and system settings.
+            </p>
+            <div id="management-ip-container" style="display: none;">
+                <div class="management-ip-display">
+                    <span id="management-ip-value"></span>
+                </div>
+            </div>
+            <button type="button" class="btn btn-secondary btn-small" id="web-portal-btn" data-app-id="{{ ngfw.app_id }}">
+                View Details
+            </button>
+        </div>
+    </div>
+
+    <div id="management-access-status" style="margin-top: 16px; display: none;">
+        <p class="access-unavailable" id="access-unavailable-msg"></p>
     </div>
 </div>
 
@@ -343,6 +475,9 @@
 {% block extra_js %}
 <script>
 document.addEventListener('DOMContentLoaded', () => {
+    const appId = '{{ ngfw.app_id }}';
+    const csrfToken = '{{ csrf_token }}';
+
     // Refresh button handler
     const refreshBtn = document.querySelector('.ngfw-refresh-btn');
     if (refreshBtn) {
@@ -382,7 +517,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json',
-                        'X-CSRFToken': '{{ csrf_token }}'
+                        'X-CSRFToken': csrfToken
                     }
                 });
 
@@ -420,6 +555,119 @@ document.addEventListener('DOMContentLoaded', () => {
                 alert('An error occurred. Please try again.');
                 this.disabled = false;
                 this.textContent = 'Complete Setup';
+            }
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // Management Access Handlers
+    // -------------------------------------------------------------------------
+
+    const cliAccessBtn = document.getElementById('cli-access-btn');
+    const webPortalBtn = document.getElementById('web-portal-btn');
+    const managementIpContainer = document.getElementById('management-ip-container');
+    const managementIpValue = document.getElementById('management-ip-value');
+    const accessStatusDiv = document.getElementById('management-access-status');
+    const accessUnavailableMsg = document.getElementById('access-unavailable-msg');
+
+    // Check initial access status based on NGFW status
+    const ngfwStatus = '{{ ngfw.status }}';
+    const accessibleStatuses = ['ready', 'awaiting_association', 'configuring'];
+
+    if (!accessibleStatuses.includes(ngfwStatus)) {
+        // Disable buttons and show message for inaccessible states
+        if (cliAccessBtn) cliAccessBtn.disabled = true;
+        if (webPortalBtn) webPortalBtn.disabled = true;
+        if (accessStatusDiv) {
+            accessStatusDiv.style.display = 'block';
+            accessUnavailableMsg.textContent = `Management access is unavailable while NGFW is ${ngfwStatus.replace('_', ' ')}.`;
+        }
+    }
+
+    // CLI Access button - opens SSH via Guacamole
+    if (cliAccessBtn) {
+        cliAccessBtn.addEventListener('click', async function() {
+            this.disabled = true;
+            this.textContent = 'Connecting...';
+
+            try {
+                const response = await fetch(`/mission-control/api/ngfw/${appId}/ssh-url/`, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRFToken': csrfToken
+                    }
+                });
+
+                const data = await response.json();
+
+                if (data.error) {
+                    alert('Error: ' + data.error);
+                    this.disabled = false;
+                    this.textContent = 'Open CLI';
+                    return;
+                }
+
+                if (data.url) {
+                    // Open Guacamole SSH session in new tab
+                    window.open(data.url, '_blank');
+                }
+
+                this.disabled = false;
+                this.textContent = 'Open CLI';
+
+            } catch (err) {
+                console.error('CLI access error:', err);
+                alert('Failed to connect. Please try again.');
+                this.disabled = false;
+                this.textContent = 'Open CLI';
+            }
+        });
+    }
+
+    // Web Portal button - show management info
+    if (webPortalBtn) {
+        webPortalBtn.addEventListener('click', async function() {
+            this.disabled = true;
+            const originalText = this.textContent;
+            this.textContent = 'Loading...';
+
+            try {
+                const response = await fetch(`/mission-control/api/ngfw/${appId}/management-info/`);
+                const data = await response.json();
+
+                if (data.error && !data.management_ip) {
+                    alert('Error: ' + data.error);
+                    this.disabled = false;
+                    this.textContent = originalText;
+                    return;
+                }
+
+                if (data.management_ip) {
+                    // Show management IP info
+                    managementIpValue.innerHTML = `
+                        <strong>Management IP:</strong> ${data.management_ip}<br>
+                        <strong>Web URL:</strong> <a href="${data.web_url}" target="_blank" rel="noopener noreferrer" style="color: var(--xdr-link);">${data.web_url}</a><br>
+                        <small style="color: var(--xdr-text-tertiary);">
+                            Note: Direct access requires VPN or network connectivity to the range VPC.
+                            Use CLI access via the button above for browser-based access.
+                        </small>
+                    `;
+                    managementIpContainer.style.display = 'block';
+                    this.textContent = 'Refresh';
+                } else {
+                    managementIpValue.textContent = 'Management IP not available';
+                    managementIpContainer.style.display = 'block';
+                    this.textContent = originalText;
+                }
+
+                this.disabled = false;
+
+            } catch (err) {
+                console.error('Management info error:', err);
+                alert('Failed to retrieve management information.');
+                this.disabled = false;
+                this.textContent = originalText;
             }
         });
     }


### PR DESCRIPTION
Implement direct management access to NGFWs from the detail page:
- Add SSH CLI access via Guacamole for PAN-OS CLI commands
- Add web portal info display with management IP and URL
- New API endpoints: /api/ngfw/{app_id}/ssh-url/ and /management-info/
- New engine service: get_ngfw_connection_info() for retrieving NGFW state
- New guacamole function: create_guacamole_ssh_url() for SSH connections

This allows users fine-grained control over their NGFW configuration
through both command-line and web interfaces once provisioned.