### PR TITLE
PLAT-101: Enforce magic link expiration, configurable expiry, and rate limiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.62.0] - 2026-04-05
+
+### Added
+- Enforce magic link token expiration at login — expired tokens are now rejected (PLAT-101)
+- Configurable magic link expiration via `MAGIC_LINK_EXPIRY_HOURS` setting (default 24 hours)
+- Configurable single-use tokens via `MAGIC_LINK_SINGLE_USE` setting (default multi-use)
+- Rate limiting on invitation generation endpoints (50 per hour per organizer)
+
 ## [3.61.0] - 2026-04-05
 
 ### Added

--- a/shifter/shifter_platform/config/settings.py
+++ b/shifter/shifter_platform/config/settings.py
@@ -208,6 +208,10 @@ AUTHENTICATION_BACKENDS = [
     "django.contrib.auth.backends.ModelBackend",
 ]
 
+# Magic link authentication (PLAT-101)
+MAGIC_LINK_EXPIRY_HOURS = int(os.environ.get("MAGIC_LINK_EXPIRY_HOURS", "24"))
+MAGIC_LINK_SINGLE_USE = os.environ.get("MAGIC_LINK_SINGLE_USE", "false").lower() == "true"
+
 # Cognito OIDC settings - loaded from environment
 OIDC_RP_CLIENT_ID = os.environ.get("OIDC_RP_CLIENT_ID", "")
 OIDC_RP_CLIENT_SECRET = os.environ.get("OIDC_RP_CLIENT_SECRET", "")

--- a/shifter/shifter_platform/ctf/models.py
+++ b/shifter/shifter_platform/ctf/models.py
@@ -1230,7 +1230,10 @@ class CTFParticipant(CTFBaseModel):
             else:
                 from datetime import timedelta
 
-                self.invite_token_expires = timezone.now() + timedelta(days=7)
+                from django.conf import settings
+
+                hours = getattr(settings, "MAGIC_LINK_EXPIRY_HOURS", 24)
+                self.invite_token_expires = timezone.now() + timedelta(hours=hours)
         super().save(*args, **kwargs)
 
     def clean(self) -> None:

--- a/shifter/shifter_platform/ctf/models.py
+++ b/shifter/shifter_platform/ctf/models.py
@@ -1224,16 +1224,17 @@ class CTFParticipant(CTFBaseModel):
         if not self.invite_token:
             self.invite_token = secrets.token_urlsafe(32)
         if not self.invite_token_expires:
-            # Token valid through event end
+            from datetime import timedelta
+
+            from django.conf import settings
+
+            hours = getattr(settings, "MAGIC_LINK_EXPIRY_HOURS", 24)
+            config_expiry = timezone.now() + timedelta(hours=hours)
             if hasattr(self, "event") and self.event_id and self.event.event_end:
-                self.invite_token_expires = self.event.event_end
+                # Use the earlier of event end or configured expiry
+                self.invite_token_expires = min(self.event.event_end, config_expiry)
             else:
-                from datetime import timedelta
-
-                from django.conf import settings
-
-                hours = getattr(settings, "MAGIC_LINK_EXPIRY_HOURS", 24)
-                self.invite_token_expires = timezone.now() + timedelta(hours=hours)
+                self.invite_token_expires = config_expiry
         super().save(*args, **kwargs)
 
     def clean(self) -> None:

--- a/shifter/shifter_platform/ctf/services/participant.py
+++ b/shifter/shifter_platform/ctf/services/participant.py
@@ -403,9 +403,15 @@ def resend_invite(participant_id: UUID) -> CTFParticipant:
             details={"participant_id": str(participant_id)},
         ) from None
 
-    # Generate new token — valid through event end
+    # Generate new token — valid through min(event end, configured expiry)
+    from datetime import timedelta
+
+    from django.conf import settings
+
     now = timezone.now()
-    token_expires = participant.event.event_end
+    hours = getattr(settings, "MAGIC_LINK_EXPIRY_HOURS", 24)
+    config_expiry = now + timedelta(hours=hours)
+    token_expires = min(participant.event.event_end, config_expiry)
 
     participant.invite_token = secrets.token_urlsafe(32)
     participant.invite_token_expires = token_expires

--- a/shifter/shifter_platform/ctf/views.py
+++ b/shifter/shifter_platform/ctf/views.py
@@ -36,16 +36,22 @@ logger = logging.getLogger(__name__)
 def _check_invite_rate_limit(user_id: int, limit: int = 50, window: int = 3600) -> bool:
     """Return True if within rate limit for magic link generation.
 
-    Uses Django's cache to track invitations per user. Default: 50 per hour.
+    Uses Django's cache with a fixed-window counter. Default: 50 per hour.
+    Note: with the default LocMemCache, limits are per-process. For cross-worker
+    enforcement, configure a shared CACHES backend (e.g. Redis, Memcached).
     """
     from django.core.cache import cache
 
     key = f"invite_ratelimit:{user_id}"
