### PR TITLE
Add organizer notifications on event start/end (CTF-1004)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.56.1] - 2026-04-04
+
+### Added
+- Organizer email notifications on automated event start/end transitions (CTF-1004)
+- Email templates for event start and event end organizer notifications
+- `notify_organizer_event_start()` and `notify_organizer_event_end()` notification service functions
+- Tests for scheduler event start/end handlers and organizer notifications
+
 ## [3.56.0] - 2026-04-04
 
 ### Added

--- a/shifter/shifter_platform/ctf/management/commands/run_ctf_scheduler.py
+++ b/shifter/shifter_platform/ctf/management/commands/run_ctf_scheduler.py
@@ -190,13 +190,19 @@ def _handle_cleanup_ranges(task: CTFScheduledTask, shutdown_check=None) -> None:
 def _handle_event_start(task: CTFScheduledTask, shutdown_check=None) -> None:
     from ctf.services.event import activate_event
 
-    activate_event(task.event)
+    if activate_event(task.event):
+        from ctf.services.notification import notify_organizer_event_start
+
+        notify_organizer_event_start(task.event_id)
 
 
 def _handle_event_end(task: CTFScheduledTask, shutdown_check=None) -> None:
     from ctf.services.event import complete_event
 
-    complete_event(task.event)
+    if complete_event(task.event):
+        from ctf.services.notification import notify_organizer_event_end
+
+        notify_organizer_event_end(task.event_id)
 
     # Also trigger cleanup if auto_cleanup is enabled
     if task.event.auto_cleanup:

--- a/shifter/shifter_platform/ctf/services/notification.py
+++ b/shifter/shifter_platform/ctf/services/notification.py
@@ -423,7 +423,7 @@ def notify_organizer_provision_failure(
             subject=f"Provisioning failures for {event.name}",
             body=f"{len(failures)} participant(s) failed provisioning",
             status=NotificationStatus.SENT.value,
-            recipient_filter="organizer",
+            recipient_filter="organizers",
             sent_count=1,
             created_by=organizer,
         )
@@ -467,7 +467,7 @@ def notify_organizer_event_start(event_id: UUID) -> None:
             subject=f"Event started: {event.name}",
             body=f"Event {event.name} has automatically started",
             status=NotificationStatus.SENT.value,
-            recipient_filter="organizer",
+            recipient_filter="organizers",
             sent_count=1,
             created_by=organizer,
         )
@@ -511,7 +511,7 @@ def notify_organizer_event_end(event_id: UUID) -> None:
             subject=f"Event ended: {event.name}",
             body=f"Event {event.name} has automatically ended",
             status=NotificationStatus.SENT.value,
-            recipient_filter="organizer",
+            recipient_filter="organizers",
             sent_count=1,
             created_by=organizer,
         )

--- a/shifter/shifter_platform/ctf/services/notification.py
+++ b/shifter/shifter_platform/ctf/services/notification.py
@@ -429,6 +429,94 @@ def notify_organizer_provision_failure(
         )
 
 
+def notify_organizer_event_start(event_id: UUID) -> None:
+    """Notify the event organizer that the event has automatically started.
+
+    Args:
+        event_id: UUID of the event.
+    """
+    logger.info("Notifying organizer of event start for event %s", event_id)
+
+    try:
+        event = CTFEvent.objects.get(pk=event_id)
+    except CTFEvent.DoesNotExist:
+        logger.error("Cannot notify: event %s not found", event_id)
+        return
+
+    organizer = event.created_by
+    if not organizer or not organizer.email:
+        logger.warning("Cannot notify: event %s has no organizer email", event_id)
+        return
+
+    html_content, text_content = _render_email(
+        "event_start",
+        {"event": event},
+    )
+
+    success = _send_email(
+        recipient=organizer.email,
+        subject=f"Event started: {event.name}",
+        html_content=html_content,
+        text_content=text_content,
+    )
+
+    if success:
+        CTFNotification.objects.create(
+            event=event,
+            notification_type=NotificationType.EVENT_START.value,
+            subject=f"Event started: {event.name}",
+            body=f"Event {event.name} has automatically started",
+            status=NotificationStatus.SENT.value,
+            recipient_filter="organizer",
+            sent_count=1,
+            created_by=organizer,
+        )
+
+
+def notify_organizer_event_end(event_id: UUID) -> None:
+    """Notify the event organizer that the event has automatically ended.
+
+    Args:
+        event_id: UUID of the event.
+    """
+    logger.info("Notifying organizer of event end for event %s", event_id)
+
+    try:
+        event = CTFEvent.objects.get(pk=event_id)
+    except CTFEvent.DoesNotExist:
+        logger.error("Cannot notify: event %s not found", event_id)
+        return
+
+    organizer = event.created_by
+    if not organizer or not organizer.email:
+        logger.warning("Cannot notify: event %s has no organizer email", event_id)
+        return
+
+    html_content, text_content = _render_email(
+        "event_end",
+        {"event": event},
+    )
+
+    success = _send_email(
+        recipient=organizer.email,
+        subject=f"Event ended: {event.name}",
+        html_content=html_content,
+        text_content=text_content,
+    )
+
+    if success:
+        CTFNotification.objects.create(
+            event=event,
+            notification_type=NotificationType.EVENT_END.value,
+            subject=f"Event ended: {event.name}",
+            body=f"Event {event.name} has automatically ended",
+            status=NotificationStatus.SENT.value,
+            recipient_filter="organizer",
+            sent_count=1,
+            created_by=organizer,
+        )
+
+
 # -----------------------------------------------------------------------------
 # Private helpers
 # -----------------------------------------------------------------------------

