### PR TITLE
Add per-event email template customization (CTF-805)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.58.0] - 2026-04-05
+
+### Added
+- Per-event email template customization: organizers can override default email templates for any notification type (CTF-805)
+- `CTFEmailTemplate` model with unique constraint per event and notification type
+- Admin page listing template override status per notification type
+- API endpoint for CRUD operations on custom email templates
+
 ## [3.57.0] - 2026-04-04
 
 ### Added

--- a/shifter/shifter_platform/ctf/admin.py
+++ b/shifter/shifter_platform/ctf/admin.py
@@ -19,6 +19,7 @@ from ctf.models import (
     CTFChallenge,
     CTFChallengeFile,
     CTFChallengePrerequisite,
+    CTFEmailTemplate,
     CTFEvent,
     CTFNotification,
     CTFParticipant,
@@ -854,5 +855,48 @@ class CTFChallengePrerequisiteAdmin(SoftDeleteAdminMixin, admin.ModelAdmin):
 
     @admin.display(description="Deleted", boolean=True)
     def is_deleted_display(self, obj: CTFChallengePrerequisite) -> bool:
+        """Display soft delete status."""
+        return obj.is_deleted
+
+
+@admin.register(CTFEmailTemplate)
+class CTFEmailTemplateAdmin(SoftDeleteAdminMixin, admin.ModelAdmin):
+    """Admin for per-event email template overrides."""
+
+    list_display = [
+        "event",
+        "notification_type",
+        "subject",
+        "is_deleted_display",
+    ]
+    list_filter = ["notification_type", "event", "deleted_at"]
+    search_fields = ["event__name", "subject"]
+    ordering = ["event", "notification_type"]
+    readonly_fields = ["id", "created_at", "updated_at", "deleted_at"]
+
+    fieldsets = [
+        (
+            None,
+            {
+                "fields": ["event", "notification_type", "subject"],
+            },
+        ),
+        (
+            "Template Content",
+            {
+                "fields": ["html_body", "text_body"],
+            },
+        ),
+        (
+            "Metadata",
+            {
+                "fields": ["id", "created_at", "updated_at", "deleted_at"],
+                "classes": ["collapse"],
+            },
+        ),
+    ]
+
+    @admin.display(description="Deleted", boolean=True)
+    def is_deleted_display(self, obj: CTFEmailTemplate) -> bool:
         """Display soft delete status."""
         return obj.is_deleted

--- a/shifter/shifter_platform/ctf/migrations/0022_add_email_template.py
+++ b/shifter/shifter_platform/ctf/migrations/0022_add_email_template.py
@@ -1,0 +1,103 @@
+"""Add CTFEmailTemplate model for per-event email customisation."""
+
+from __future__ import annotations
+
+import uuid
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("ctf", "0021_add_scoreboard_visible"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="CTFEmailTemplate",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        default=uuid.uuid4,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "deleted_at",
+                    models.DateTimeField(
+                        blank=True,
+                        db_index=True,
+                        default=None,
+                        help_text="Soft-delete timestamp",
+                        null=True,
+                    ),
+                ),
+                (
+                    "notification_type",
+                    models.CharField(
+                        choices=[
+                            ("invite", "Invite"),
+                            ("credentials", "Credentials"),
+                            ("reminder", "Reminder"),
+                            ("announcement", "Announcement"),
+                            ("event_start", "Event Start"),
+                            ("event_end", "Event End"),
+                            ("provision_failure", "Provision Failure"),
+                        ],
+                        help_text="Notification type this template overrides",
+                        max_length=20,
+                    ),
+                ),
+                (
+                    "subject",
+                    models.CharField(
+                        blank=True,
+                        default="",
+                        help_text="Custom subject line (leave blank to use default)",
+                        max_length=200,
+                    ),
+                ),
+                (
+                    "html_body",
+                    models.TextField(
+                        help_text="Custom HTML email body (Django template syntax)",
+                    ),
+                ),
+                (
+                    "text_body",
+                    models.TextField(
+                        help_text="Custom plain-text email body (Django template syntax)",
+                    ),
+                ),
+                (
+                    "event",
+                    models.ForeignKey(
+                        help_text="Event this template belongs to",
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="email_templates",
+                        to="ctf.ctfevent",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "CTF Email Template",
+                "verbose_name_plural": "CTF Email Templates",
+                "db_table": "ctf_email_template",
+                "ordering": ["notification_type"],
+            },
+        ),
+        migrations.AddConstraint(
+            model_name="ctfemailtemplate",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(("deleted_at__isnull", True)),
+                fields=("event", "notification_type"),
+                name="unique_active_email_template_per_event_type",
+            ),
+        ),
+    ]

--- a/shifter/shifter_platform/ctf/models.py
+++ b/shifter/shifter_platform/ctf/models.py
@@ -7,6 +7,7 @@ This module defines all database models for CTF event management including:
 - CTFParticipant: Individual competitors
 - CTFSubmission: Flag submission attempts
 - CTFNotification: Event notifications
