### PR TITLE
Fix team scoreboard solve count and participant template (CTF-402)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.53.1] - 2026-04-02
+
+### Fixed
+- Team scoreboard solve count now counts unique challenges solved instead of total submissions (CTF-402)
+- Participant scoreboard template context variable mismatch preventing scoreboard from rendering (CTF-402)
+- Participant scoreboard auto-refresh reading wrong JSON key from API response (CTF-402)
+- Participant scoreboard now displays team-specific columns (Members) when team mode is active (CTF-402)
+
 ## [3.53.0] - 2026-04-02
 
 ### Added

--- a/shifter/shifter_platform/ctf/services/scoring.py
+++ b/shifter/shifter_platform/ctf/services/scoring.py
@@ -149,8 +149,9 @@ def get_team_scoreboard(event_id: UUID, limit: int | None = None) -> list[dict[s
             award_points=Coalesce(Sum("members__awards__points"), 0),
             computed_score=F("submission_score") + F("award_points"),
             solve_count=Count(
-                "members__submissions",
+                "members__submissions__challenge",
                 filter=Q(members__submissions__is_correct=True),
+                distinct=True,
             ),
             computed_member_count=Count("members", distinct=True),
             last_solve_time=Max(

--- a/shifter/shifter_platform/templates/ctf/participant/scoreboard.html
+++ b/shifter/shifter_platform/templates/ctf/participant/scoreboard.html
@@ -25,15 +25,19 @@
 
     <div class="card">
         <div class="card-body p-0">
-            {% if scoreboard %}
+            {% if rankings %}
             <div class="table-responsive">
                 <table class="table table-hover mb-0" id="scoreboard-table">
                     <thead>
                         <tr>
                             <th>Rank</th>
                             <th>Name</th>
+                            {% if team_mode %}
+                            <th>Members</th>
+                            {% else %}
                             {% if event.team_mode %}
                             <th>Team</th>
+                            {% endif %}
                             {% endif %}
                             <th>Score</th>
                             <th>Solves</th>
@@ -41,8 +45,8 @@
                         </tr>
                     </thead>
                     <tbody id="scoreboard-body">
-                        {% for entry in scoreboard %}
-                        <tr {% if entry.participant_id == participant_id %}class="table-active"{% endif %}>
+                        {% for entry in rankings %}
+                        <tr {% if not team_mode and entry.participant_id == participant_id %}class="table-active"{% endif %}>
                             <td>
                                 {% if entry.rank == 1 %}
                                 <strong>1</strong>
@@ -56,15 +60,19 @@
                             </td>
                             <td>
                                 <strong>{{ entry.name }}</strong>
-                                {% if entry.participant_id == participant_id %}
+                                {% if not team_mode and entry.participant_id == participant_id %}
                                 <span class="badge bg-primary ms-1">You</span>
                                 {% endif %}
                             </td>
+                            {% if team_mode %}
+                            <td>{{ entry.member_count }}</td>
+                            {% else %}
                             {% if event.team_mode %}
                             <td>{{ entry.team_name|default:"-" }}</td>
                             {% endif %}
+                            {% endif %}
                             <td><strong>{{ entry.score }}</strong></td>
-                            <td>{{ entry.solves }}</td>
+                            <td>{{ entry.solve_count }}</td>
                             <td>{{ entry.last_solve|default:"-" }}</td>
                         </tr>
                         {% endfor %}
@@ -112,8 +120,8 @@ function fetchScoreboard() {
     fetch("{% url 'ctf:api_scoreboard' event_id=event.pk %}")
     .then(function(response) { return response.json(); })
     .then(function(data) {
-        if (data.scoreboard) {
-            rebuildScoreboardTable(data.scoreboard);
+        if (data.rankings) {
+            rebuildScoreboardTable(data.rankings, data.team_mode);
         }
     })
     .catch(function(err) {
@@ -121,20 +129,19 @@ function fetchScoreboard() {
     });
 }
 
-function rebuildScoreboardTable(scoreboard) {
+function rebuildScoreboardTable(rankings, teamMode) {
     var tbody = document.getElementById('scoreboard-body');
     if (!tbody) return;
 
     var participantId = "{{ participant_id }}";
-    var teamMode = {{ event.team_mode|yesno:"true,false" }};
 
     while (tbody.firstChild) {
         tbody.removeChild(tbody.firstChild);
     }
 
-    for (var i = 0; i < scoreboard.length; i++) {
-        var entry = scoreboard[i];
-        var isCurrentUser = (String(entry.participant_id) === String(participantId));
+    for (var i = 0; i < rankings.length; i++) {
+        var entry = rankings[i];
+        var isCurrentUser = !teamMode && (String(entry.participant_id) === String(participantId));
 
         var tr = document.createElement('tr');
         if (isCurrentUser) tr.className = 'table-active';
@@ -162,9 +169,9 @@ function rebuildScoreboardTable(scoreboard) {
         tr.appendChild(tdName);
 
         if (teamMode) {
-            var tdTeam = document.createElement('td');
-            tdTeam.textContent = entry.team_name || '-';
-            tr.appendChild(tdTeam);
+            var tdMembers = document.createElement('td');
+            tdMembers.textContent = entry.member_count;
+            tr.appendChild(tdMembers);
         }
 
         var tdScore = document.createElement('td');
@@ -174,7 +181,7 @@ function rebuildScoreboardTable(scoreboard) {
         tr.appendChild(tdScore);
 
         var tdSolves = document.createElement('td');
-        tdSolves.textContent = entry.solves;
+        tdSolves.textContent = entry.solve_count;
         tr.appendChild(tdSolves);
 
         var tdLastSolve = document.createElement('td');

--- a/shifter/shifter_platform/tests/ctf/test_scoring.py
+++ b/shifter/shifter_platform/tests/ctf/test_scoring.py
@@ -318,6 +318,22 @@ class TestGetTeamScoreboard:
         for entry in board:
             assert entry["score"] == 0
 
+    def test_team_solve_count_is_unique_challenges(self, mock_team_objects, mock_queryset):
+        """solve_count should reflect unique challenges solved, not total submissions."""
+        # Mock team where 3 members solved 2 unique challenges (some overlap)
+        t_alpha = _make_team(
+            "Alpha",
+            computed_score=300,
+            solve_count=2,  # 2 unique challenges
+            computed_member_count=3,
+            last_solve_time=_NOW,
+        )
+
+        self._wire_qs(mock_team_objects, mock_queryset, [t_alpha])
+
+        board = get_team_scoreboard(uuid4())
+        assert board[0]["solve_count"] == 2
+
 
 # -----------------------------------------------------------------------------
 # get_participant_rank tests


### PR DESCRIPTION
## Summary
- Fix `get_team_scoreboard` to count **unique challenges solved** (`distinct=True`) instead of total correct submissions
- Fix participant scoreboard template context variable mismatch (`rankings` vs `scoreboard`) that prevented the table from rendering
- Fix participant scoreboard JS auto-refresh to read correct API response key
- Add team-mode-specific columns (Members instead of Team) to participant scoreboard
- Fix field name mismatches (`solve_count` not `solves`) in template and JS

Closes #921

## Test plan
- [x] `pytest tests/ctf/test_scoring.py` — 39 passed
- [x] Pre-commit hooks pass (ruff, eslint, bandit, mypy, architecture checks)
- [ ] Manual: verify participant scoreboard renders in team mode
- [ ] Manual: verify auto-refresh works with correct field names