-    count = cache.get(key, 0)
-    if count >= limit:
-        return False
-    cache.set(key, count + 1, timeout=window)
-    return True
+    # add() only sets if key doesn't exist — preserves the original TTL
+    cache.add(key, 0, timeout=window)
+    try:
+        count = cache.incr(key)
+    except ValueError:
+        # Key expired between add and incr — retry
+        cache.set(key, 1, timeout=window)
+        count = 1
+    return count <= limit
 
 
 def _get_user(request: HttpRequest) -> User:

--- a/shifter/shifter_platform/ctf/views.py
+++ b/shifter/shifter_platform/ctf/views.py
@@ -33,6 +33,21 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _check_invite_rate_limit(user_id: int, limit: int = 50, window: int = 3600) -> bool:
+    """Return True if within rate limit for magic link generation.
+
+    Uses Django's cache to track invitations per user. Default: 50 per hour.
+    """
+    from django.core.cache import cache
+
+    key = f"invite_ratelimit:{user_id}"
+    count = cache.get(key, 0)
+    if count >= limit:
+        return False
+    cache.set(key, count + 1, timeout=window)
+    return True
+
+
 def _get_user(request: HttpRequest) -> User:
     """Get authenticated user from request. Use only in @login_required views."""
     assert request.user.is_authenticated, "View must use @login_required"
@@ -171,7 +186,11 @@ def ctf_register(request: HttpRequest) -> HttpResponse:
     No login required. The invite token IS the authentication.
     Participants are auto-registered at add-time via _auto_register_participant(),
     so every valid token maps to a participant with a linked Django user.
