### PR TITLE
CTF-408: Add per-participant score timeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.53.0] - 2026-04-02
+
+### Added
+- Per-participant score timeline API and charts showing cumulative score progression over event duration (CTF-408)
+- Score timeline chart on participant scoreboard page (own timeline) and admin participant detail page (any participant)
+- `get_score_timeline()` service function in CTF scoring module
+
 ## [3.52.0] - 2026-04-01
 
 ### Added

--- a/shifter/shifter_platform/ctf/services/__init__.py
+++ b/shifter/shifter_platform/ctf/services/__init__.py
@@ -93,6 +93,7 @@ from ctf.services.scoring import (
     get_challenge_statistics,
     get_event_statistics,
     get_participant_rank,
+    get_score_timeline,
     get_scoreboard,
     get_team_scoreboard,
 )
@@ -145,6 +146,7 @@ __all__ = [
     "get_participant_submissions",
     "get_prerequisites",
     "get_range_status",
+    "get_score_timeline",
     "get_scoreboard",
     "get_team_scoreboard",
     "get_total_hint_penalty",

--- a/shifter/shifter_platform/ctf/services/scoring.py
+++ b/shifter/shifter_platform/ctf/services/scoring.py
@@ -301,19 +301,28 @@ def get_score_timeline(participant_id: UUID) -> list[dict[str, Any]]:
 
     events.sort(key=lambda e: e[0])
 
+    # Fold pre-start events into the origin point's cumulative value
+    pre_start_cumulative = 0
+    post_start_events: list[tuple[datetime, int, str, str]] = []
+    for ev in events:
+        if ev[0] < event_start:
+            pre_start_cumulative += ev[1]
+        else:
+            post_start_events.append(ev)
+
     # Build timeline with cumulative totals
     timeline: list[dict[str, Any]] = [
         {
             "timestamp": event_start.isoformat(),
-            "points": 0,
-            "cumulative": 0,
+            "points": pre_start_cumulative,
+            "cumulative": pre_start_cumulative,
             "label": "Event start",
             "type": "start",
         }
     ]
 
-    cumulative = 0
-    for ts, points, label, event_type in events:
+    cumulative = pre_start_cumulative
+    for ts, points, label, event_type in post_start_events:
         cumulative += points
         timeline.append(
             {

--- a/shifter/shifter_platform/ctf/services/scoring.py
+++ b/shifter/shifter_platform/ctf/services/scoring.py
@@ -17,7 +17,7 @@ from ctf.enums import ParticipantStatus
 from ctf.models import CTFAward, CTFParticipant, CTFSubmission, CTFTeam
 
 if TYPE_CHECKING:
-    pass
+    from datetime import datetime
 
 logger = logging.getLogger(__name__)
 
@@ -253,6 +253,79 @@ def get_challenge_statistics(challenge_id: UUID) -> dict[str, Any]:
             else 0
         ),
     }
+
+
+def get_score_timeline(participant_id: UUID) -> list[dict[str, Any]]:
+    """Get cumulative score timeline for a participant.
+
+    Returns a chronologically-ordered list of score events (solves and awards)
+    with running cumulative totals, suitable for rendering a step chart.
+
+    Args:
+        participant_id: UUID of the participant.
+
+    Returns:
+        List of dicts with timestamp, points, cumulative score, label, and type.
+        The first entry is always the event start with cumulative 0.
+    """
+    logger.debug("Getting score timeline for participant %s", participant_id)
+
+    participant = CTFParticipant.objects.select_related("event").get(pk=participant_id)
+    event_start = participant.event.event_start
+
+    # Correct submissions ordered by time
+    submissions = list(
+        CTFSubmission.objects.filter(
+            participant_id=participant_id,
+            is_correct=True,
+        )
+        .values("submitted_at", "points_awarded", "challenge__name")
+        .order_by("submitted_at")
+    )
+
+    # Awards ordered by time
+    awards = list(
+        CTFAward.objects.filter(
+            participant_id=participant_id,
+        )
+        .values("created_at", "points", "reason")
+        .order_by("created_at")
+    )
+
+    # Merge into unified event list
+    events: list[tuple[datetime, int, str, str]] = []
+    for s in submissions:
+        events.append((s["submitted_at"], s["points_awarded"], s["challenge__name"] or "", "solve"))
+    for a in awards:
+        events.append((a["created_at"], a["points"], a["reason"] or "", "award"))
+
+    events.sort(key=lambda e: e[0])
+
+    # Build timeline with cumulative totals
+    timeline: list[dict[str, Any]] = [
+        {
+            "timestamp": event_start.isoformat(),
+            "points": 0,
+            "cumulative": 0,
+            "label": "Event start",
+            "type": "start",
+        }
+    ]
+
+    cumulative = 0
+    for ts, points, label, event_type in events:
+        cumulative += points
+        timeline.append(
+            {
+                "timestamp": ts.isoformat(),
+                "points": points,
+                "cumulative": cumulative,
+                "label": label[:50] if len(label) > 50 else label,
+                "type": event_type,
+            }
+        )
+
+    return timeline
 
 
 def get_event_statistics(event_id: UUID) -> dict[str, Any]:

--- a/shifter/shifter_platform/ctf/urls.py
+++ b/shifter/shifter_platform/ctf/urls.py
@@ -237,6 +237,11 @@ api_patterns = [
         views.api_scoreboard,
         name="api_scoreboard",
     ),
+    path(
+        "api/participants/<uuid:participant_id>/score-timeline/",
+        views.api_score_timeline,
+        name="api_score_timeline",
+    ),
     # Notification APIs
     path(
         "api/events/<uuid:event_id>/notifications/",

--- a/shifter/shifter_platform/ctf/views.py
+++ b/shifter/shifter_platform/ctf/views.py
@@ -2424,6 +2424,51 @@ def api_scoreboard(request: HttpRequest, event_id: UUID) -> JsonResponse:
 
 
 @login_required
+@ctf_role_required
+@require_GET
+def api_score_timeline(request: HttpRequest, participant_id: UUID) -> JsonResponse:
+    """API: Get per-participant score timeline.
+
+    Returns chronological score progression data for rendering a step chart.
+    Participants can view their own timeline; organizers can view any
+    participant's timeline for events they own.
+
+    Args:
+        participant_id: UUID of the participant.
+    """
+    from ctf.exceptions import CTFNotFoundError
+    from ctf.services import get_participant
+    from ctf.services.scoring import get_score_timeline
+
+    try:
+        participant = get_participant(participant_id)
+    except CTFNotFoundError:
+        return JsonResponse({"error": "Participant not found"}, status=404)
+
+    # Authorization: organizers can view their events' participants,
+    # participants can only view their own timeline
+    user = _get_user(request)
+    role = get_user_role(user)
+
+    if role.is_ctf_organizer:
+        ownership_error = _check_event_ownership(participant.event, user)
+        if ownership_error:
+            return ownership_error
+    elif participant.user_id != user.pk:
+        return JsonResponse({"error": "Forbidden"}, status=403)
+
+    timeline = get_score_timeline(participant_id)
+
+    return JsonResponse(
+        {
+            "participant_id": str(participant.id),
+            "participant_name": participant.name,
+            "timeline": timeline,
+        }
+    )
+
+
+@login_required
 @ctf_organizer_required
 @require_http_methods(["GET", "POST"])
 def api_notification_list(request: HttpRequest, event_id: UUID) -> JsonResponse:

--- a/shifter/shifter_platform/eslint.config.js
+++ b/shifter/shifter_platform/eslint.config.js
@@ -20,7 +20,7 @@ export default [
       },
     },
     rules: {
-      'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+      'no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^init' }],
     },
   },
 ];

