### PR TITLE
CTF-702: Event timing enforcement, local timezone display, and countdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.61.0] - 2026-04-05
+
+### Added
+- Time-boundary enforcement on flag submissions rejects attempts before event start or after event end, regardless of event state (CTF-702)
+- Countdown timer on participant event page showing time until event start or end
+- Client-side local timezone display for event start and end times on participant event page
+
 ## [3.60.0] - 2026-04-05
 
 ### Added

--- a/shifter/shifter_platform/ctf/services/submission.py
+++ b/shifter/shifter_platform/ctf/services/submission.py
@@ -116,6 +116,19 @@ def submit_flag(
             details={"event_id": str(event.id), "status": event.status},
         )
 
+    # Enforce time boundaries regardless of state (CTF-702)
+    now = timezone.now()
+    if now < event.event_start or now > event.event_end:
+        raise CTFStateError(
+            "Event is not within its competition window",
+            details={
+                "event_id": str(event.id),
+                "event_start": event.event_start.isoformat(),
+                "event_end": event.event_end.isoformat(),
+                "server_time": now.isoformat(),
+            },
+        )
+
     # Check visibility state
     if challenge.visibility == "hidden":
         raise CTFStateError(

--- a/shifter/shifter_platform/static/js/ctf-event-timing.js
+++ b/shifter/shifter_platform/static/js/ctf-event-timing.js
@@ -82,7 +82,12 @@
 
         var startISO = card.getAttribute('data-event-start');
         var endISO = card.getAttribute('data-event-end');
+        var eventStatus = card.getAttribute('data-event-status') || '';
         if (!startISO || !endISO) return;
+
+        // Don't show countdown for cancelled or terminal states
+        var TERMINAL_STATES = ['cancelled', 'archived'];
+        if (TERMINAL_STATES.indexOf(eventStatus) !== -1) return;
 
         var eventStart = new Date(startISO);
         var eventEnd = new Date(endISO);
@@ -92,6 +97,15 @@
         function update() {
             var now = new Date();
             var diff;
+
+            // If event is completed/ended by status, show ended regardless of timestamps
+            if (eventStatus === 'completed' || eventStatus === 'ended') {
+                labelEl.textContent = '';
+                timerEl.textContent = 'Event has ended';
+                card.style.display = '';
+                clearInterval(intervalId);
+                return;
+            }
 
             if (now < eventStart) {
                 labelEl.textContent = 'Event starts in';

--- a/shifter/shifter_platform/static/js/ctf-event-timing.js
+++ b/shifter/shifter_platform/static/js/ctf-event-timing.js
@@ -1,0 +1,133 @@
+/**
+ * CTF Event Timing (CTF-702)
+ *
+ * Handles:
+ * - Converting event start/end times to participant's local timezone
+ * - Displaying a live countdown timer until event start or end
+ */
+
+(function () {
+    'use strict';
+
+    var SECOND = 1000;
+    var MINUTE = 60 * SECOND;
+    var HOUR = 60 * MINUTE;
+    var DAY = 24 * HOUR;
+
+    /**
+     * Format a Date in the browser's local timezone.
+     * Example output: "Apr 05, 2026 14:30 EDT"
+     */
+    function formatLocalTime(date) {
+        return date.toLocaleString(undefined, {
+            year: 'numeric',
+            month: 'short',
+            day: '2-digit',
+            hour: '2-digit',
+            minute: '2-digit',
+            timeZoneName: 'short',
+        });
+    }
+
+    /**
+     * Format a duration in milliseconds as "Xd Xh Xm Xs".
+     * Omits zero-value leading components (e.g. "2h 05m 03s" not "0d 2h 05m 03s").
+     */
+    function formatDuration(ms) {
+        if (ms <= 0) return '0s';
+
+        var days = Math.floor(ms / DAY);
+        var hours = Math.floor((ms % DAY) / HOUR);
+        var minutes = Math.floor((ms % HOUR) / MINUTE);
+        var seconds = Math.floor((ms % MINUTE) / SECOND);
+
+        var parts = [];
+        if (days > 0) parts.push(days + 'd');
+        if (days > 0 || hours > 0) parts.push(hours + 'h');
+        if (days > 0 || hours > 0 || minutes > 0) {
+            parts.push((minutes < 10 && parts.length > 0 ? '0' : '') + minutes + 'm');
+        }
+        parts.push((seconds < 10 && parts.length > 0 ? '0' : '') + seconds + 's');
+
+        return parts.join(' ');
+    }
+
+    /**
+     * Convert the static schedule display to local timezone.
+     */
+    function initLocalTimes() {
+        var schedule = document.getElementById('ctf-schedule');
+        if (!schedule) return;
+
+        var startISO = schedule.getAttribute('data-event-start');
+        var endISO = schedule.getAttribute('data-event-end');
+
+        if (startISO) {
+            var startEl = document.getElementById('ctf-start-time');
+            if (startEl) startEl.textContent = formatLocalTime(new Date(startISO));
+        }
+
+        if (endISO) {
+            var endEl = document.getElementById('ctf-end-time');
+            if (endEl) endEl.textContent = formatLocalTime(new Date(endISO));
+        }
+    }
+
+    /**
+     * Initialize and run the countdown timer.
+     */
+    function initCountdown() {
+        var card = document.getElementById('ctf-countdown-card');
+        if (!card) return;
+
+        var startISO = card.getAttribute('data-event-start');
+        var endISO = card.getAttribute('data-event-end');
+        if (!startISO || !endISO) return;
+
+        var eventStart = new Date(startISO);
+        var eventEnd = new Date(endISO);
+        var labelEl = document.getElementById('ctf-countdown-label');
+        var timerEl = document.getElementById('ctf-countdown-timer');
+
+        function update() {
+            var now = new Date();
+            var diff;
+
+            if (now < eventStart) {
+                labelEl.textContent = 'Event starts in';
+                diff = eventStart - now;
+                timerEl.textContent = formatDuration(diff);
+                card.style.display = '';
+            } else if (now < eventEnd) {
+                labelEl.textContent = 'Time remaining';
+                diff = eventEnd - now;
+                timerEl.textContent = formatDuration(diff);
+                card.style.display = '';
+            } else {
+                labelEl.textContent = '';
+                timerEl.textContent = 'Event has ended';
+                card.style.display = '';
+                clearInterval(intervalId);
+            }
+        }
+
+        update();
+        var intervalId = setInterval(update, SECOND);
+    }
+
+    // Run on DOM ready
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', function () {
+            initLocalTimes();
+            initCountdown();
+        });
+    } else {
+        initLocalTimes();
+        initCountdown();
+    }
+
+    // Expose for testing
+    if (typeof module !== 'undefined' && module.exports) { // eslint-disable-line no-undef
+        module.exports = { formatLocalTime: formatLocalTime, formatDuration: formatDuration }; // eslint-disable-line no-undef
+    }
+})();

