### PR TITLE
Point GC_BASE_URL at red-dragon

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -24,7 +24,7 @@
       "command": "node",
       "args": ["${GROUND_CONTROL_DIR}/mcp/ground-control/index.js"],
       "env": {
-        "GC_BASE_URL": "http://gc-dev:8000",
+        "GC_BASE_URL": "http://red-dragon:8000",
         "GH_REPO": "Brad-Edwards/shifter"
       }
     }


### PR DESCRIPTION
Cutover from gc-dev (EC2) to red-dragon (Hetzner). Data migrated; gc-dev pending decommission.