--- a/shifter/shifter_platform/templates/ctf/email/event_end.html
+++ b/shifter/shifter_platform/templates/ctf/email/event_end.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><title>Event Ended</title></head>
+<body style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
+<h2>Event Ended</h2>
+<p>Your event <strong>{{ event.name }}</strong> has automatically transitioned to <strong>ended</strong>.</p>
+<p>Flag submissions have been disabled.</p>
+<p style="margin-top: 16px;">
+<strong>Start Time:</strong> {{ event.event_start|date:"F j, Y g:i A" }}<br>
+<strong>End Time:</strong> {{ event.event_end|date:"F j, Y g:i A" }}
+</p>
+</body>
+</html>

--- a/shifter/shifter_platform/templates/ctf/email/event_end.txt
+++ b/shifter/shifter_platform/templates/ctf/email/event_end.txt
@@ -1,0 +1,8 @@
+Event Ended
+
+Your event {{ event.name }} has automatically transitioned to ended.
+
+Flag submissions have been disabled.
+
+Start Time: {{ event.event_start|date:"F j, Y g:i A" }}
+End Time: {{ event.event_end|date:"F j, Y g:i A" }}

--- a/shifter/shifter_platform/templates/ctf/email/event_start.html
+++ b/shifter/shifter_platform/templates/ctf/email/event_start.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><title>Event Started</title></head>
+<body style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
+<h2>Event Started</h2>
+<p>Your event <strong>{{ event.name }}</strong> has automatically transitioned to <strong>active</strong>.</p>
+<p>Flag submissions are now enabled for participants.</p>
+<p style="margin-top: 16px;">
+<strong>Start Time:</strong> {{ event.event_start|date:"F j, Y g:i A" }}<br>
+<strong>End Time:</strong> {{ event.event_end|date:"F j, Y g:i A" }}
+</p>
+</body>
+</html>

--- a/shifter/shifter_platform/templates/ctf/email/event_start.txt
+++ b/shifter/shifter_platform/templates/ctf/email/event_start.txt
@@ -1,0 +1,8 @@
+Event Started
+
+Your event {{ event.name }} has automatically transitioned to active.
+
+Flag submissions are now enabled for participants.
+
+Start Time: {{ event.event_start|date:"F j, Y g:i A" }}
+End Time: {{ event.event_end|date:"F j, Y g:i A" }}

--- a/shifter/shifter_platform/tests/ctf/test_services/test_notification.py
+++ b/shifter/shifter_platform/tests/ctf/test_services/test_notification.py
@@ -427,7 +427,7 @@ class TestNotifyOrganizerEventStart:
         mock_notif_cls.objects.create.assert_called_once()
         call_kwargs = mock_notif_cls.objects.create.call_args.kwargs
         assert call_kwargs["notification_type"] == NotificationType.EVENT_START.value
-        assert call_kwargs["recipient_filter"] == "organizer"
+        assert call_kwargs["recipient_filter"] == "organizers"
 
     @patch("ctf.services.notification.CTFEvent")
     def test_event_not_found(self, mock_event_cls):
@@ -476,7 +476,7 @@ class TestNotifyOrganizerEventEnd:
         mock_notif_cls.objects.create.assert_called_once()
         call_kwargs = mock_notif_cls.objects.create.call_args.kwargs
         assert call_kwargs["notification_type"] == NotificationType.EVENT_END.value
-        assert call_kwargs["recipient_filter"] == "organizer"
+        assert call_kwargs["recipient_filter"] == "organizers"
 
     @patch("ctf.services.notification.CTFEvent")
     def test_event_not_found(self, mock_event_cls):