--- a/shifter/shifter_platform/static/js/score-timeline.js
+++ b/shifter/shifter_platform/static/js/score-timeline.js
@@ -1,0 +1,100 @@
+/**
+ * Score Timeline Chart
+ *
+ * Renders a stepped-line Chart.js chart showing cumulative score progression
+ * for a CTF participant. Fetches data from the score-timeline API endpoint.
+ *
+ * Usage: call initScoreTimeline(canvasId, apiUrl) after Chart.js is loaded.
+ */
+
+/* global Chart */
+
+function initScoreTimeline(canvasId, apiUrl) {
+    var canvas = document.getElementById(canvasId);
+    if (!canvas) return;
+
+    fetch(apiUrl)
+        .then(function (response) {
+            return response.json();
+        })
+        .then(function (data) {
+            if (!data.timeline || data.timeline.length === 0) {
+                var parent = canvas.parentElement;
+                parent.removeChild(canvas);
+                parent.textContent = "No score data yet.";
+                return;
+            }
+
+            var labels = [];
+            var scores = [];
+            var tooltipLabels = [];
+
+            data.timeline.forEach(function (entry) {
+                labels.push(new Date(entry.timestamp));
+                scores.push(entry.cumulative);
+                var pointsText =
+                    entry.points > 0
+                        ? " (+" + entry.points + ")"
+                        : entry.points < 0
+                          ? " (" + entry.points + ")"
+                          : "";
+                tooltipLabels.push(entry.label + pointsText);
+            });
+
+            new Chart(canvas, {
+                type: "line",
+                data: {
+                    labels: labels,
+                    datasets: [
+                        {
+                            label: "Score",
+                            data: scores,
+                            borderColor: "#128df3",
+                            backgroundColor: "rgba(18, 141, 243, 0.1)",
+                            fill: true,
+                            stepped: "before",
+                            pointRadius: 3,
+                            pointBackgroundColor: "#128df3",
+                            borderWidth: 2,
+                        },
+                    ],
+                },
+                options: {
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    scales: {
+                        x: {
+                            type: "time",
+                            time: {
+                                tooltipFormat: "MMM d, HH:mm",
+                                displayFormats: {
+                                    hour: "HH:mm",
+                                    day: "MMM d",
+                                },
+                            },
+                            ticks: { color: "#b8b8b8" },
+                            grid: { color: "rgba(255,255,255,0.1)" },
+                        },
+                        y: {
+                            beginAtZero: true,
+                            ticks: { color: "#b8b8b8", precision: 0 },
+                            grid: { color: "rgba(255,255,255,0.1)" },
+                        },
+                    },
+                    plugins: {
+                        legend: { display: false },
+                        tooltip: {
+                            callbacks: {
+                                afterLabel: function (context) {
+                                    return tooltipLabels[context.dataIndex];
+                                },
+                            },
+                        },
+                    },
+                },
+            });
+        })
+        .catch(function (err) {
+            console.error("Failed to load score timeline:", err);
+        });
+}