+- CTFEmailTemplate: Per-event email template overrides
 - CTFScheduledTask: Scheduled automation tasks
 """
 
@@ -1658,6 +1659,63 @@ class CTFNotification(CTFBaseModel):
     def __str__(self) -> str:
         """Return notification description."""
         return f"[{self.notification_type}] {self.subject}"
+
+
+class CTFEmailTemplate(CTFBaseModel):
+    """Per-event email template override.
+
+    Organizers can customise email templates for specific notification types
+    within their event.  When a custom template exists it is rendered instead
+    of the default filesystem template.
+
+    Attributes:
+        event: The event this template belongs to.
+        notification_type: Which notification type this template overrides.
+        subject: Custom subject line (optional — falls back to default).
+        html_body: Custom HTML body using Django template syntax.
+        text_body: Custom plain-text body using Django template syntax.
+    """
+
+    event = models.ForeignKey(
+        CTFEvent,
+        on_delete=models.CASCADE,
+        related_name="email_templates",
+        help_text="Event this template belongs to",
+    )
+    notification_type = models.CharField(
+        max_length=20,
+        choices=NotificationType.choices(),
+        help_text="Notification type this template overrides",
+    )
+    subject = models.CharField(
+        max_length=200,
+        blank=True,
+        default="",
+        help_text="Custom subject line (leave blank to use default)",
+    )
+    html_body = models.TextField(
+        help_text="Custom HTML email body (Django template syntax)",
+    )
+    text_body = models.TextField(
+        help_text="Custom plain-text email body (Django template syntax)",
+    )
+
+    class Meta:
+        db_table = "ctf_email_template"
+        ordering = ["notification_type"]
+        verbose_name = "CTF Email Template"
+        verbose_name_plural = "CTF Email Templates"
+        constraints = [
+            models.UniqueConstraint(
+                fields=["event", "notification_type"],
+                condition=models.Q(deleted_at__isnull=True),
+                name="unique_active_email_template_per_event_type",
+            ),
+        ]
+
+    def __str__(self) -> str:
+        """Return template description."""
+        return f"{self.event.name} - {self.notification_type}"
 
 
 class CTFScheduledTask(CTFBaseModel):

--- a/shifter/shifter_platform/ctf/services/notification.py
+++ b/shifter/shifter_platform/ctf/services/notification.py
@@ -51,7 +51,7 @@ def send_invitations(event_id: UUID) -> dict[str, Any]:
     for participant in participants:
         try:
             registration_url = _build_registration_url(participant.invite_token)
-            html_content, text_content = _render_email(
+            html_content, text_content, custom_subject = _render_email(
                 "invitation",
                 {
                     "event": event,
@@ -63,7 +63,7 @@ def send_invitations(event_id: UUID) -> dict[str, Any]:
             )
             success = _send_email(
                 recipient=participant.email,
-                subject=f"You're invited to {event.name}",
+                subject=custom_subject or f"You're invited to {event.name}",
                 html_content=html_content,
                 text_content=text_content,
             )
@@ -141,7 +141,7 @@ def send_credentials(event_id: UUID) -> dict[str, Any]:
             base = (getattr(settings, "SITE_URL", "") or "").rstrip("/")
             access_url = f"{base}{range_page_url}"
 
-            html_content, text_content = _render_email(
+            html_content, text_content, custom_subject = _render_email(
                 "credentials",
                 {
                     "event": event,
@@ -152,7 +152,7 @@ def send_credentials(event_id: UUID) -> dict[str, Any]:
             )
             success = _send_email(
                 recipient=participant.email,
-                subject=f"Your credentials for {event.name}",
+                subject=custom_subject or f"Your credentials for {event.name}",
                 html_content=html_content,
                 text_content=text_content,
             )
@@ -217,7 +217,7 @@ def send_reminder(event_id: UUID, hours_before: int = 24) -> dict[str, Any]:
 
     for participant in participants:
         try:
-            html_content, text_content = _render_email(
+            html_content, text_content, custom_subject = _render_email(
                 "reminder",
                 {
                     "event": event,
@@ -228,7 +228,7 @@ def send_reminder(event_id: UUID, hours_before: int = 24) -> dict[str, Any]:
             )
             success = _send_email(
                 recipient=participant.email,
-                subject=f"Reminder: {event.name} starts soon",
+                subject=custom_subject or f"Reminder: {event.name} starts soon",
                 html_content=html_content,
                 text_content=text_content,
             )
@@ -306,7 +306,7 @@ def send_announcement(
 
     for participant in participants:
         try:
-            html_content, text_content = _render_email(
+            html_content, text_content, custom_subject = _render_email(
                 "announcement",
                 {
                     "event": event,
@@ -318,7 +318,7 @@ def send_announcement(
             )
             success = _send_email(
                 recipient=participant.email,
-                subject=subject,
+                subject=custom_subject or subject,
                 html_content=html_content,
                 text_content=text_content,
             )
@@ -404,7 +404,7 @@ def notify_organizer_provision_failure(
         logger.warning("Cannot notify: event %s has no organizer email", event_id)
         return
 
-    html_content, text_content = _render_email(
+    html_content, text_content, custom_subject = _render_email(
         "provision_failure",
         {
             "event": event,
@@ -416,7 +416,7 @@ def notify_organizer_provision_failure(
 
     success = _send_email(
         recipient=organizer.email,
-        subject=f"Range provisioning failures: {event.name}",
+        subject=custom_subject or f"Range provisioning failures: {event.name}",
         html_content=html_content,
         text_content=text_content,
     )
@@ -453,7 +453,7 @@ def notify_organizer_event_start(event_id: UUID) -> None:
         logger.warning("Cannot notify: event %s has no organizer email", event_id)
         return
 
-    html_content, text_content = _render_email(
+    html_content, text_content, custom_subject = _render_email(
         "event_start",
         {"event": event},
         event=event,
@@ -461,7 +461,7 @@ def notify_organizer_event_start(event_id: UUID) -> None:
 
     success = _send_email(
         recipient=organizer.email,
-        subject=f"Event started: {event.name}",
+        subject=custom_subject or f"Event started: {event.name}",
         html_content=html_content,
         text_content=text_content,
     )
@@ -498,7 +498,7 @@ def notify_organizer_event_end(event_id: UUID) -> None:
         logger.warning("Cannot notify: event %s has no organizer email", event_id)
         return
 
-    html_content, text_content = _render_email(
+    html_content, text_content, custom_subject = _render_email(
         "event_end",
         {"event": event},
         event=event,
@@ -506,7 +506,7 @@ def notify_organizer_event_end(event_id: UUID) -> None:
 
     success = _send_email(
         recipient=organizer.email,
-        subject=f"Event ended: {event.name}",
+        subject=custom_subject or f"Event ended: {event.name}",
         html_content=html_content,
         text_content=text_content,
     )
@@ -582,7 +582,7 @@ def _render_email(
     template_name: str,
     context: dict,
     event: CTFEvent | None = None,
-) -> tuple[str, str]:
+) -> tuple[str, str, str]:
     """Render email templates.
 
     If *event* is provided and has a custom template for the given