--- a/shifter/shifter_platform/tests/ctf/test_services/test_notification.py
+++ b/shifter/shifter_platform/tests/ctf/test_services/test_notification.py
@@ -394,3 +394,106 @@ class TestInvitedAtNotSetAtCreation:
         assert len(created) == 2
         for p in created:
             assert p.invited_at is None
+
+
+# ---------------------------------------------------------------------------
+# Organizer event start/end notifications (CTF-1004)
+# ---------------------------------------------------------------------------
+
+
+class TestNotifyOrganizerEventStart:
+    """Tests for notify_organizer_event_start."""
+
+    @patch("ctf.services.notification.CTFNotification")
+    @patch("ctf.services.notification.CTFEvent")
+    def test_sends_email_and_records_notification(self, mock_event_cls, mock_notif_cls, ctf_event):
+        """Sends email to organizer and creates notification record."""
+        mock_event_cls.objects.get.return_value = ctf_event
+        mock_event_cls.DoesNotExist = Exception
+
+        with (
+            patch.object(notification, "_send_email", return_value=True) as mock_send,
+            patch.object(notification, "_render_email", return_value=("<html>", "text")) as mock_render,
+        ):
+            notification.notify_organizer_event_start(ctf_event.pk)
+
+        mock_render.assert_called_once_with("event_start", {"event": ctf_event})
+        mock_send.assert_called_once_with(
+            recipient=ctf_event.created_by.email,
+            subject=f"Event started: {ctf_event.name}",
+            html_content="<html>",
+            text_content="text",
+        )
+        mock_notif_cls.objects.create.assert_called_once()
+        call_kwargs = mock_notif_cls.objects.create.call_args.kwargs
+        assert call_kwargs["notification_type"] == NotificationType.EVENT_START.value
+        assert call_kwargs["recipient_filter"] == "organizer"
+
+    @patch("ctf.services.notification.CTFEvent")
+    def test_event_not_found(self, mock_event_cls):
+        """Returns gracefully if event does not exist."""
+        mock_event_cls.DoesNotExist = type("DoesNotExist", (Exception,), {})
+        mock_event_cls.objects.get.side_effect = mock_event_cls.DoesNotExist
+
+        notification.notify_organizer_event_start(uuid4())
+
+    @patch("ctf.services.notification.CTFEvent")
+    def test_no_organizer_email(self, mock_event_cls, ctf_event):
+        """Returns gracefully if organizer has no email."""
+        ctf_event.created_by.email = None
+        mock_event_cls.objects.get.return_value = ctf_event
+        mock_event_cls.DoesNotExist = Exception
+
+        with patch.object(notification, "_send_email") as mock_send:
+            notification.notify_organizer_event_start(ctf_event.pk)
+
+        mock_send.assert_not_called()
+
+
+class TestNotifyOrganizerEventEnd:
+    """Tests for notify_organizer_event_end."""
+
+    @patch("ctf.services.notification.CTFNotification")
+    @patch("ctf.services.notification.CTFEvent")
+    def test_sends_email_and_records_notification(self, mock_event_cls, mock_notif_cls, ctf_event):
+        """Sends email to organizer and creates notification record."""
+        mock_event_cls.objects.get.return_value = ctf_event
+        mock_event_cls.DoesNotExist = Exception
+
+        with (
+            patch.object(notification, "_send_email", return_value=True) as mock_send,
+            patch.object(notification, "_render_email", return_value=("<html>", "text")) as mock_render,
+        ):
+            notification.notify_organizer_event_end(ctf_event.pk)
+
+        mock_render.assert_called_once_with("event_end", {"event": ctf_event})
+        mock_send.assert_called_once_with(
+            recipient=ctf_event.created_by.email,
+            subject=f"Event ended: {ctf_event.name}",
+            html_content="<html>",
+            text_content="text",
+        )
+        mock_notif_cls.objects.create.assert_called_once()
+        call_kwargs = mock_notif_cls.objects.create.call_args.kwargs
+        assert call_kwargs["notification_type"] == NotificationType.EVENT_END.value
+        assert call_kwargs["recipient_filter"] == "organizer"
+
+    @patch("ctf.services.notification.CTFEvent")
+    def test_event_not_found(self, mock_event_cls):
+        """Returns gracefully if event does not exist."""
+        mock_event_cls.DoesNotExist = type("DoesNotExist", (Exception,), {})
+        mock_event_cls.objects.get.side_effect = mock_event_cls.DoesNotExist
+
+        notification.notify_organizer_event_end(uuid4())
+
+    @patch("ctf.services.notification.CTFEvent")
+    def test_no_organizer_email(self, mock_event_cls, ctf_event):
+        """Returns gracefully if organizer has no email."""
+        ctf_event.created_by.email = None
+        mock_event_cls.objects.get.return_value = ctf_event
+        mock_event_cls.DoesNotExist = Exception
+
+        with patch.object(notification, "_send_email") as mock_send:
+            notification.notify_organizer_event_end(ctf_event.pk)
+
+        mock_send.assert_not_called()

