### PR TITLE
Add scoreboard visibility toggle (CTF-004)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.56.0] - 2026-04-04
+
+### Added
+- Scoreboard visibility toggle: organizers can hide the scoreboard from participants until ready (CTF-004)
+- `scoreboard_visible` boolean field on CTFEvent model (default True)
+- Participant scoreboard view and API return hidden state when scoreboard is not visible
+- Admin scoreboard shows banner when scoreboard is hidden from participants
+- Scoreboard visibility checkbox in event create/edit form
+
 ## [3.55.0] - 2026-04-02
 
 ### Added

--- a/shifter/shifter_platform/ctf/forms.py
+++ b/shifter/shifter_platform/ctf/forms.py
@@ -65,6 +65,7 @@ class CTFEventForm(forms.ModelForm):
             "attempt_limit_mode",
             "attempt_limit_cooldown_seconds",
             "rating_visibility",
+            "scoreboard_visible",
             "scoreboard_freeze_at",
         ]
         widgets = {

--- a/shifter/shifter_platform/ctf/migrations/0021_add_scoreboard_visible.py
+++ b/shifter/shifter_platform/ctf/migrations/0021_add_scoreboard_visible.py
@@ -1,0 +1,20 @@
+"""Add scoreboard_visible field to CTFEvent."""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("ctf", "0020_add_brackets"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="ctfevent",
+            name="scoreboard_visible",
+            field=models.BooleanField(
+                default=True,
+                help_text="Whether the scoreboard is visible to participants. When False, participants see a hidden message.",
+            ),
+        ),
+    ]

--- a/shifter/shifter_platform/ctf/models.py
+++ b/shifter/shifter_platform/ctf/models.py
@@ -321,6 +321,10 @@ class CTFEvent(CTFBaseModel):
         default=RatingVisibility.PUBLIC.value,
         help_text="Challenge rating visibility: public, organizer-only, or disabled",
     )
+    scoreboard_visible = models.BooleanField(
+        default=True,
+        help_text="Whether the scoreboard is visible to participants. When False, participants see a hidden message.",
+    )
     scoreboard_freeze_at = models.DateTimeField(
         null=True,
         blank=True,

--- a/shifter/shifter_platform/ctf/services/event.py
+++ b/shifter/shifter_platform/ctf/services/event.py
@@ -43,6 +43,7 @@ _EVENT_MUTABLE_FIELDS = frozenset(
         "attempt_limit_mode",
         "attempt_limit_cooldown_seconds",
         "rating_visibility",
+        "scoreboard_visible",
         "scoreboard_freeze_at",
     }
 )

--- a/shifter/shifter_platform/ctf/views.py
+++ b/shifter/shifter_platform/ctf/views.py
@@ -528,6 +528,15 @@ def scoreboard(request: HttpRequest) -> HttpResponse:
         return render(request, "ctf/participant/scoreboard.html", {})
 
     event = participant.event
+
+    # If organizer has hidden the scoreboard, show a hidden message
+    if not event.scoreboard_visible:
+        return render(
+            request,
+            "ctf/participant/scoreboard.html",
+            {"participant": participant, "event": event, "scoreboard_hidden": True},
+        )
+
     freeze_at = event.scoreboard_freeze_at if event.is_scoreboard_frozen else None
     brackets, selected_bracket, bracket_id = _resolve_bracket_filter(event.id, request.GET.get("bracket"))
 
@@ -2019,6 +2028,7 @@ def api_event_detail(request: HttpRequest, event_id: UUID) -> JsonResponse:
                 "attempt_limit_mode": event.attempt_limit_mode,
                 "attempt_limit_cooldown_seconds": event.attempt_limit_cooldown_seconds,
                 "rating_visibility": event.rating_visibility,
+                "scoreboard_visible": event.scoreboard_visible,
                 "scoreboard_freeze_at": event.scoreboard_freeze_at.isoformat() if event.scoreboard_freeze_at else None,
             }
         )
@@ -2684,6 +2694,11 @@ def api_scoreboard(request: HttpRequest, event_id: UUID) -> JsonResponse:
 
     # Organizers see real-time scores; participants see frozen scores
     is_organizer = event.created_by_id == request.user.pk
+
+    # If scoreboard is hidden from participants, return early
+    if not is_organizer and not event.scoreboard_visible:
+        return JsonResponse({"scoreboard_hidden": True})
+
     freeze_at = None
     if not is_organizer and event.is_scoreboard_frozen:
         freeze_at = event.scoreboard_freeze_at