@@ -595,14 +595,22 @@ def _render_email(
         event: Optional event for custom template lookup.
 
     Returns:
-        Tuple of (html_content, text_content).
+        Tuple of (html_content, text_content, custom_subject).
+        custom_subject is non-empty only when a custom template with a
+        subject override is used; callers should prefer it over their
+        default subject when non-empty.
     """
+    # Map filesystem template names to NotificationType enum values where
+    # they differ (the "invitation" template corresponds to the "invite" type).
+    _TEMPLATE_TO_TYPE = {"invitation": "invite"}
+
     if event is not None:
         from ctf.models import CTFEmailTemplate
 
+        lookup_type = _TEMPLATE_TO_TYPE.get(template_name, template_name)
         custom = CTFEmailTemplate.objects.filter(
             event=event,
-            notification_type=template_name,
+            notification_type=lookup_type,
         ).first()
         if custom is not None:
             from django.template import Context, Template
@@ -611,10 +619,10 @@ def _render_email(
             # execution.  Only authenticated event organizers can write templates.
             html_content = Template(custom.html_body).render(Context(context))
             text_content = Template(custom.text_body).render(Context(context))
-            return html_content, text_content
+            return html_content, text_content, custom.subject or ""
 
     from django.template.loader import render_to_string
 
     html_content = render_to_string(f"ctf/email/{template_name}.html", context)
     text_content = render_to_string(f"ctf/email/{template_name}.txt", context)
-    return html_content, text_content
+    return html_content, text_content, ""

--- a/shifter/shifter_platform/ctf/services/notification.py
+++ b/shifter/shifter_platform/ctf/services/notification.py
@@ -607,6 +607,8 @@ def _render_email(
         if custom is not None:
             from django.template import Context, Template
 
+            # Safe: Django's template engine does not allow arbitrary code
+            # execution.  Only authenticated event organizers can write templates.
             html_content = Template(custom.html_body).render(Context(context))
             text_content = Template(custom.text_body).render(Context(context))
             return html_content, text_content

--- a/shifter/shifter_platform/ctf/services/notification.py
+++ b/shifter/shifter_platform/ctf/services/notification.py
@@ -59,6 +59,7 @@ def send_invitations(event_id: UUID) -> dict[str, Any]:
                     "invite_token": participant.invite_token,
                     "registration_url": registration_url,
                 },
+                event=event,
             )
             success = _send_email(
                 recipient=participant.email,
@@ -147,6 +148,7 @@ def send_credentials(event_id: UUID) -> dict[str, Any]:
                     "participant": participant,
                     "access_url": access_url,
                 },
+                event=event,
             )
             success = _send_email(
                 recipient=participant.email,
@@ -222,6 +224,7 @@ def send_reminder(event_id: UUID, hours_before: int = 24) -> dict[str, Any]:
                     "participant": participant,
                     "hours_before": hours_before,
                 },
+                event=event,
             )
             success = _send_email(
                 recipient=participant.email,
@@ -311,6 +314,7 @@ def send_announcement(
                     "subject": subject,
                     "body": body,
                 },
+                event=event,
             )
             success = _send_email(
                 recipient=participant.email,
@@ -407,6 +411,7 @@ def notify_organizer_provision_failure(
             "failures": failures,
             "failure_count": len(failures),
         },
+        event=event,
     )
 
     success = _send_email(
@@ -451,6 +456,7 @@ def notify_organizer_event_start(event_id: UUID) -> None:
     html_content, text_content = _render_email(
         "event_start",
         {"event": event},
+        event=event,
     )
 
     success = _send_email(
@@ -495,6 +501,7 @@ def notify_organizer_event_end(event_id: UUID) -> None:
     html_content, text_content = _render_email(
         "event_end",
         {"event": event},
+        event=event,
     )
 
     success = _send_email(
@@ -571,16 +578,39 @@ def _send_email(
         return False
 
 
-def _render_email(template_name: str, context: dict) -> tuple[str, str]:
+def _render_email(
+    template_name: str,
+    context: dict,
+    event: CTFEvent | None = None,
+) -> tuple[str, str]:
     """Render email templates.
 
+    If *event* is provided and has a custom template for the given
+    notification type, the custom template is rendered from the database.
+    Otherwise the default filesystem template is used.
+
     Args:
-        template_name: Base name (e.g., "invitation").
+        template_name: Base name / notification type (e.g., "invitation").
         context: Template context.
+        event: Optional event for custom template lookup.
 
     Returns:
         Tuple of (html_content, text_content).
     """
+    if event is not None:
+        from ctf.models import CTFEmailTemplate
+
+        custom = CTFEmailTemplate.objects.filter(
+            event=event,
+            notification_type=template_name,
+        ).first()
+        if custom is not None:
+            from django.template import Context, Template
+
+            html_content = Template(custom.html_body).render(Context(context))
+            text_content = Template(custom.text_body).render(Context(context))
+            return html_content, text_content
+
     from django.template.loader import render_to_string
 
     html_content = render_to_string(f"ctf/email/{template_name}.html", context)

--- a/shifter/shifter_platform/ctf/services/participant.py
+++ b/shifter/shifter_platform/ctf/services/participant.py
@@ -416,7 +416,7 @@ def resend_invite(participant_id: UUID) -> CTFParticipant:
     from ctf.services.notification import _build_registration_url, _render_email, _send_email
 
     registration_url = _build_registration_url(participant.invite_token)
-    html_content, text_content = _render_email(
+    html_content, text_content, custom_subject = _render_email(
         "invitation",
         {
             "event": participant.event,
@@ -424,10 +424,11 @@ def resend_invite(participant_id: UUID) -> CTFParticipant:
             "invite_token": participant.invite_token,
             "registration_url": registration_url,
         },
+        event=participant.event,
     )
     sent = _send_email(
         recipient=participant.email,
-        subject=f"You're invited to {participant.event.name}",
+        subject=custom_subject or f"You're invited to {participant.event.name}",
         html_content=html_content,
         text_content=text_content,
     )

--- a/shifter/shifter_platform/ctf/urls.py
+++ b/shifter/shifter_platform/ctf/urls.py
@@ -136,6 +136,12 @@ admin_patterns = [
         views.admin_notification_create,
         name="admin_notification_create",
     ),
+    # Email Templates
+    path(
+        "admin/events/<uuid:event_id>/email-templates/",
+        views.admin_event_email_templates,
+        name="admin_event_email_templates",
+    ),
     # Analytics
     path(
         "admin/events/<uuid:event_id>/analytics/",
@@ -289,6 +295,12 @@ api_patterns = [
         "api/notifications/<uuid:notification_id>/send/",
         views.api_notification_send,
         name="api_notification_send",
+    ),
+    # Email Template APIs
+    path(
+        "api/events/<uuid:event_id>/email-templates/<str:notification_type>/",
+        views.api_event_email_template,
+        name="api_event_email_template",
     ),
     # Invitation APIs
     path(

--- a/shifter/shifter_platform/ctf/views.py
+++ b/shifter/shifter_platform/ctf/views.py
@@ -1929,6 +1929,52 @@ def admin_notification_create(request: HttpRequest, event_id: UUID) -> HttpRespo
 
 @login_required
 @ctf_organizer_required
+@require_http_methods(["GET"])
+def admin_event_email_templates(request: HttpRequest, event_id: UUID) -> HttpResponse:
+    """List email template overrides for an event.
+
+    Shows all notification types with their current template status
+    (default or custom).
+
+    Args:
+        event_id: UUID of the event.
+    """
+    from django.http import Http404
+
+    from ctf.enums import NotificationType
+    from ctf.exceptions import CTFNotFoundError
+    from ctf.models import CTFEmailTemplate
+    from ctf.services import get_event
+
+    try:
+        event = get_event(event_id)
+    except CTFNotFoundError:
+        raise Http404("Event not found") from None
+
+    if event.created_by_id != request.user.pk:
+        return HttpResponse("Forbidden: You do not have access to this event", status=403)
+
+    custom_templates = {t.notification_type: t for t in CTFEmailTemplate.objects.filter(event=event)}
+
+    template_list = []
+    for nt in NotificationType:
+        template_list.append(
+            {
+                "type": nt.value,
+                "label": nt.value.replace("_", " ").title(),
+                "custom": custom_templates.get(nt.value),
+            }
+        )
+
+    return render(
+        request,
+        "ctf/admin/email_templates.html",
+        {"event": event, "template_list": template_list},
+    )
+
+
+@login_required
+@ctf_organizer_required
 def admin_analytics(request: HttpRequest, event_id: UUID) -> HttpResponse:
     """Analytics view for an event.
 
@@ -3000,6 +3046,91 @@ def api_notification_send(request: HttpRequest, notification_id: UUID) -> HttpRe
         {
             "notification_id": str(notification_id),
             "status": "sent",
+        }
+    )
+
+
+@login_required
+@ctf_organizer_required
+@require_http_methods(["GET", "PUT", "DELETE"])
+def api_event_email_template(request: HttpRequest, event_id: UUID, notification_type: str) -> JsonResponse:
+    """API: Get, update, or delete a per-event email template override.
+
+    GET returns the custom template (or 404 if using default).
+    PUT creates or updates the custom template.
+    DELETE removes the custom template (reverts to default).
+
+    Args:
+        event_id: UUID of the event.
+        notification_type: Notification type string (e.g. "invitation").
+    """
+    import json
+
+    from ctf.enums import NotificationType
+    from ctf.exceptions import CTFNotFoundError
+    from ctf.models import CTFEmailTemplate
+    from ctf.services import get_event
+
+    # Validate notification_type
+    valid_types = {nt.value for nt in NotificationType}
+    if notification_type not in valid_types:
+        return JsonResponse({"error": f"Invalid notification type: {notification_type}"}, status=400)
+
+    try:
+        event = get_event(event_id)
+    except CTFNotFoundError:
+        return JsonResponse({"error": "Event not found"}, status=404)
+
+    if event.created_by_id != request.user.pk:
+        return JsonResponse({"error": "Forbidden"}, status=403)
+
+    if request.method == "GET":
+        template = CTFEmailTemplate.objects.filter(event=event, notification_type=notification_type).first()
+        if template is None:
+            return JsonResponse({"error": "No custom template"}, status=404)
+        return JsonResponse(
+            {
+                "id": str(template.id),
+                "notification_type": template.notification_type,
+                "subject": template.subject,
+                "html_body": template.html_body,
+                "text_body": template.text_body,
+            }
+        )
+
+    if request.method == "DELETE":
+        deleted_count, _ = CTFEmailTemplate.objects.filter(event=event, notification_type=notification_type).delete()
+        if deleted_count == 0:
+            return JsonResponse({"error": "No custom template to delete"}, status=404)
+        return JsonResponse({"status": "reverted_to_default"})
+
+    # PUT — create or update
+    try:
+        body = json.loads(request.body)
+    except json.JSONDecodeError:
+        return JsonResponse({"error": "Invalid JSON"}, status=400)
+
+    html_body = body.get("html_body", "").strip()
+    text_body = body.get("text_body", "").strip()
+    if not html_body or not text_body:
+        return JsonResponse({"error": "html_body and text_body are required"}, status=400)
+
+    template, _created = CTFEmailTemplate.objects.update_or_create(
+        event=event,
+        notification_type=notification_type,
+        defaults={
+            "subject": body.get("subject", "").strip(),
+            "html_body": html_body,
+            "text_body": text_body,
+        },
+    )
+    return JsonResponse(
+        {
+            "id": str(template.id),
+            "notification_type": template.notification_type,
+            "subject": template.subject,
+            "html_body": template.html_body,
+            "text_body": template.text_body,
         }
     )
 