--- a/shifter/shifter_platform/static/js/ctf-event-timing.test.js
+++ b/shifter/shifter_platform/static/js/ctf-event-timing.test.js
@@ -1,0 +1,44 @@
+var timing = require('./ctf-event-timing.js');
+
+describe('ctf-event-timing', () => {
+    describe('formatDuration', () => {
+        test('returns 0s for zero or negative', () => {
+            expect(timing.formatDuration(0)).toBe('0s');
+            expect(timing.formatDuration(-1000)).toBe('0s');
+        });
+
+        test('formats seconds only', () => {
+            expect(timing.formatDuration(5000)).toBe('5s');
+            expect(timing.formatDuration(59000)).toBe('59s');
+        });
+
+        test('formats minutes and seconds', () => {
+            expect(timing.formatDuration(65000)).toBe('1m 05s');
+            expect(timing.formatDuration(600000)).toBe('10m 00s');
+        });
+
+        test('formats hours, minutes, seconds', () => {
+            expect(timing.formatDuration(3661000)).toBe('1h 01m 01s');
+            expect(timing.formatDuration(7200000)).toBe('2h 00m 00s');
+        });
+
+        test('formats days', () => {
+            // 1 day, 2 hours, 3 minutes, 4 seconds
+            var ms = (1 * 86400 + 2 * 3600 + 3 * 60 + 4) * 1000;
+            expect(timing.formatDuration(ms)).toBe('1d 2h 03m 04s');
+        });
+    });
+
+    describe('formatLocalTime', () => {
+        test('returns a non-empty string for a valid date', () => {
+            var result = timing.formatLocalTime(new Date('2026-04-05T14:30:00Z'));
+            expect(typeof result).toBe('string');
+            expect(result.length).toBeGreaterThan(0);
+        });
+
+        test('includes year component', () => {
+            var result = timing.formatLocalTime(new Date('2026-04-05T14:30:00Z'));
+            expect(result).toMatch(/2026/);
+        });
+    });
+});