+
+    Token expiration is enforced via is_invite_valid. When MAGIC_LINK_SINGLE_USE
+    is True, the token is cleared after the first successful login.
     """
+    from django.conf import settings
     from django.contrib.auth import login
 
     from ctf.models import CTFParticipant
@@ -184,7 +203,15 @@ def ctf_register(request: HttpRequest) -> HttpResponse:
     if not participant or not participant.user:
         return HttpResponse("Invalid invite token.", status=400)
 
+    if not participant.is_invite_valid:
+        return HttpResponse("Invite token has expired.", status=400)
+
     login(request, participant.user, backend="django.contrib.auth.backends.ModelBackend")
+
+    if getattr(settings, "MAGIC_LINK_SINGLE_USE", False):
+        participant.invite_token = ""  # nosec B105 — clearing token, not a password
+        participant.save(update_fields=["invite_token", "updated_at"])
+
     return redirect("mission_control:dashboard")
 
 
@@ -2769,6 +2796,9 @@ def api_participant_resend_invite(request: HttpRequest, participant_id: UUID) ->
     from ctf.exceptions import CTFNotFoundError, CTFStateError
     from ctf.services import get_participant, resend_invite
 
+    if not _check_invite_rate_limit(_get_user(request).pk):
+        return JsonResponse({"error": "Too many invitations. Try again later."}, status=429)
+
     try:
         participant = get_participant(participant_id)
     except CTFNotFoundError:
@@ -3309,6 +3339,9 @@ def api_send_invitations(request: HttpRequest, event_id: UUID) -> JsonResponse:
     from ctf.exceptions import CTFNotFoundError
     from ctf.services import get_event
     from ctf.services.notification import send_invitations
+
+    if not _check_invite_rate_limit(_get_user(request).pk):
+        return JsonResponse({"error": "Too many invitations. Try again later."}, status=429)
 
     try:
         event = get_event(event_id)

--- a/shifter/shifter_platform/tests/ctf/test_auth.py
+++ b/shifter/shifter_platform/tests/ctf/test_auth.py
@@ -766,6 +766,7 @@ class TestCTFRegisterView:
         mock_user = _make_mock_user(email="part@test.com")
         mock_participant = MagicMock()
         mock_participant.user = mock_user
+        mock_participant.is_invite_valid = True
         mock_objects.filter.return_value.select_related.return_value.first.return_value = mock_participant
 
         request = request_factory.get("/ctf/register/?token=valid-token")
@@ -778,12 +779,13 @@ class TestCTFRegisterView:
     @patch("django.contrib.auth.login")
     @patch("ctf.models.CTFParticipant.objects")
     def test_repeated_token_use_works(self, mock_objects, mock_login, request_factory):
-        """Using the same token again should log in the same user."""
+        """Using the same token again should log in the same user (multi-use default)."""
         from ctf.views import ctf_register
 
         mock_user = _make_mock_user(email="part@test.com")
         mock_participant = MagicMock()
         mock_participant.user = mock_user
+        mock_participant.is_invite_valid = True
         mock_objects.filter.return_value.select_related.return_value.first.return_value = mock_participant
 
         # First use
@@ -829,6 +831,78 @@ class TestCTFRegisterView:
         request = request_factory.get("/ctf/register/?token=invited-token")
         response = ctf_register(request)
         assert response.status_code == 400
+
+    @patch("django.contrib.auth.login")
+    @patch("ctf.models.CTFParticipant.objects")
+    def test_expired_token_rejected(self, mock_objects, mock_login, request_factory):
+        """Expired invite token should return 400."""
+        from ctf.views import ctf_register
+
+        mock_participant = MagicMock()
+        mock_participant.user = _make_mock_user(email="expired@test.com")
+        mock_participant.is_invite_valid = False
+        mock_objects.filter.return_value.select_related.return_value.first.return_value = mock_participant
+
+        request = request_factory.get("/ctf/register/?token=expired-token")
+        response = ctf_register(request)
+        assert response.status_code == 400
+        assert b"expired" in response.content.lower()
+        mock_login.assert_not_called()
+
+    @patch("django.contrib.auth.login")
+    @patch("ctf.models.CTFParticipant.objects")
+    def test_valid_token_checks_expiration(self, mock_objects, mock_login, request_factory):
+        """Valid token should pass the is_invite_valid check and log in."""
+        from ctf.views import ctf_register
+
+        mock_participant = MagicMock()
+        mock_participant.user = _make_mock_user(email="valid@test.com")
+        mock_participant.is_invite_valid = True
+        mock_objects.filter.return_value.select_related.return_value.first.return_value = mock_participant
+
+        request = request_factory.get("/ctf/register/?token=valid-token")
+        response = ctf_register(request)
+        assert response.status_code == 302
+        mock_login.assert_called_once()
+
+    @override_settings(MAGIC_LINK_SINGLE_USE=True)
+    @patch("django.contrib.auth.login")
+    @patch("ctf.models.CTFParticipant.objects")
+    def test_single_use_clears_token(self, mock_objects, mock_login, request_factory):
+        """When MAGIC_LINK_SINGLE_USE is True, token is cleared after login."""
+        from ctf.views import ctf_register
+
+        mock_participant = MagicMock()
+        mock_participant.user = _make_mock_user(email="single@test.com")
+        mock_participant.is_invite_valid = True
+        mock_objects.filter.return_value.select_related.return_value.first.return_value = mock_participant
+
+        request = request_factory.get("/ctf/register/?token=single-use-token")
+        response = ctf_register(request)
+        assert response.status_code == 302
+        mock_participant.save.assert_called_once()
+        assert mock_participant.invite_token == ""
+
+
+class TestInviteRateLimit:
+    """Test rate limiting on magic link generation endpoints (PLAT-101)."""
+
+    def test_rate_limit_allows_within_limit(self):
+        """Requests within limit should succeed."""
+        from ctf.views import _check_invite_rate_limit
+
+        with patch("django.core.cache.cache") as mock_cache:
+            mock_cache.get.return_value = 0
+            assert _check_invite_rate_limit(user_id=1, limit=50) is True
+            mock_cache.set.assert_called_once()
+
+    def test_rate_limit_blocks_over_limit(self):
+        """Requests over limit should be blocked."""
+        from ctf.views import _check_invite_rate_limit
+
+        with patch("django.core.cache.cache") as mock_cache:
+            mock_cache.get.return_value = 50
+            assert _check_invite_rate_limit(user_id=1, limit=50) is False
 
 
 # ---------------------------------------------------------------------------

--- a/shifter/shifter_platform/tests/ctf/test_auth.py
+++ b/shifter/shifter_platform/tests/ctf/test_auth.py
@@ -892,16 +892,15 @@ class TestInviteRateLimit:
         from ctf.views import _check_invite_rate_limit
 
         with patch("django.core.cache.cache") as mock_cache:
-            mock_cache.get.return_value = 0
+            mock_cache.incr.return_value = 1
             assert _check_invite_rate_limit(user_id=1, limit=50) is True
-            mock_cache.set.assert_called_once()
 
     def test_rate_limit_blocks_over_limit(self):
         """Requests over limit should be blocked."""
         from ctf.views import _check_invite_rate_limit
 
         with patch("django.core.cache.cache") as mock_cache:
-            mock_cache.get.return_value = 50
+            mock_cache.incr.return_value = 51
             assert _check_invite_rate_limit(user_id=1, limit=50) is False
 
 


### PR DESCRIPTION
## Summary
- Enforce token expiration at login — `ctf_register` now checks `is_invite_valid` before authenticating (PLAT-101)
- Add `MAGIC_LINK_EXPIRY_HOURS` setting (default 24h) for configurable token expiration
- Add `MAGIC_LINK_SINGLE_USE` setting (default `false`) for optional single-use tokens
- Rate-limit magic link generation (50/hour per organizer) on send and resend invitation endpoints

## Files Changed
- `ctf/views.py` — token expiration check, `_check_invite_rate_limit` helper, rate limiting on 2 endpoints
- `ctf/models.py` — configurable fallback expiration from `MAGIC_LINK_EXPIRY_HOURS`
- `config/settings.py` — new `MAGIC_LINK_EXPIRY_HOURS` and `MAGIC_LINK_SINGLE_USE` settings
- `tests/ctf/test_auth.py` — 5 new tests (expiration, reusability, single-use, rate limiting)

## Test plan
- [x] All 53 auth tests pass
- [x] Pre-commit hooks all pass (ruff, bandit, mypy, architecture checks)
- [ ] Manual: verify expired token returns 400, valid token still logs in

Closes #945