--- a/shifter/shifter_platform/templates/ctf/admin/participant_detail.html
+++ b/shifter/shifter_platform/templates/ctf/admin/participant_detail.html
@@ -274,8 +274,16 @@
         </div>
     </div>
 
-    <!-- Right Column: Submission History -->
+    <!-- Right Column: Timeline & Submission History -->
     <div>
+        <!-- Score Timeline Chart -->
+        <div class="card" style="margin-bottom: 16px;">
+            <div class="card-title">Score Timeline</div>
+            <div style="position: relative; height: 250px; padding: 0 16px 16px;">
+                <canvas id="score-timeline-chart"></canvas>
+            </div>
+        </div>
+
         <div class="card">
             <div class="card-title">Submission History</div>
             {% if submissions %}
@@ -332,6 +340,89 @@
 {% endblock %}
 
 {% block extra_js %}
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+<script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@3"></script>
+<script>
+// Score Timeline Chart
+(function() {
+    var canvas = document.getElementById('score-timeline-chart');
+    if (!canvas) return;
+
+    fetch('/ctf/api/participants/{{ participant.pk }}/score-timeline/', {
+        headers: { 'X-CSRFToken': '{{ csrf_token }}' }
+    })
+    .then(function(response) { return response.json(); })
+    .then(function(data) {
+        if (!data.timeline || data.timeline.length === 0) {
+            canvas.parentElement.textContent = 'No score data yet.';
+            return;
+        }
+
+        var labels = [];
+        var scores = [];
+        var tooltipLabels = [];
+
+        for (var i = 0; i < data.timeline.length; i++) {
+            var entry = data.timeline[i];
+            var d = new Date(entry.timestamp);
+            labels.push(d);
+            scores.push(entry.cumulative);
+            tooltipLabels.push(entry.label + (entry.points ? ' (+' + entry.points + ')' : ''));
+        }
+
+        new Chart(canvas, {
+            type: 'line',
+            data: {
+                labels: labels,
+                datasets: [{
+                    label: 'Score',
+                    data: scores,
+                    borderColor: '#128df3',
+                    backgroundColor: 'rgba(18, 141, 243, 0.1)',
+                    fill: true,
+                    stepped: 'before',
+                    pointRadius: 3,
+                    pointBackgroundColor: '#128df3',
+                    borderWidth: 2
+                }]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                scales: {
+                    x: {
+                        type: 'time',
+                        time: {
+                            tooltipFormat: 'MMM d, HH:mm',
+                            displayFormats: { hour: 'HH:mm', day: 'MMM d' }
+                        },
+                        ticks: { color: '#b8b8b8' },
+                        grid: { color: 'rgba(255,255,255,0.1)' }
+                    },
+                    y: {
+                        beginAtZero: true,
+                        ticks: { color: '#b8b8b8', precision: 0 },
+                        grid: { color: 'rgba(255,255,255,0.1)' }
+                    }
+                },
+                plugins: {
+                    legend: { display: false },
+                    tooltip: {
+                        callbacks: {
+                            afterLabel: function(context) {
+                                return tooltipLabels[context.dataIndex];
+                            }
+                        }
+                    }
+                }
+            }
+        });
+    })
+    .catch(function(err) {
+        console.error('Failed to load score timeline:', err);
+    });
+})();
+</script>
 <script>
 function resendInvite(participantId) {
     if (!confirm('Resend invitation email to this participant?')) return;

--- a/shifter/shifter_platform/templates/ctf/admin/participant_detail.html
+++ b/shifter/shifter_platform/templates/ctf/admin/participant_detail.html
@@ -1,4 +1,5 @@
 {% extends "mission_control/base.html" %}
+{% load static %}
 {% block title %}{{ participant.name }} - {{ event.name }}{% endblock %}
 
 {% block extra_css %}
@@ -340,88 +341,11 @@
 {% endblock %}
 
 {% block extra_js %}
-<script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
-<script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@3"></script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1/dist/chart.umd.min.js" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@3.0.0/dist/chartjs-adapter-date-fns.bundle.min.js" integrity="sha384-cVMg8E3QFwTvGCDuK+ET4PD341jF3W8nO1auiXfuZNQkzbUUiBGLsIQUE+b1mxws" crossorigin="anonymous"></script>
+<script src="{% static 'js/score-timeline.js' %}"></script>
 <script>
-// Score Timeline Chart
-(function() {
-    var canvas = document.getElementById('score-timeline-chart');
-    if (!canvas) return;
-
-    fetch('/ctf/api/participants/{{ participant.pk }}/score-timeline/', {
-        headers: { 'X-CSRFToken': '{{ csrf_token }}' }
-    })
-    .then(function(response) { return response.json(); })
-    .then(function(data) {
-        if (!data.timeline || data.timeline.length === 0) {
-            canvas.parentElement.textContent = 'No score data yet.';
-            return;
-        }
-
-        var labels = [];
-        var scores = [];
-        var tooltipLabels = [];
-
-        for (var i = 0; i < data.timeline.length; i++) {
-            var entry = data.timeline[i];
-            var d = new Date(entry.timestamp);
-            labels.push(d);
-            scores.push(entry.cumulative);
-            tooltipLabels.push(entry.label + (entry.points ? ' (+' + entry.points + ')' : ''));
-        }
-
-        new Chart(canvas, {
-            type: 'line',
-            data: {
-                labels: labels,
-                datasets: [{
-                    label: 'Score',
-                    data: scores,
-                    borderColor: '#128df3',
-                    backgroundColor: 'rgba(18, 141, 243, 0.1)',
-                    fill: true,
-                    stepped: 'before',
-                    pointRadius: 3,
-                    pointBackgroundColor: '#128df3',
-                    borderWidth: 2
-                }]
-            },
-            options: {
-                responsive: true,
-                maintainAspectRatio: false,
-                scales: {
-                    x: {
-                        type: 'time',
-                        time: {
-                            tooltipFormat: 'MMM d, HH:mm',
-                            displayFormats: { hour: 'HH:mm', day: 'MMM d' }
-                        },
-                        ticks: { color: '#b8b8b8' },
-                        grid: { color: 'rgba(255,255,255,0.1)' }
-                    },
-                    y: {
-                        beginAtZero: true,
-                        ticks: { color: '#b8b8b8', precision: 0 },
-                        grid: { color: 'rgba(255,255,255,0.1)' }
-                    }
-                },
-                plugins: {
-                    legend: { display: false },
-                    tooltip: {
-                        callbacks: {
-                            afterLabel: function(context) {
-                                return tooltipLabels[context.dataIndex];
-                            }
-                        }
-                    }
-                }
-            }
-        });
-    })
-    .catch(function(err) {
-        console.error('Failed to load score timeline:', err);
-    });
-})();
+initScoreTimeline('score-timeline-chart', '/ctf/api/participants/{{ participant.pk }}/score-timeline/');
 </script>
 <script>
 function resendInvite(participantId) {

--- a/shifter/shifter_platform/templates/ctf/participant/scoreboard.html
+++ b/shifter/shifter_platform/templates/ctf/participant/scoreboard.html
@@ -11,8 +11,8 @@
         </button>
     </div>
 
-    {% if participant %}
-    <!-- Score Timeline Chart -->
+    {% if participant and not team_mode %}
+    <!-- Score Timeline Chart (individual mode only) -->
     <div class="card mb-4">
         <div class="card-body">
             <h5 class="card-title mb-3">Your Score Timeline</h5>
@@ -185,7 +185,7 @@ function rebuildScoreboardTable(scoreboard) {
     }
 }
 </script>
-{% if participant %}
+{% if participant and not team_mode %}
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1/dist/chart.umd.min.js" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@3.0.0/dist/chartjs-adapter-date-fns.bundle.min.js" integrity="sha384-cVMg8E3QFwTvGCDuK+ET4PD341jF3W8nO1auiXfuZNQkzbUUiBGLsIQUE+b1mxws" crossorigin="anonymous"></script>
 <script src="{% static 'js/score-timeline.js' %}"></script>

--- a/shifter/shifter_platform/templates/ctf/participant/scoreboard.html
+++ b/shifter/shifter_platform/templates/ctf/participant/scoreboard.html
@@ -10,6 +10,18 @@
         </button>
     </div>
 
+    {% if participant %}
+    <!-- Score Timeline Chart -->
+    <div class="card mb-4">
+        <div class="card-body">
+            <h5 class="card-title mb-3">Your Score Timeline</h5>
+            <div style="position: relative; height: 250px;">
+                <canvas id="score-timeline-chart"></canvas>
+            </div>
+        </div>
+    </div>
+    {% endif %}
+
     <div class="card">
         <div class="card-body p-0">
             {% if scoreboard %}
@@ -69,6 +81,8 @@
 {% endblock %}
 
 {% block extra_js %}
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+<script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@3"></script>
 <script>
 var autoRefreshInterval = null;
 
@@ -100,7 +114,7 @@ function fetchScoreboard() {
     .then(function(response) { return response.json(); })
     .then(function(data) {
         if (data.scoreboard) {
-            updateScoreboardTable(data.scoreboard);
+            rebuildScoreboardTable(data.scoreboard);
         }
     })
     .catch(function(err) {
@@ -108,48 +122,152 @@ function fetchScoreboard() {
     });
 }
 
-function updateScoreboardTable(scoreboard) {
+function rebuildScoreboardTable(scoreboard) {
     var tbody = document.getElementById('scoreboard-body');
     if (!tbody) return;
 
     var participantId = "{{ participant_id }}";
     var teamMode = {{ event.team_mode|yesno:"true,false" }};
-    var html = '';
+
+    // Clear existing rows safely
+    while (tbody.firstChild) {
+        tbody.removeChild(tbody.firstChild);
+    }
 
     for (var i = 0; i < scoreboard.length; i++) {
         var entry = scoreboard[i];
         var isCurrentUser = (String(entry.participant_id) === String(participantId));
-        var rowClass = isCurrentUser ? ' class="table-active"' : '';
 
-        html += '<tr' + rowClass + '>';
-        html += '<td>';
+        var tr = document.createElement('tr');
+        if (isCurrentUser) tr.className = 'table-active';
+
+        // Rank cell
+        var tdRank = document.createElement('td');
         if (entry.rank <= 3) {
-            html += '<strong>' + entry.rank + '</strong>';
+            var strong = document.createElement('strong');
+            strong.textContent = entry.rank;
+            tdRank.appendChild(strong);
         } else {
-            html += entry.rank;
+            tdRank.textContent = entry.rank;
         }
-        html += '</td>';
-        html += '<td><strong>' + escapeHtml(entry.name) + '</strong>';
+        tr.appendChild(tdRank);
+
+        // Name cell
+        var tdName = document.createElement('td');
+        var nameStrong = document.createElement('strong');
+        nameStrong.textContent = entry.name;
+        tdName.appendChild(nameStrong);
         if (isCurrentUser) {
-            html += ' <span class="badge bg-primary ms-1">You</span>';
+            var badge = document.createElement('span');
+            badge.className = 'badge bg-primary ms-1';
+            badge.textContent = 'You';
+            tdName.appendChild(badge);
         }
-        html += '</td>';
+        tr.appendChild(tdName);
+
+        // Team cell (if team mode)
         if (teamMode) {
-            html += '<td>' + escapeHtml(entry.team_name || '-') + '</td>';
+            var tdTeam = document.createElement('td');
+            tdTeam.textContent = entry.team_name || '-';
+            tr.appendChild(tdTeam);
         }
-        html += '<td><strong>' + entry.score + '</strong></td>';
-        html += '<td>' + entry.solves + '</td>';
-        html += '<td>' + (entry.last_solve || '-') + '</td>';
-        html += '</tr>';
+
+        // Score cell
+        var tdScore = document.createElement('td');
+        var scoreStrong = document.createElement('strong');
+        scoreStrong.textContent = entry.score;
+        tdScore.appendChild(scoreStrong);
+        tr.appendChild(tdScore);
+
+        // Solves cell
+        var tdSolves = document.createElement('td');
+        tdSolves.textContent = entry.solves;
+        tr.appendChild(tdSolves);
+
+        // Last solve cell
+        var tdLastSolve = document.createElement('td');
+        tdLastSolve.textContent = entry.last_solve || '-';
+        tr.appendChild(tdLastSolve);
+
+        tbody.appendChild(tr);
     }
-
-    tbody.innerHTML = html;
 }
 
-function escapeHtml(text) {
-    var div = document.createElement('div');
-    div.appendChild(document.createTextNode(text));
-    return div.innerHTML;
-}
+{% if participant %}
+// Score Timeline Chart
+(function() {
+    var canvas = document.getElementById('score-timeline-chart');
+    if (!canvas) return;
+
+    fetch("{% url 'ctf:api_score_timeline' participant_id=participant.pk %}")
+    .then(function(response) { return response.json(); })
+    .then(function(data) {
+        if (!data.timeline || data.timeline.length === 0) return;
+
+        var labels = [];
+        var scores = [];
+        var tooltipLabels = [];
+
+        for (var i = 0; i < data.timeline.length; i++) {
+            var entry = data.timeline[i];
+            var d = new Date(entry.timestamp);
+            labels.push(d);
+            scores.push(entry.cumulative);
+            tooltipLabels.push(entry.label + (entry.points ? ' (+' + entry.points + ')' : ''));
+        }
+
+        new Chart(canvas, {
+            type: 'line',
+            data: {
+                labels: labels,
+                datasets: [{
+                    label: 'Score',
+                    data: scores,
+                    borderColor: '#128df3',
+                    backgroundColor: 'rgba(18, 141, 243, 0.1)',
+                    fill: true,
+                    stepped: 'before',
+                    pointRadius: 3,
+                    pointBackgroundColor: '#128df3',
+                    borderWidth: 2
+                }]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                scales: {
+                    x: {
+                        type: 'time',
+                        time: {
+                            tooltipFormat: 'MMM d, HH:mm',
+                            displayFormats: { hour: 'HH:mm', day: 'MMM d' }
+                        },
+                        ticks: { color: '#b8b8b8' },
+                        grid: { color: 'rgba(255,255,255,0.1)' }
+                    },
+                    y: {
+                        beginAtZero: true,
+                        ticks: { color: '#b8b8b8', precision: 0 },
+                        grid: { color: 'rgba(255,255,255,0.1)' }
+                    }
+                },
+                plugins: {
+                    legend: { display: false },
+                    tooltip: {
+                        callbacks: {
+                            afterLabel: function(context) {
+                                return tooltipLabels[context.dataIndex];
+                            }
+                        }
+                    }
+                }
+            }
+        });
+    })
+    .catch(function(err) {
+        console.error('Failed to load score timeline:', err);
+    });
+})();
+{% endif %}
 </script>
 {% endblock %}

--- a/shifter/shifter_platform/templates/ctf/participant/scoreboard.html
+++ b/shifter/shifter_platform/templates/ctf/participant/scoreboard.html
@@ -1,4 +1,5 @@
 {% extends "ctf/base.html" %}
+{% load static %}
 {% block ctf_title %}Scoreboard{% endblock %}
 
 {% block ctf_content %}
@@ -81,8 +82,6 @@
 {% endblock %}
 
 {% block extra_js %}
-<script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
-<script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@3"></script>
 <script>
 var autoRefreshInterval = null;
 
@@ -129,7 +128,6 @@ function rebuildScoreboardTable(scoreboard) {
     var participantId = "{{ participant_id }}";
     var teamMode = {{ event.team_mode|yesno:"true,false" }};
 
-    // Clear existing rows safely
     while (tbody.firstChild) {
         tbody.removeChild(tbody.firstChild);
     }
@@ -141,7 +139,6 @@ function rebuildScoreboardTable(scoreboard) {
         var tr = document.createElement('tr');
         if (isCurrentUser) tr.className = 'table-active';
 
-        // Rank cell
         var tdRank = document.createElement('td');
         if (entry.rank <= 3) {
             var strong = document.createElement('strong');
@@ -152,7 +149,6 @@ function rebuildScoreboardTable(scoreboard) {
         }
         tr.appendChild(tdRank);
 
-        // Name cell
         var tdName = document.createElement('td');
         var nameStrong = document.createElement('strong');
         nameStrong.textContent = entry.name;
@@ -165,26 +161,22 @@ function rebuildScoreboardTable(scoreboard) {
         }
         tr.appendChild(tdName);
 
-        // Team cell (if team mode)
         if (teamMode) {
             var tdTeam = document.createElement('td');
             tdTeam.textContent = entry.team_name || '-';
             tr.appendChild(tdTeam);
         }
 
-        // Score cell
         var tdScore = document.createElement('td');
         var scoreStrong = document.createElement('strong');
         scoreStrong.textContent = entry.score;
         tdScore.appendChild(scoreStrong);
         tr.appendChild(tdScore);
 
-        // Solves cell
         var tdSolves = document.createElement('td');
         tdSolves.textContent = entry.solves;
         tr.appendChild(tdSolves);
 
-        // Last solve cell
         var tdLastSolve = document.createElement('td');
         tdLastSolve.textContent = entry.last_solve || '-';
         tr.appendChild(tdLastSolve);
@@ -192,82 +184,13 @@ function rebuildScoreboardTable(scoreboard) {
         tbody.appendChild(tr);
     }
 }
-
-{% if participant %}
-// Score Timeline Chart
-(function() {
-    var canvas = document.getElementById('score-timeline-chart');
-    if (!canvas) return;
-
-    fetch("{% url 'ctf:api_score_timeline' participant_id=participant.pk %}")
-    .then(function(response) { return response.json(); })
-    .then(function(data) {
-        if (!data.timeline || data.timeline.length === 0) return;
-
-        var labels = [];
-        var scores = [];
-        var tooltipLabels = [];
-
-        for (var i = 0; i < data.timeline.length; i++) {
-            var entry = data.timeline[i];
-            var d = new Date(entry.timestamp);
-            labels.push(d);
-            scores.push(entry.cumulative);
-            tooltipLabels.push(entry.label + (entry.points ? ' (+' + entry.points + ')' : ''));
-        }
-
-        new Chart(canvas, {
-            type: 'line',
-            data: {
-                labels: labels,
-                datasets: [{
-                    label: 'Score',
-                    data: scores,
-                    borderColor: '#128df3',
-                    backgroundColor: 'rgba(18, 141, 243, 0.1)',
-                    fill: true,
-                    stepped: 'before',
-                    pointRadius: 3,
-                    pointBackgroundColor: '#128df3',
-                    borderWidth: 2
-                }]
-            },
-            options: {
-                responsive: true,
-                maintainAspectRatio: false,
-                scales: {
-                    x: {
-                        type: 'time',
-                        time: {
-                            tooltipFormat: 'MMM d, HH:mm',
-                            displayFormats: { hour: 'HH:mm', day: 'MMM d' }
-                        },
-                        ticks: { color: '#b8b8b8' },
-                        grid: { color: 'rgba(255,255,255,0.1)' }
-                    },
-                    y: {
-                        beginAtZero: true,
-                        ticks: { color: '#b8b8b8', precision: 0 },
-                        grid: { color: 'rgba(255,255,255,0.1)' }
-                    }
-                },
-                plugins: {
-                    legend: { display: false },
-                    tooltip: {
-                        callbacks: {
-                            afterLabel: function(context) {
-                                return tooltipLabels[context.dataIndex];
-                            }
-                        }
-                    }
-                }
-            }
-        });
-    })
-    .catch(function(err) {
-        console.error('Failed to load score timeline:', err);
-    });
-})();
-{% endif %}
 </script>
+{% if participant %}
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1/dist/chart.umd.min.js" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@3.0.0/dist/chartjs-adapter-date-fns.bundle.min.js" integrity="sha384-cVMg8E3QFwTvGCDuK+ET4PD341jF3W8nO1auiXfuZNQkzbUUiBGLsIQUE+b1mxws" crossorigin="anonymous"></script>
+<script src="{% static 'js/score-timeline.js' %}"></script>
+<script>
+initScoreTimeline('score-timeline-chart', "{% url 'ctf:api_score_timeline' participant_id=participant.pk %}");
+</script>
+{% endif %}
 {% endblock %}

--- a/shifter/shifter_platform/tests/ctf/test_scoring.py
+++ b/shifter/shifter_platform/tests/ctf/test_scoring.py
@@ -760,3 +760,193 @@ class TestCalculatePointsWithPenalty:
         """Penalties over 100% are capped — still awards 1 point."""
         challenge = self._make_challenge(points=100)
         assert challenge.calculate_points_with_penalty(150) == 1
+
+
+# -----------------------------------------------------------------------------
+# get_score_timeline
+# -----------------------------------------------------------------------------
+
+
+class TestGetScoreTimeline:
+    """Tests for get_score_timeline().
+
+    Verifies the chronological score progression (submissions + awards)
+    with cumulative totals for a single participant.
+    """
+
+    @pytest.fixture
+    def mock_models(self):
+        """Patch all ORM objects used by get_score_timeline."""
+        with (
+            patch("ctf.services.scoring.CTFParticipant.objects") as mock_part,
+            patch("ctf.services.scoring.CTFSubmission.objects") as mock_sub,
+            patch("ctf.services.scoring.CTFAward.objects") as mock_award,
+        ):
+            yield mock_part, mock_sub, mock_award
+
+    def _setup(self, mock_models, submissions=None, awards=None):
+        """Configure mocks for a standard timeline query.
+
+        Args:
+            mock_models: Tuple of (participant, submission, award) mocks.
+            submissions: List of (submitted_at, points_awarded, challenge_name) tuples.
+            awards: List of (created_at, points, reason) tuples.
+
+        Returns:
+            UUID used as participant_id.
+        """
+        mock_part, mock_sub, mock_award = mock_models
+        pid = uuid4()
+
+        # Mock participant lookup
+        participant = MagicMock()
+        participant.event.event_start = _NOW - timedelta(hours=8)
+        mock_part.select_related.return_value.get.return_value = participant
+
+        # Mock submissions query chain
+        sub_data = [
+            {"submitted_at": s[0], "points_awarded": s[1], "challenge__name": s[2]} for s in (submissions or [])
+        ]
+        mock_sub.filter.return_value.values.return_value.order_by.return_value = sub_data
+
+        # Mock awards query chain
+        award_data = [{"created_at": a[0], "points": a[1], "reason": a[2]} for a in (awards or [])]
+        mock_award.filter.return_value.values.return_value.order_by.return_value = award_data
+
+        return pid
+
+    def test_timeline_correct_submissions_ordered(self, mock_models):
+        """Two solves produce correct cumulative sequence."""
+        from ctf.services.scoring import get_score_timeline
+
+        t1 = _NOW - timedelta(hours=6)
+        t2 = _NOW - timedelta(hours=4)
+        pid = self._setup(
+            mock_models,
+            submissions=[
+                (t1, 100, "Web 101"),
+                (t2, 200, "Crypto 201"),
+            ],
+        )
+
+        timeline = get_score_timeline(pid)
+
+        assert len(timeline) == 3  # origin + 2 solves
+        assert timeline[0]["cumulative"] == 0
+        assert timeline[0]["type"] == "start"
+        assert timeline[1]["cumulative"] == 100
+        assert timeline[1]["type"] == "solve"
+        assert timeline[2]["cumulative"] == 300
+        assert timeline[2]["type"] == "solve"
+
+    def test_timeline_includes_awards(self, mock_models):
+        """Solve + award are merged and sorted by timestamp."""
+        from ctf.services.scoring import get_score_timeline
+
+        t1 = _NOW - timedelta(hours=6)
+        t2 = _NOW - timedelta(hours=5)
+        pid = self._setup(
+            mock_models,
+            submissions=[(t1, 100, "Web 101")],
+            awards=[(t2, 50, "Bonus for style")],
+        )
+
+        timeline = get_score_timeline(pid)
+
+        assert len(timeline) == 3
+        assert timeline[1]["type"] == "solve"
+        assert timeline[1]["cumulative"] == 100
+        assert timeline[2]["type"] == "award"
+        assert timeline[2]["cumulative"] == 150
+
+    def test_timeline_negative_award(self, mock_models):
+        """Penalty (negative award) reduces cumulative score."""
+        from ctf.services.scoring import get_score_timeline
+
+        t1 = _NOW - timedelta(hours=6)
+        t2 = _NOW - timedelta(hours=5)
+        pid = self._setup(
+            mock_models,
+            submissions=[(t1, 200, "Pwn 301")],
+            awards=[(t2, -50, "Penalty")],
+        )
+
+        timeline = get_score_timeline(pid)
+
+        assert timeline[2]["cumulative"] == 150
+        assert timeline[2]["points"] == -50
+
+    def test_timeline_empty_activity(self, mock_models):
+        """No submissions or awards returns only the origin point."""
+        from ctf.services.scoring import get_score_timeline
+
+        pid = self._setup(mock_models)
+
+        timeline = get_score_timeline(pid)
+
+        assert len(timeline) == 1
+        assert timeline[0]["cumulative"] == 0
+        assert timeline[0]["type"] == "start"
+
+    def test_timeline_origin_at_event_start(self, mock_models):
+        """First entry timestamp matches event_start."""
+        from ctf.services.scoring import get_score_timeline
+
+        pid = self._setup(mock_models)
+        expected_start = (_NOW - timedelta(hours=8)).isoformat()
+
+        timeline = get_score_timeline(pid)
+
+        assert timeline[0]["timestamp"] == expected_start
+
+    def test_timeline_excludes_incorrect_submissions(self, mock_models):
+        """Only correct submissions appear — filter is in the query."""
+        from ctf.services.scoring import get_score_timeline
+
+        _mock_part, mock_sub, _mock_award = mock_models
+
+        pid = self._setup(
+            mock_models,
+            submissions=[
+                (_NOW - timedelta(hours=6), 100, "Web 101"),
+            ],
+        )
+
+        get_score_timeline(pid)
+
+        # Verify the filter was called with is_correct=True
+        call_kwargs = mock_sub.filter.call_args[1]
+        assert call_kwargs["is_correct"] is True
+
+    def test_timeline_labels_truncated(self, mock_models):
+        """Labels exceeding 50 characters are truncated."""
+        from ctf.services.scoring import get_score_timeline
+
+        long_name = "A" * 60
+        pid = self._setup(
+            mock_models,
+            submissions=[
+                (_NOW - timedelta(hours=6), 100, long_name),
+            ],
+        )
+
+        timeline = get_score_timeline(pid)
+
+        assert len(timeline[1]["label"]) == 50
+
+    def test_timeline_type_field(self, mock_models):
+        """Solve entries have type 'solve', award entries have type 'award'."""
+        from ctf.services.scoring import get_score_timeline
+
+        t1 = _NOW - timedelta(hours=6)
+        t2 = _NOW - timedelta(hours=5)
+        pid = self._setup(
+            mock_models,
+            submissions=[(t1, 100, "Web")],
+            awards=[(t2, 25, "Bonus")],
+        )
+
+        timeline = get_score_timeline(pid)
+
+        types = [e["type"] for e in timeline]
+        assert types == ["start", "solve", "award"]

--- a/shifter/shifter_platform/tests/ctf/test_scoring.py
+++ b/shifter/shifter_platform/tests/ctf/test_scoring.py
@@ -950,3 +950,27 @@ class TestGetScoreTimeline:
 
         types = [e["type"] for e in timeline]
         assert types == ["start", "solve", "award"]
+
+    def test_timeline_pre_start_awards_folded_into_origin(self, mock_models):
+        """Awards granted before event_start are folded into the origin point."""
+        from ctf.services.scoring import get_score_timeline
+
+        # event_start is _NOW - 8h; award at _NOW - 10h is before start
+        pre_start = _NOW - timedelta(hours=10)
+        post_start = _NOW - timedelta(hours=6)
+        pid = self._setup(
+            mock_models,
+            submissions=[(post_start, 100, "Web 101")],
+            awards=[(pre_start, 50, "Early bonus")],
+        )
+
+        timeline = get_score_timeline(pid)
+
+        # Origin includes the pre-start award
+        assert timeline[0]["type"] == "start"
+        assert timeline[0]["cumulative"] == 50
+        assert timeline[0]["points"] == 50
+        # Post-start solve adds on top
+        assert timeline[1]["cumulative"] == 150
+        # No entry for the pre-start award itself
+        assert len(timeline) == 2


### PR DESCRIPTION
## Summary
- Add `get_score_timeline()` service function that reconstructs cumulative score progression from submissions and awards
- Add `api_score_timeline` API endpoint with role-based access (participants see own, organizers see any in their events)
- Add Chart.js stepped-line chart on participant scoreboard (own timeline) and admin participant detail (any participant)
- 8 new unit tests covering all timeline logic

Closes #919

## Requirement
**CTF-408**: Per-User Score Timeline (Wave 2, COULD)

## Files Changed
- `ctf/services/scoring.py` — new `get_score_timeline()` function
- `ctf/services/__init__.py` — export
- `ctf/views.py` — new `api_score_timeline()` view
- `ctf/urls.py` — new URL pattern
- `templates/ctf/participant/scoreboard.html` — timeline chart for participants
- `templates/ctf/admin/participant_detail.html` — timeline chart for organizers
- `tests/ctf/test_scoring.py` — `TestGetScoreTimeline` (8 tests)
- `CHANGELOG.md` — v3.53.0 entry

## Test plan
- [x] `pytest tests/ctf/test_scoring.py` — 37/37 pass
- [x] Pre-commit hooks pass (ruff, bandit, mypy, architecture checks)
- [x] Traceability links created in Ground Control