### PR TITLE
Add shared email templating and delivery service (PLAT-103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.59.0] - 2026-04-05
+
+### Added
+- Shared email templating and delivery service in `shared.email` (PLAT-103)
+- `render_template()` for rendering HTML+text email template pairs with variable substitution
+- `send_email()` for synchronous delivery with error logging (never raises)
+- `send_email_async()` for fire-and-forget background delivery via thread pool
+- CTF notification service now delegates to the shared email service
+
 ## [3.58.0] - 2026-04-05
 
 ### Added

--- a/shifter/shifter_platform/ctf/services/notification.py
+++ b/shifter/shifter_platform/ctf/services/notification.py
@@ -552,7 +552,7 @@ def _send_email(
     """Send an email using the shared platform email service.
 
     Delegates to ``shared.email.send_email`` which handles error logging
-    and never raises.
+    and never raises.  Uses ``CTF_FROM_EMAIL`` as the sender address.
 
     Args:
         recipient: Email address.
@@ -563,9 +563,11 @@ def _send_email(
     Returns:
         True if sent successfully.
     """
+    from django.conf import settings
+
     from shared.email import send_email
 
-    return send_email(recipient, subject, html_content, text_content)
+    return send_email(recipient, subject, html_content, text_content, from_email=settings.CTF_FROM_EMAIL)
 
 
 def _render_email(

--- a/shifter/shifter_platform/ctf/services/notification.py
+++ b/shifter/shifter_platform/ctf/services/notification.py
@@ -549,7 +549,10 @@ def _send_email(
     html_content: str,
     text_content: str,
 ) -> bool:
-    """Send an email using Django's email backend.
+    """Send an email using the shared platform email service.
+
+    Delegates to ``shared.email.send_email`` which handles error logging
+    and never raises.
 
     Args:
         recipient: Email address.
@@ -560,22 +563,9 @@ def _send_email(
     Returns:
         True if sent successfully.
     """
-    from django.conf import settings
-    from django.core.mail import EmailMultiAlternatives
+    from shared.email import send_email
 
-    try:
-        msg = EmailMultiAlternatives(
-            subject=subject,
-            body=text_content,
-            from_email=settings.CTF_FROM_EMAIL,
-            to=[recipient],
-        )
-        msg.attach_alternative(html_content, "text/html")
-        msg.send()
-        return True
-    except Exception:
-        logger.exception("Failed to send email to %s", recipient)
-        return False
+    return send_email(recipient, subject, html_content, text_content)
 
 
 def _render_email(
@@ -621,8 +611,7 @@ def _render_email(
             text_content = Template(custom.text_body).render(Context(context))
             return html_content, text_content, custom.subject or ""
 
-    from django.template.loader import render_to_string
+    from shared.email import render_template
 
-    html_content = render_to_string(f"ctf/email/{template_name}.html", context)
-    text_content = render_to_string(f"ctf/email/{template_name}.txt", context)
-    return html_content, text_content, ""
+    html, text = render_template(f"ctf/email/{template_name}", context)
+    return html, text, ""

--- a/shifter/shifter_platform/shared/email.py
+++ b/shifter/shifter_platform/shared/email.py
@@ -1,0 +1,119 @@
+"""Shared email templating and delivery service (PLAT-103).
+
+Provides platform-wide helpers for rendering Django email templates and
+sending multipart (HTML + plain-text) messages.  Other apps should import
+from this module rather than assembling ``EmailMultiAlternatives`` directly.
+
+Key features
+~~~~~~~~~~~~
+* ``render_template`` — renders an HTML/text template pair with context
+  variable substitution.
+* ``send_email`` — synchronous send with exception handling (failures are
+  logged, never raised).
+* ``send_email_async`` — fire-and-forget dispatch to a background thread so
+  the triggering action is never blocked by SMTP latency.
+"""
+
+from __future__ import annotations
+
+import atexit
+import logging
+from concurrent.futures import ThreadPoolExecutor
+
+logger = logging.getLogger(__name__)
+
+# Lazy-initialised thread pool for async delivery.  The small pool size
+# prevents runaway threads while still allowing several concurrent sends.
+_executor: ThreadPoolExecutor | None = None
+_MAX_WORKERS = 4
+
+
+def _get_executor() -> ThreadPoolExecutor:
+    """Return (and lazily create) the module-level thread pool."""
+    global _executor
+    if _executor is None:
+        _executor = ThreadPoolExecutor(max_workers=_MAX_WORKERS, thread_name_prefix="email")
+        atexit.register(_executor.shutdown, wait=False)
+    return _executor
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def render_template(template_path: str, context: dict) -> tuple[str, str]:
+    """Render an HTML + plain-text email template pair.
+
+    Args:
+        template_path: Path prefix relative to the templates root **without**
+            the extension.  For example ``"ctf/email/invitation"`` will render
+            ``ctf/email/invitation.html`` and ``ctf/email/invitation.txt``.
+        context: Template context dict for variable substitution.
+
+    Returns:
+        ``(html_content, text_content)`` tuple.
+    """
+    from django.template.loader import render_to_string
+
+    html_content = render_to_string(f"{template_path}.html", context)
+    text_content = render_to_string(f"{template_path}.txt", context)
+    return html_content, text_content
+
+
+def send_email(
+    recipient: str,
+    subject: str,
+    html_content: str,
+    text_content: str,
+) -> bool:
+    """Send a multipart email synchronously.
+
+    Failures are logged at ERROR level but never raised — the caller is
+    guaranteed not to crash due to email delivery issues.
+
+    Args:
+        recipient: Destination email address.
+        subject: Email subject line.
+        html_content: HTML body.
+        text_content: Plain-text body.
+
+    Returns:
+        ``True`` if the message was accepted for delivery, ``False`` otherwise.
+    """
+    from django.conf import settings
+    from django.core.mail import EmailMultiAlternatives
+
+    try:
+        msg = EmailMultiAlternatives(
+            subject=subject,
+            body=text_content,
+            from_email=getattr(settings, "DEFAULT_FROM_EMAIL", None),
+            to=[recipient],
+        )
+        msg.attach_alternative(html_content, "text/html")
+        msg.send()
+        return True
+    except Exception:
+        logger.exception("Failed to send email to %s", recipient)
+        return False
+
+
+def send_email_async(
+    recipient: str,
+    subject: str,
+    html_content: str,
+    text_content: str,
+) -> None:
+    """Dispatch email delivery to a background thread.
+
+    This is fire-and-forget — the calling thread returns immediately.
+    Delivery failures are logged but never propagated to the caller.
+
+    Args:
+        recipient: Destination email address.
+        subject: Email subject line.
+        html_content: HTML body.
+        text_content: Plain-text body.
+    """
+    _get_executor().submit(send_email, recipient, subject, html_content, text_content)

--- a/shifter/shifter_platform/shared/email.py
+++ b/shifter/shifter_platform/shared/email.py
@@ -66,6 +66,8 @@ def send_email(
     subject: str,
     html_content: str,
     text_content: str,
+    *,
+    from_email: str | None = None,
 ) -> bool:
     """Send a multipart email synchronously.
 
@@ -77,6 +79,7 @@ def send_email(
         subject: Email subject line.
         html_content: HTML body.
         text_content: Plain-text body.
+        from_email: Sender address.  Falls back to ``DEFAULT_FROM_EMAIL``.
 
     Returns:
         ``True`` if the message was accepted for delivery, ``False`` otherwise.
@@ -84,11 +87,13 @@ def send_email(
     from django.conf import settings
     from django.core.mail import EmailMultiAlternatives
 
+    sender = from_email or getattr(settings, "DEFAULT_FROM_EMAIL", None)
+
     try:
         msg = EmailMultiAlternatives(
             subject=subject,
             body=text_content,
-            from_email=getattr(settings, "DEFAULT_FROM_EMAIL", None),
+            from_email=sender,
             to=[recipient],
         )
         msg.attach_alternative(html_content, "text/html")
@@ -104,6 +109,8 @@ def send_email_async(
     subject: str,
     html_content: str,
     text_content: str,
+    *,
+    from_email: str | None = None,
 ) -> None:
     """Dispatch email delivery to a background thread.
 
@@ -115,5 +122,6 @@ def send_email_async(
         subject: Email subject line.
         html_content: HTML body.
         text_content: Plain-text body.
+        from_email: Sender address.  Falls back to ``DEFAULT_FROM_EMAIL``.
     """
-    _get_executor().submit(send_email, recipient, subject, html_content, text_content)
+    _get_executor().submit(send_email, recipient, subject, html_content, text_content, from_email=from_email)

--- a/shifter/shifter_platform/tests/shared/test_email.py
+++ b/shifter/shifter_platform/tests/shared/test_email.py
@@ -82,4 +82,4 @@ class TestSendEmailAsync:
         # Re-create executor for other tests
         email._executor = None
 
-        mock_send.assert_called_once_with("a@b.com", "Sub", "<h>", "t")
+        mock_send.assert_called_once_with("a@b.com", "Sub", "<h>", "t", from_email=None)

--- a/shifter/shifter_platform/tests/shared/test_email.py
+++ b/shifter/shifter_platform/tests/shared/test_email.py
@@ -1,0 +1,85 @@
+"""Tests for shared.email — platform email templating and delivery service."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from shared import email
+
+# ---------------------------------------------------------------------------
+# render_template
+# ---------------------------------------------------------------------------
+
+
+class TestRenderTemplate:
+    """Tests for render_template()."""
+
+    @patch("django.template.loader.render_to_string")
+    def test_renders_html_and_text(self, mock_render):
+        """Renders both .html and .txt templates."""
+        mock_render.side_effect = ["<html>Hello</html>", "Hello"]
+
+        html, text = email.render_template("ctf/email/invitation", {"key": "val"})
+
+        assert html == "<html>Hello</html>"
+        assert text == "Hello"
+        assert mock_render.call_count == 2
+        mock_render.assert_any_call("ctf/email/invitation.html", {"key": "val"})
+        mock_render.assert_any_call("ctf/email/invitation.txt", {"key": "val"})
+
+
+# ---------------------------------------------------------------------------
+# send_email
+# ---------------------------------------------------------------------------
+
+
+class TestSendEmail:
+    """Tests for send_email()."""
+
+    @patch("django.core.mail.EmailMultiAlternatives")
+    def test_send_success(self, mock_cls):
+        """Returns True on successful send."""
+        mock_msg = MagicMock()
+        mock_cls.return_value = mock_msg
+
+        result = email.send_email("a@b.com", "Subject", "<html>", "text")
+
+        assert result is True
+        mock_msg.attach_alternative.assert_called_once_with("<html>", "text/html")
+        mock_msg.send.assert_called_once()
+
+    @patch("django.core.mail.EmailMultiAlternatives")
+    def test_send_failure_returns_false(self, mock_cls):
+        """Returns False and logs on failure without raising."""
+        mock_msg = MagicMock()
+        mock_msg.send.side_effect = RuntimeError("SMTP down")
+        mock_cls.return_value = mock_msg
+
+        result = email.send_email("a@b.com", "Subject", "<html>", "text")
+
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# send_email_async
+# ---------------------------------------------------------------------------
+
+
+class TestSendEmailAsync:
+    """Tests for send_email_async()."""
+
+    @patch("shared.email.send_email")
+    def test_dispatches_to_thread(self, mock_send):
+        """Submits email to thread pool and returns immediately."""
+        mock_send.return_value = True
+
+        # Should not raise and should return None (fire-and-forget)
+        email.send_email_async("a@b.com", "Sub", "<h>", "t")
+
+        # Wait for the thread pool to finish
+        email._get_executor().shutdown(wait=True)
+
+        # Re-create executor for other tests
+        email._executor = None
+
+        mock_send.assert_called_once_with("a@b.com", "Sub", "<h>", "t")


### PR DESCRIPTION
## Summary
- Add `shared.email` module providing platform-wide email templating and delivery (PLAT-103)
- `render_template()` renders HTML+text template pairs with Django variable substitution
- `send_email()` sends multipart emails with error logging (never raises)
- `send_email_async()` dispatches delivery to a background thread pool (fire-and-forget)
- CTF notification service now delegates to the shared email service

Closes #937

## Test plan
- [x] 4 new tests for shared email service (render, send success, send failure, async dispatch)
- [x] All 2614 tests pass
- [x] Pre-commit hooks pass (ruff, mypy, bandit, architecture layer checks)
- [ ] Verify email delivery works end-to-end in dev environment