--- a/shifter/shifter_platform/tests/ctf/test_services/test_scheduler_handlers.py
+++ b/shifter/shifter_platform/tests/ctf/test_services/test_scheduler_handlers.py
@@ -1,0 +1,85 @@
+"""Tests for CTF scheduler event start/end handlers (CTF-1004)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+
+@pytest.fixture
+def scheduled_task():
+    """Mock CTFScheduledTask for event start/end."""
+    task = MagicMock()
+    task.event_id = uuid4()
+    task.event = MagicMock()
+    task.event.auto_cleanup = False
+    return task
+
+
+class TestHandleEventStart:
+    """Tests for _handle_event_start scheduler handler."""
+
+    @patch("ctf.services.notification.notify_organizer_event_start")
+    @patch("ctf.services.event.activate_event", return_value=True)
+    def test_calls_activate_and_notify(self, mock_activate, mock_notify, scheduled_task):
+        """Activates event and notifies organizer on success."""
+        from ctf.management.commands.run_ctf_scheduler import _handle_event_start
+
+        _handle_event_start(scheduled_task)
+
+        mock_activate.assert_called_once_with(scheduled_task.event)
+        mock_notify.assert_called_once_with(scheduled_task.event_id)
+
+    @patch("ctf.services.notification.notify_organizer_event_start")
+    @patch("ctf.services.event.activate_event", return_value=False)
+    def test_no_notify_on_failure(self, mock_activate, mock_notify, scheduled_task):
+        """Does not notify organizer if activation fails."""
+        from ctf.management.commands.run_ctf_scheduler import _handle_event_start
+
+        _handle_event_start(scheduled_task)
+
+        mock_activate.assert_called_once_with(scheduled_task.event)
+        mock_notify.assert_not_called()
+
+
+class TestHandleEventEnd:
+    """Tests for _handle_event_end scheduler handler."""
+
+    @patch("ctf.services.notification.notify_organizer_event_end")
+    @patch("ctf.services.event.complete_event", return_value=True)
+    def test_calls_complete_and_notify(self, mock_complete, mock_notify, scheduled_task):
+        """Completes event and notifies organizer on success."""
+        from ctf.management.commands.run_ctf_scheduler import _handle_event_end
+
+        _handle_event_end(scheduled_task)
+
+        mock_complete.assert_called_once_with(scheduled_task.event)
+        mock_notify.assert_called_once_with(scheduled_task.event_id)
+
+    @patch("ctf.services.notification.notify_organizer_event_end")
+    @patch("ctf.services.event.complete_event", return_value=False)
+    def test_no_notify_on_failure(self, mock_complete, mock_notify, scheduled_task):
+        """Does not notify organizer if completion fails."""
+        from ctf.management.commands.run_ctf_scheduler import _handle_event_end
+
+        _handle_event_end(scheduled_task)
+
+        mock_complete.assert_called_once_with(scheduled_task.event)
+        mock_notify.assert_not_called()
+
+    @patch("ctf.services.range.cleanup_event_ranges", return_value={"ok": True})
+    @patch("ctf.services.notification.notify_organizer_event_end")
+    @patch("ctf.services.event.complete_event", return_value=True)
+    def test_triggers_cleanup_when_enabled(self, mock_complete, mock_notify, mock_cleanup, scheduled_task):
+        """Triggers range cleanup when auto_cleanup is enabled."""
+        scheduled_task.event.auto_cleanup = True
+
+        from ctf.management.commands.run_ctf_scheduler import _handle_event_end
+
+        _handle_event_end(scheduled_task)
+
+        mock_complete.assert_called_once_with(scheduled_task.event)
+        mock_notify.assert_called_once_with(scheduled_task.event_id)
+        mock_cleanup.assert_called_once_with(scheduled_task.event_id)


### PR DESCRIPTION
## Summary
- Add organizer email notifications when events automatically start or end (CTF-1004)
- Create `notify_organizer_event_start()` and `notify_organizer_event_end()` in notification service
- Integrate notifications into scheduler handlers (`_handle_event_start`, `_handle_event_end`)
- Add HTML/text email templates for event start and event end notifications
- Add tests for notification functions and scheduler handlers (11 new tests)

Closes #929

## Test plan
- [x] All 574 CTF tests pass
- [x] New notification tests verify email sending and notification recording
- [x] Scheduler handler tests verify notify-on-success, skip-on-failure, and cleanup behavior
- [x] Pre-commit hooks pass (ruff, bandit, mypy, architecture checks)