--- a/shifter/shifter_platform/templates/ctf/admin/event_form.html
+++ b/shifter/shifter_platform/templates/ctf/admin/event_form.html
@@ -121,11 +121,23 @@ input[type="datetime-local"] {
             <div class="field-error" id="error-registration_deadline"></div>
         </div>
 
-        <div class="form-group">
-            <label class="form-label" for="field-scoreboard_freeze_at">Scoreboard Freeze Time</label>
-            <input type="datetime-local" id="field-scoreboard_freeze_at" class="form-input">
-            <div class="form-help">Optional. Scoreboard freezes at this time. Participants see frozen standings; organizers see real-time.</div>
-            <div class="field-error" id="error-scoreboard_freeze_at"></div>
+        <div class="form-row">
+            <div class="form-group">
+                <label class="form-checkbox">
+                    <input type="checkbox" id="field-scoreboard_visible" checked>
+                    <div>
+                        <span class="form-checkbox-label">Scoreboard Visible</span>
+                        <div class="form-checkbox-help">When unchecked, participants cannot see the scoreboard</div>
+                    </div>
+                </label>
+            </div>
+
+            <div class="form-group">
+                <label class="form-label" for="field-scoreboard_freeze_at">Scoreboard Freeze Time</label>
+                <input type="datetime-local" id="field-scoreboard_freeze_at" class="form-input">
+                <div class="form-help">Optional. Scoreboard freezes at this time. Participants see frozen standings; organizers see real-time.</div>
+                <div class="field-error" id="error-scoreboard_freeze_at"></div>
+            </div>
         </div>
     </div>
 
@@ -292,7 +304,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     var FIELDS = [
         'name', 'description', 'event_start', 'event_end',
-        'registration_deadline', 'scoreboard_freeze_at', 'scenario_id',
+        'registration_deadline', 'scoreboard_visible', 'scoreboard_freeze_at', 'scenario_id',
         'range_spinup_minutes', 'auto_cleanup', 'ngfw_enabled',
         'cleanup_delay_hours', 'max_participants', 'team_mode',
         'team_size_limit', 'submission_cooldown_seconds',
@@ -363,6 +375,7 @@ document.addEventListener('DOMContentLoaded', function() {
             event_start: toISODatetime(getField('event_start').value),
             event_end: toISODatetime(getField('event_end').value),
             auto_cleanup: getField('auto_cleanup').checked,
+            scoreboard_visible: getField('scoreboard_visible').checked,
             team_mode: getField('team_mode').checked,
         };
 
@@ -549,6 +562,7 @@ document.addEventListener('DOMContentLoaded', function() {
             getField('event_start').value = toDatetimeLocal(event.event_start);
             getField('event_end').value = toDatetimeLocal(event.event_end);
             getField('registration_deadline').value = toDatetimeLocal(event.registration_deadline);
+            getField('scoreboard_visible').checked = event.scoreboard_visible !== false;
             getField('scoreboard_freeze_at').value = toDatetimeLocal(event.scoreboard_freeze_at);
             getField('range_spinup_minutes').value = event.range_spinup_minutes || 30;
             getField('auto_cleanup').checked = !!event.auto_cleanup;

--- a/shifter/shifter_platform/templates/ctf/admin/scoreboard.html
+++ b/shifter/shifter_platform/templates/ctf/admin/scoreboard.html
@@ -86,6 +86,12 @@
     <h1 class="page-title">Scoreboard</h1>
 </div>
 
+{% if not event.scoreboard_visible %}
+<div class="card" style="padding: 12px 16px; margin-bottom: 16px; border-left: 3px solid #ff4d4f;">
+    Scoreboard is hidden from participants. They cannot see rankings until you enable visibility in event settings.
+</div>
+{% endif %}
+
 {% if frozen %}
 <div class="card" style="padding: 12px 16px; margin-bottom: 16px; border-left: 3px solid #faad14;">
     Scoreboard is frozen for participants. You are viewing real-time standings.

--- a/shifter/shifter_platform/templates/ctf/participant/scoreboard.html
+++ b/shifter/shifter_platform/templates/ctf/participant/scoreboard.html
@@ -6,10 +6,21 @@
 <div class="container-fluid py-4">
     <div class="d-flex justify-content-between align-items-center mb-4">
         <h1 class="h3 mb-0">Scoreboard</h1>
+        {% if not scoreboard_hidden %}
         <button type="button" class="btn btn-sm btn-outline-primary" id="refresh-btn" onclick="refreshScoreboard()">
             Auto-Refresh: Off
         </button>
+        {% endif %}
     </div>
+
+    {% if scoreboard_hidden %}
+    <div class="card">
+        <div class="card-body text-center py-5">
+            <h5 class="text-muted mb-2">Scoreboard Hidden</h5>
+            <p class="text-muted mb-0">The scoreboard is not yet available. The organizer will make it visible when ready.</p>
+        </div>
+    </div>
+    {% else %}
 
     {% if frozen %}
     <div class="alert alert-info mb-4" id="freeze-banner">
@@ -103,6 +114,8 @@
             {% endif %}
         </div>
     </div>
+
+    {% endif %}{# end scoreboard_hidden #}
 </div>
 {% endblock %}
 

--- a/shifter/shifter_platform/templates/ctf/participant/scoreboard.html
+++ b/shifter/shifter_platform/templates/ctf/participant/scoreboard.html
@@ -154,6 +154,35 @@ function fetchScoreboard() {
     fetch(url)
     .then(function(response) { return response.json(); })
     .then(function(data) {
+        if (data.scoreboard_hidden) {
+            // Organizer hid the scoreboard mid-event — stop polling and show message
+            if (autoRefreshInterval) { clearInterval(autoRefreshInterval); autoRefreshInterval = null; }
+            var tbody = document.getElementById('scoreboard-body');
+            if (tbody) { while (tbody.firstChild) { tbody.removeChild(tbody.firstChild); } }
+            var table = document.getElementById('scoreboard-table');
+            if (table) { table.style.display = 'none'; }
+            var container = document.querySelector('.container-fluid');
+            if (!document.getElementById('hidden-banner')) {
+                var hiddenDiv = document.createElement('div');
+                hiddenDiv.id = 'hidden-banner';
+                hiddenDiv.className = 'card';
+                var body = document.createElement('div');
+                body.className = 'card-body text-center py-5';
+                var h5 = document.createElement('h5');
+                h5.className = 'text-muted mb-2';
+                h5.textContent = 'Scoreboard Hidden';
+                var p = document.createElement('p');
+                p.className = 'text-muted mb-0';
+                p.textContent = 'The scoreboard is not yet available. The organizer will make it visible when ready.';
+                body.appendChild(h5);
+                body.appendChild(p);
+                hiddenDiv.appendChild(body);
+                container.appendChild(hiddenDiv);
+            }
+            var btn = document.getElementById('refresh-btn');
+            if (btn) btn.style.display = 'none';
+            return;
+        }
         if (data.rankings) {
             rebuildScoreboardTable(data.rankings, data.team_mode);
         }

--- a/shifter/shifter_platform/tests/ctf/test_scoring.py
+++ b/shifter/shifter_platform/tests/ctf/test_scoring.py
@@ -1088,3 +1088,38 @@ class TestIsScoreboardFrozen:
             status="active",
         )
         assert event.is_scoreboard_frozen is False
+
+
+class TestScoreboardVisibility:
+    """Tests for CTFEvent.scoreboard_visible field behaviour."""
+
+    def _make_event(self, scoreboard_visible=True):
+        """Create a mock event with visibility configuration."""
+        from ctf.models import CTFEvent
+
+        event = MagicMock(spec=CTFEvent)
+        event.scoreboard_visible = scoreboard_visible
+        return event
+
+    def test_scoreboard_visible_by_default(self):
+        """scoreboard_visible defaults to True."""
+        from ctf.models import CTFEvent
+
+        field = CTFEvent._meta.get_field("scoreboard_visible")
+        assert field.default is True
+
+    def test_scoreboard_hidden_when_not_visible(self):
+        """Event with scoreboard_visible=False reports hidden."""
+        event = self._make_event(scoreboard_visible=False)
+        assert event.scoreboard_visible is False
+
+    def test_scoreboard_shown_when_visible(self):
+        """Event with scoreboard_visible=True reports visible."""
+        event = self._make_event(scoreboard_visible=True)
+        assert event.scoreboard_visible is True
+
+    def test_scoreboard_visible_in_mutable_fields(self):
+        """scoreboard_visible is in the event mutable fields whitelist."""
+        from ctf.services.event import _EVENT_MUTABLE_FIELDS
+
+        assert "scoreboard_visible" in _EVENT_MUTABLE_FIELDS


### PR DESCRIPTION
## Summary
- Adds `scoreboard_visible` boolean field to CTFEvent (default `True`) allowing organizers to hide the entire scoreboard from participants
- Participant scoreboard view and API return a "hidden" state when disabled; admin view always shows real-time data with a status banner
- Checkbox added to event create/edit form in the Schedule section
- Completes requirement CTF-004: Scoreboard & Rankings

Closes #927

## Test plan
- [ ] Verify new migration applies cleanly
- [ ] Create event with scoreboard_visible unchecked → confirm participants see "Scoreboard Hidden" message
- [ ] Toggle scoreboard_visible on → confirm participants see normal scoreboard
- [ ] Confirm admin scoreboard always shows rankings regardless of visibility setting
- [ ] Confirm API endpoint returns `{"scoreboard_hidden": true}` for participants when hidden
- [ ] Confirm all 2578 tests pass (verified locally)