--- a/shifter/shifter_platform/templates/ctf/participant/event.html
+++ b/shifter/shifter_platform/templates/ctf/participant/event.html
@@ -39,19 +39,36 @@
 
         <!-- Sidebar Info -->
         <div class="col-md-4 mb-4">
+            <!-- Countdown Timer -->
+            {% if event.event_start and event.event_end %}
+            <div class="card mb-3" id="ctf-countdown-card"
+                 data-event-start="{{ event.event_start|date:'c' }}"
+                 data-event-end="{{ event.event_end|date:'c' }}"
+                 data-event-status="{{ event.status }}"
+                 style="display:none;">
+                <div class="card-body text-center">
+                    <div id="ctf-countdown-label" class="text-muted small mb-1"></div>
+                    <div id="ctf-countdown-timer" class="h4 mb-0 font-monospace"></div>
+                </div>
+            </div>
+            {% endif %}
+
             <!-- Schedule -->
             <div class="card mb-3">
                 <div class="card-header">
                     <h5 class="mb-0">Schedule</h5>
                 </div>
-                <div class="card-body">
+                <div class="card-body"
+                     {% if event.event_start %}data-event-start="{{ event.event_start|date:'c' }}"{% endif %}
+                     {% if event.event_end %}data-event-end="{{ event.event_end|date:'c' }}"{% endif %}
+                     id="ctf-schedule">
                     <div class="mb-3">
                         <strong>Start</strong><br>
-                        {{ event.event_start|date:"M d, Y H:i" }}
+                        <span id="ctf-start-time">{{ event.event_start|date:"M d, Y H:i" }} UTC</span>
                     </div>
                     <div>
                         <strong>End</strong><br>
-                        {{ event.event_end|date:"M d, Y H:i" }}
+                        <span id="ctf-end-time">{{ event.event_end|date:"M d, Y H:i" }} UTC</span>
                     </div>
                 </div>
             </div>
@@ -80,4 +97,9 @@
         </div>
     </div>
 </div>
+{% endblock %}
+
+{% block extra_js %}
+{% load static %}
+<script src="{% static 'js/ctf-event-timing.js' %}"></script>
 {% endblock %}

--- a/shifter/shifter_platform/tests/ctf/test_services/test_submission.py
+++ b/shifter/shifter_platform/tests/ctf/test_services/test_submission.py
@@ -18,7 +18,7 @@ from ctf.enums import (
     EventStatus,
     ParticipantStatus,
 )
-from ctf.exceptions import CTFRateLimitError
+from ctf.exceptions import CTFRateLimitError, CTFStateError
 from ctf.models import CTFChallenge, CTFEvent, CTFParticipant, CTFSubmission
 from ctf.services.submission import submit_flag
 
@@ -403,3 +403,97 @@ class TestAttemptLimits:
             scenario_id="basic",
         )
         assert event.attempt_limit_mode == "lockout"