--- a/shifter/shifter_platform/ctf/views.py
+++ b/shifter/shifter_platform/ctf/views.py
@@ -3099,9 +3099,10 @@ def api_event_email_template(request: HttpRequest, event_id: UUID, notification_
         )
 
     if request.method == "DELETE":
-        deleted_count, _ = CTFEmailTemplate.objects.filter(event=event, notification_type=notification_type).delete()
-        if deleted_count == 0:
+        template = CTFEmailTemplate.objects.filter(event=event, notification_type=notification_type).first()
+        if template is None:
             return JsonResponse({"error": "No custom template to delete"}, status=404)
+        template.delete(soft=True)
         return JsonResponse({"status": "reverted_to_default"})
 
     # PUT — create or update
@@ -3114,6 +3115,15 @@ def api_event_email_template(request: HttpRequest, event_id: UUID, notification_
     text_body = body.get("text_body", "").strip()
     if not html_body or not text_body:
         return JsonResponse({"error": "html_body and text_body are required"}, status=400)
+
+    # Validate Django template syntax before saving
+    from django.template import Template, TemplateSyntaxError
+
+    for label, source in [("html_body", html_body), ("text_body", text_body)]:
+        try:
+            Template(source)
+        except TemplateSyntaxError as exc:
+            return JsonResponse({"error": f"Invalid template syntax in {label}: {exc}"}, status=400)
 
     template, _created = CTFEmailTemplate.objects.update_or_create(
         event=event,

--- a/shifter/shifter_platform/templates/ctf/admin/email_templates.html
+++ b/shifter/shifter_platform/templates/ctf/admin/email_templates.html
@@ -1,0 +1,102 @@
+{% extends "mission_control/base.html" %}
+{% block title %}Email Templates - {{ event.name }}{% endblock %}
+
+{% block extra_css %}
+<style>
+.breadcrumb {
+    font-size: 13px;
+    color: var(--xdr-text-secondary);
+    margin-bottom: 8px;
+}
+
+.breadcrumb a {
+    color: #128df3;
+}
+
+.breadcrumb .separator {
+    margin: 0 6px;
+    color: var(--xdr-text-secondary);
+}
+
+.template-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    gap: 16px;
+}
+
+.template-card {
+    border: 1px solid var(--xdr-border);
+    border-radius: 6px;
+    padding: 16px;
+    background: var(--xdr-bg-secondary);
+}
+
+.template-card .type-label {
+    font-weight: 600;
+    font-size: 15px;
+    margin-bottom: 8px;
+}
+
+.template-card .status {
+    font-size: 13px;
+    margin-bottom: 12px;
+}
+
+.badge-default {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 3px;
+    background: var(--xdr-bg-tertiary);
+    color: var(--xdr-text-secondary);
+    font-size: 12px;
+}
+
+.badge-custom {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 3px;
+    background: rgba(40, 167, 69, 0.15);
+    color: #28a745;
+    font-size: 12px;
+}
+</style>
+{% endblock %}
+
+{% block content %}
+<!-- Header -->
+<div class="flex-between mb-lg">
+    <div>
+        <div class="breadcrumb">
+            <a href="{% url 'ctf:admin_event_list' %}">Events</a>
+            <span class="separator">/</span>
+            <a href="{% url 'ctf:admin_event_detail' event_id=event.pk %}">{{ event.name }}</a>
+            <span class="separator">/</span>
+            <span>Email Templates</span>
+        </div>
+        <h1 class="page-title">Email Templates</h1>
+        <p style="color: var(--xdr-text-secondary); font-size: 13px; margin-top: 4px;">
+            Customise email templates for this event. Types using the default template can be overridden via the API.
+        </p>
+    </div>
+</div>
+
+<div class="template-grid">
+    {% for item in template_list %}
+    <div class="template-card">
+        <div class="type-label">{{ item.label }}</div>
+        <div class="status">
+            {% if item.custom %}
+            <span class="badge-custom">Custom</span>
+            {% if item.custom.subject %}
+            <div style="margin-top: 6px; font-size: 13px; color: var(--xdr-text-secondary);">
+                Subject: {{ item.custom.subject }}
+            </div>
+            {% endif %}
+            {% else %}
+            <span class="badge-default">Default</span>
+            {% endif %}
+        </div>
+    </div>
+    {% endfor %}
+</div>
+{% endblock %}

--- a/shifter/shifter_platform/tests/ctf/test_services/test_notification.py
+++ b/shifter/shifter_platform/tests/ctf/test_services/test_notification.py
@@ -86,7 +86,7 @@ class TestSendInvitations:
         with (
             patch.object(notification, "_send_email", return_value=True),
             patch.object(notification, "_build_registration_url", return_value="https://example.com/register"),
-            patch.object(notification, "_render_email", return_value=("<html>", "text")),
+            patch.object(notification, "_render_email", return_value=("<html>", "text", "")),
         ):
             result = notification.send_invitations(ctf_event.pk)
 
@@ -107,7 +107,7 @@ class TestSendInvitations:
         with (
             patch.object(notification, "_send_email", return_value=True),
             patch.object(notification, "_build_registration_url", return_value="https://example.com/register"),
-            patch.object(notification, "_render_email", return_value=("<html>", "text")),
+            patch.object(notification, "_render_email", return_value=("<html>", "text", "")),
         ):
             result = notification.send_invitations(ctf_event.pk)
 
@@ -126,7 +126,7 @@ class TestSendInvitations:
         with (
             patch.object(notification, "_send_email", return_value=False),
             patch.object(notification, "_build_registration_url", return_value="https://example.com/register"),
-            patch.object(notification, "_render_email", return_value=("<html>", "text")),
+            patch.object(notification, "_render_email", return_value=("<html>", "text", "")),
         ):
             result = notification.send_invitations(ctf_event.pk)
 
@@ -148,7 +148,7 @@ class TestSendInvitations:
         with (
             patch.object(notification, "_send_email", return_value=True),
             patch.object(notification, "_build_registration_url", return_value="https://example.com/register"),
-            patch.object(notification, "_render_email", return_value=("<html>", "text")),
+            patch.object(notification, "_render_email", return_value=("<html>", "text", "")),
         ):
             notification.send_invitations(ctf_event.pk)
 
@@ -183,7 +183,7 @@ class TestSendCredentials:
 
         with (
             patch.object(notification, "_send_email", return_value=True),
-            patch.object(notification, "_render_email", return_value=("<html>", "text")),
+            patch.object(notification, "_render_email", return_value=("<html>", "text", "")),
             patch("django.urls.reverse", return_value="/ctf/range/"),
         ):
             result = notification.send_credentials(ctf_event.pk)
@@ -226,7 +226,7 @@ class TestSendReminder:
 
         with (
             patch.object(notification, "_send_email", return_value=True),
-            patch.object(notification, "_render_email", return_value=("<html>", "text")),
+            patch.object(notification, "_render_email", return_value=("<html>", "text", "")),
         ):
             result = notification.send_reminder(ctf_event.pk)
 
@@ -273,7 +273,7 @@ class TestSendAnnouncement:
 
         with (
             patch.object(notification, "_send_email", return_value=True),
-            patch.object(notification, "_render_email", return_value=("<html>", "text")),
+            patch.object(notification, "_render_email", return_value=("<html>", "text", "")),
         ):
             result = notification.send_announcement(
                 ctf_event.pk,
@@ -342,7 +342,7 @@ class TestRenderEmail:
             f"{ctf_event.name} {registration_url}",
         ]
 
-        html, text = notification._render_email(
+        html, text, custom_subject = notification._render_email(
             "invitation",
             {
                 "event": ctf_event,
@@ -356,6 +356,7 @@ class TestRenderEmail:
         assert ctf_event.name in text
         assert registration_url in html
         assert registration_url in text
+        assert custom_subject == ""
         assert mock_render.call_count == 2
 
 
@@ -413,7 +414,7 @@ class TestNotifyOrganizerEventStart:
 
         with (
             patch.object(notification, "_send_email", return_value=True) as mock_send,
-            patch.object(notification, "_render_email", return_value=("<html>", "text")) as mock_render,
+            patch.object(notification, "_render_email", return_value=("<html>", "text", "")) as mock_render,
         ):
             notification.notify_organizer_event_start(ctf_event.pk)
 
@@ -462,7 +463,7 @@ class TestNotifyOrganizerEventEnd:
 
         with (
             patch.object(notification, "_send_email", return_value=True) as mock_send,
-            patch.object(notification, "_render_email", return_value=("<html>", "text")) as mock_render,
+            patch.object(notification, "_render_email", return_value=("<html>", "text", "")) as mock_render,
         ):
             notification.notify_organizer_event_end(ctf_event.pk)
 
@@ -515,7 +516,7 @@ class TestRenderEmailWithCustomTemplate:
         with patch("ctf.models.CTFEmailTemplate.objects") as mock_qs:
             mock_qs.filter.return_value.first.return_value = None
 
-            html, text = notification._render_email(
+            html, text, custom_subject = notification._render_email(
                 "invitation",
                 {"event": ctf_event},
                 event=ctf_event,
@@ -523,6 +524,7 @@ class TestRenderEmailWithCustomTemplate:
 
         assert html == "<html>default</html>"
         assert text == "default"
+        assert custom_subject == ""
         assert mock_render.call_count == 2
 
     def test_uses_custom_template_when_present(self):
@@ -536,11 +538,12 @@ class TestRenderEmailWithCustomTemplate:
         mock_template = MagicMock()
         mock_template.html_body = "<html>Hello {{ event.name }}</html>"
         mock_template.text_body = "Hello {{ event.name }}"
+        mock_template.subject = "Custom Subject"
 
         with patch("ctf.models.CTFEmailTemplate.objects") as mock_qs:
             mock_qs.filter.return_value.first.return_value = mock_template
 
-            html, text = notification._render_email(
+            html, text, custom_subject = notification._render_email(
                 "invitation",
                 {"event": event},
                 event=event,
@@ -549,16 +552,18 @@ class TestRenderEmailWithCustomTemplate:
         assert "My Custom Event" in html
         assert "My Custom Event" in text
         assert "<html>" in html
+        assert custom_subject == "Custom Subject"
 
     @patch("django.template.loader.render_to_string")
     def test_no_db_lookup_when_event_is_none(self, mock_render):
         """Skips DB lookup when event is not provided (backward compat)."""
         mock_render.side_effect = ["<html>ok</html>", "ok"]
 
-        html, _text = notification._render_email(
+        html, _text, custom_subject = notification._render_email(
             "invitation",
             {"key": "value"},
         )
 
         assert html == "<html>ok</html>"
+        assert custom_subject == ""
         assert mock_render.call_count == 2

--- a/shifter/shifter_platform/tests/ctf/test_services/test_notification.py
+++ b/shifter/shifter_platform/tests/ctf/test_services/test_notification.py
@@ -417,7 +417,7 @@ class TestNotifyOrganizerEventStart:
         ):
             notification.notify_organizer_event_start(ctf_event.pk)
 
-        mock_render.assert_called_once_with("event_start", {"event": ctf_event})
+        mock_render.assert_called_once_with("event_start", {"event": ctf_event}, event=ctf_event)
         mock_send.assert_called_once_with(
             recipient=ctf_event.created_by.email,
             subject=f"Event started: {ctf_event.name}",
@@ -466,7 +466,7 @@ class TestNotifyOrganizerEventEnd:
         ):
             notification.notify_organizer_event_end(ctf_event.pk)
 
-        mock_render.assert_called_once_with("event_end", {"event": ctf_event})
+        mock_render.assert_called_once_with("event_end", {"event": ctf_event}, event=ctf_event)
         mock_send.assert_called_once_with(
             recipient=ctf_event.created_by.email,
             subject=f"Event ended: {ctf_event.name}",
@@ -497,3 +497,68 @@ class TestNotifyOrganizerEventEnd:
             notification.notify_organizer_event_end(ctf_event.pk)
 
         mock_send.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Custom Email Template Tests
+# ---------------------------------------------------------------------------
+
+
+class TestRenderEmailWithCustomTemplate:
+    """Tests for _render_email with per-event custom template overrides."""
+
+    @patch("django.template.loader.render_to_string")
+    def test_falls_back_to_default_when_no_custom(self, mock_render, ctf_event):
+        """Uses filesystem template when no custom template exists."""
+        mock_render.side_effect = ["<html>default</html>", "default"]
+
+        with patch("ctf.models.CTFEmailTemplate.objects") as mock_qs:
+            mock_qs.filter.return_value.first.return_value = None
+
+            html, text = notification._render_email(
+                "invitation",
+                {"event": ctf_event},
+                event=ctf_event,
+            )
+
+        assert html == "<html>default</html>"
+        assert text == "default"
+        assert mock_render.call_count == 2
+
+    def test_uses_custom_template_when_present(self):
+        """Renders from DB template instead of filesystem when custom exists."""
+
+        class _SimpleEvent:
+            name = "My Custom Event"
+
+        event = _SimpleEvent()
+
+        mock_template = MagicMock()
+        mock_template.html_body = "<html>Hello {{ event.name }}</html>"
+        mock_template.text_body = "Hello {{ event.name }}"
+
+        with patch("ctf.models.CTFEmailTemplate.objects") as mock_qs:
+            mock_qs.filter.return_value.first.return_value = mock_template
+
+            html, text = notification._render_email(
+                "invitation",
+                {"event": event},
+                event=event,
+            )
+
+        assert "My Custom Event" in html
+        assert "My Custom Event" in text
+        assert "<html>" in html
+
+    @patch("django.template.loader.render_to_string")
+    def test_no_db_lookup_when_event_is_none(self, mock_render):
+        """Skips DB lookup when event is not provided (backward compat)."""
+        mock_render.side_effect = ["<html>ok</html>", "ok"]
+
+        html, _text = notification._render_email(
+            "invitation",
+            {"key": "value"},
+        )
+
+        assert html == "<html>ok</html>"
+        assert mock_render.call_count == 2


### PR DESCRIPTION
## Summary
- Add `CTFEmailTemplate` model allowing organizers to override default email templates per notification type per event
- Modify `_render_email()` to check for custom templates before falling back to filesystem defaults
- Add admin page showing template override status for each notification type
- Add REST API endpoint (GET/PUT/DELETE) for managing custom templates

Closes #935

## Test plan
- [x] 3 new tests for custom template rendering (custom override, default fallback, backward compat)
- [x] All 2610 tests pass
- [x] Pre-commit hooks pass (ruff, mypy, bandit, architecture checks)
- [ ] Verify custom template renders instead of default when set via API
- [ ] Verify DELETE reverts to default template