### PR TITLE
Enforce registration deadline for participant invites (CTF-007)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.56.2] - 2026-04-04
+
+### Fixed
+- Enforce registration deadline when inviting or bulk-importing participants (CTF-007)
+
 ## [3.56.1] - 2026-04-04
 
 ### Added

--- a/shifter/shifter_platform/ctf/services/participant.py
+++ b/shifter/shifter_platform/ctf/services/participant.py
@@ -56,6 +56,17 @@ def invite_participant(
             details={"event_id": str(event_id)},
         ) from None
 
+    # Check registration deadline
+    if event.registration_deadline and timezone.now() > event.registration_deadline:
+        raise CTFValidationError(
+            "Registration deadline has passed",
+            code="CTF_REGISTRATION_DEADLINE_PASSED",
+            details={
+                "event_id": str(event_id),
+                "deadline": event.registration_deadline.isoformat(),
+            },
+        )
+
     # Check max participants
     if event.max_participants:
         current_count = event.participants.count()
@@ -134,6 +145,17 @@ def bulk_import_participants(
             f"Event {event_id} not found",
             details={"event_id": str(event_id)},
         ) from None
+
+    # Check registration deadline
+    if event.registration_deadline and timezone.now() > event.registration_deadline:
+        raise CTFValidationError(
+            "Registration deadline has passed",
+            code="CTF_REGISTRATION_DEADLINE_PASSED",
+            details={
+                "event_id": str(event_id),
+                "deadline": event.registration_deadline.isoformat(),
+            },
+        )
 
     # Parse CSV
     reader = csv.reader(io.StringIO(csv_content))

--- a/shifter/shifter_platform/tests/ctf/test_services/test_participant.py
+++ b/shifter/shifter_platform/tests/ctf/test_services/test_participant.py
@@ -1,0 +1,58 @@
+"""Tests for CTF participant service registration deadline enforcement (CTF-007)."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+from django.utils import timezone
+
+from ctf.exceptions import CTFValidationError
+from ctf.services.participant import bulk_import_participants, invite_participant
+
+
+class TestRegistrationDeadlineEnforcement:
+    """Registration deadline must be enforced when inviting participants."""
+
+    def test_invite_rejects_after_deadline(self, ctf_event):
+        """invite_participant raises CTFValidationError after deadline passes."""
+        ctf_event.registration_deadline = timezone.now() - timedelta(hours=1)
+        ctf_event.save(update_fields=["registration_deadline"])
+
+        with pytest.raises(CTFValidationError, match="Registration deadline has passed"):
+            invite_participant(ctf_event.pk, "late@test.com", "Late User")
+
+    def test_invite_allows_before_deadline(self, ctf_event):
+        """invite_participant succeeds before deadline."""
+        # Deadline must be before event_start per model validation
+        ctf_event.registration_deadline = timezone.now() + timedelta(hours=12)
+        ctf_event.save(update_fields=["registration_deadline"])
+
+        participant = invite_participant(ctf_event.pk, "early@test.com", "Early User")
+        assert participant.email == "early@test.com"
+
+    def test_invite_allows_when_no_deadline(self, ctf_event):
+        """invite_participant succeeds when no deadline is set."""
+        assert ctf_event.registration_deadline is None
+
+        participant = invite_participant(ctf_event.pk, "anytime@test.com", "Anytime User")
+        assert participant.email == "anytime@test.com"
+
+    def test_bulk_import_rejects_after_deadline(self, ctf_event):
+        """bulk_import_participants raises CTFValidationError after deadline passes."""
+        ctf_event.registration_deadline = timezone.now() - timedelta(hours=1)
+        ctf_event.save(update_fields=["registration_deadline"])
+
+        csv_content = "Alice,alice@test.com\nBob,bob@test.com"
+
+        with pytest.raises(CTFValidationError, match="Registration deadline has passed"):
+            bulk_import_participants(ctf_event.pk, csv_content)
+
+    def test_bulk_import_allows_before_deadline(self, ctf_event):
+        """bulk_import_participants succeeds before deadline."""
+        ctf_event.registration_deadline = timezone.now() + timedelta(hours=12)
+        ctf_event.save(update_fields=["registration_deadline"])
+
+        csv_content = "Alice,alice@test.com"
+        participants = bulk_import_participants(ctf_event.pk, csv_content)
+        assert len(participants) == 1


### PR DESCRIPTION
## Summary
- Enforce `registration_deadline` when inviting or bulk-importing participants (CTF-007)
- `invite_participant()` and `bulk_import_participants()` now raise `CTFValidationError` if the registration deadline has passed
- Add 5 tests for deadline enforcement (reject after, allow before, allow when no deadline)

Closes #931

## Test plan
- [x] All 579 CTF tests pass
- [x] New deadline enforcement tests verify reject/allow behavior
- [x] Pre-commit hooks pass (ruff, bandit, mypy, architecture checks)