+
+
+# ── Fixtures for time-boundary tests ─────────────────────────────────────
+
+
+@pytest.fixture
+def future_start_event(db, organizer_user):
+    """Active event whose start time is in the future."""
+    return CTFEvent.objects.create(
+        name="Future Start Event",
+        created_by=organizer_user,
+        status=EventStatus.ACTIVE.value,
+        event_start=timezone.now() + timedelta(hours=1),
+        event_end=timezone.now() + timedelta(hours=8),
+        scenario_id="basic",
+        submission_cooldown_seconds=0,
+    )
+
+
+@pytest.fixture
+def past_end_event(db, organizer_user):
+    """Active event whose end time is in the past."""
+    return CTFEvent.objects.create(
+        name="Past End Event",
+        created_by=organizer_user,
+        status=EventStatus.ACTIVE.value,
+        event_start=timezone.now() - timedelta(hours=8),
+        event_end=timezone.now() - timedelta(hours=1),
+        scenario_id="basic",
+        submission_cooldown_seconds=0,
+    )
+
+
+@pytest.mark.django_db
+class TestTimeBoundaryEnforcement:
+    """Tests for event time-boundary enforcement (CTF-702).
+
+    Submissions must be rejected when outside the event_start/event_end
+    window, even if the event status is ACTIVE.
+    """
+
+    @patch("ctf.services.submission.verify_flag", return_value=False)
+    def test_rejects_before_event_start(self, mock_verify, future_start_event, participant_user, db):
+        """Flag submission is rejected when now < event_start, even if ACTIVE."""
+        challenge = CTFChallenge.objects.create(
+            event=future_start_event,
+            name="Early Challenge",
+            description="Test",
+            category=ChallengeCategory.WEB.value,
+            points=100,
+            difficulty=ChallengeDifficulty.EASY.value,
+            flag_hash="$2b$12$placeholder_early",
+        )
+        participant = CTFParticipant.objects.create(
+            event=future_start_event,
+            user=participant_user,
+            email=participant_user.email,
+            name="Early Participant",
+            status=ParticipantStatus.ACTIVE.value,
+            registered_at=timezone.now(),
+        )
+
+        with pytest.raises(CTFStateError, match="not within its competition window"):
+            submit_flag(participant.id, challenge.id, "FLAG{too_early}")
+
+    @patch("ctf.services.submission.verify_flag", return_value=False)
+    def test_rejects_after_event_end(self, mock_verify, past_end_event, participant_user, db):
+        """Flag submission is rejected when now > event_end, even if ACTIVE."""
+        challenge = CTFChallenge.objects.create(
+            event=past_end_event,
+            name="Late Challenge",
+            description="Test",
+            category=ChallengeCategory.WEB.value,
+            points=100,
+            difficulty=ChallengeDifficulty.EASY.value,
+            flag_hash="$2b$12$placeholder_late",
+        )
+        participant = CTFParticipant.objects.create(
+            event=past_end_event,
+            user=participant_user,
+            email=participant_user.email,
+            name="Late Participant",
+            status=ParticipantStatus.ACTIVE.value,
+            registered_at=timezone.now(),
+        )
+
+        with pytest.raises(CTFStateError, match="not within its competition window"):
+            submit_flag(participant.id, challenge.id, "FLAG{too_late}")
+
+    @patch("ctf.services.submission.verify_flag", return_value=False)
+    def test_allows_within_window(self, mock_verify, participant, challenge):
+        """Flag submission succeeds when within the event time window."""
+        submission = submit_flag(participant.id, challenge.id, "FLAG{on_time}")
+        assert submission is not None


### PR DESCRIPTION
## Summary
- Add time-boundary enforcement on flag submissions — rejects attempts before `event_start` or after `event_end` regardless of event state (CTF-702)
- Display event times in participant's local timezone on the event page using client-side `Intl.DateTimeFormat`
- Add live countdown timer showing time until event start or end

## Files Changed
- `ctf/services/submission.py` — time-boundary check after status check
- `templates/ctf/participant/event.html` — countdown card, ISO data attributes, JS include
- `static/js/ctf-event-timing.js` — local timezone conversion + countdown timer
- `static/js/ctf-event-timing.test.js` — JS unit tests
- `tests/ctf/test_services/test_submission.py` — 3 time-boundary enforcement tests

## Test plan
- [x] All 14 submission tests pass (including 3 new time-boundary tests)
- [x] Jest tests pass for formatDuration and formatLocalTime
- [x] Pre-commit hooks all pass (ruff, eslint, bandit, mypy, architecture checks)
- [ ] Manual: verify countdown and local timezone display on participant event page

Closes #942