### PR TITLE
Apply RDS modifications immediately on dev; fail dev deploys with pending mods

### DIFF
--- a/.github/workflows/_quality.yml
+++ b/.github/workflows/_quality.yml
@@ -172,6 +172,24 @@ jobs:
           uv run ruff check .
           uv run ruff format --check .
 
+  check-rds-pending-modifications-lint:
+    permissions:
+      contents: read
+    name: Lint (check_rds_pending_modifications)
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+
+      - name: Lint Python
+        working-directory: scripts/check_rds_pending_modifications
+        run: |
+          uv sync --group dev
+          uv run ruff check .
+          uv run ruff format --check .
+
   k8s-lint:
     permissions:
       contents: read
@@ -524,6 +542,27 @@ jobs:
 
       - name: Run tests
         working-directory: scripts/check_layer_imports
+        run: uv run pytest tests/
+
+  check-rds-pending-modifications-tests:
+    permissions:
+      contents: read
+    name: Tests (check_rds_pending_modifications)
+    if: ${{ !inputs.skip_tests }}
+    needs: [check-rds-pending-modifications-lint]
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+
+      - name: Install dependencies
+        working-directory: scripts/check_rds_pending_modifications
+        run: uv sync --group dev
+
+      - name: Run tests
+        working-directory: scripts/check_rds_pending_modifications
         run: uv run pytest tests/
 
   adr-guard-tests:

--- a/.github/workflows/_shifter-platform.yml
+++ b/.github/workflows/_shifter-platform.yml
@@ -198,6 +198,19 @@ jobs:
 
           rm -f tfplan
       - run: terraform apply -auto-approve
+      - name: Verify RDS pending modifications applied (dev only)
+        # Dev opts into apply_immediately=true so any post-apply
+        # PendingModifiedValues means the deploy is incomplete. Prod
+        # deliberately keeps apply_immediately=false so RDS changes flow
+        # through the configured maintenance window — running the check
+        # there would fail every legitimate prod deploy.
+        # See scripts/check_rds_pending_modifications/check_rds_pending_modifications.py
+        # and dev/terraform.md "RDS Change Application".
+        if: inputs.is_dev
+        working-directory: platform/terraform/environments/${{ inputs.environment }}/portal
+        run: |
+          python3 "${GITHUB_WORKSPACE}/scripts/check_rds_pending_modifications/check_rds_pending_modifications.py" \
+            --tf-outputs-from .
       - name: Wait for Guacamole ECS services to stabilize
         env:
           ENV: ${{ inputs.environment }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,6 +78,13 @@ repos:
       - id: ruff-format
         name: ruff-format (check_layer_imports)
         files: ^scripts/check_layer_imports/
+      - id: ruff
+        name: ruff (check_rds_pending_modifications)
+        args: [--fix]
+        files: ^scripts/check_rds_pending_modifications/
+      - id: ruff-format
+        name: ruff-format (check_rds_pending_modifications)
+        files: ^scripts/check_rds_pending_modifications/
 
   # JavaScript/CSS linting
   - repo: local
@@ -373,6 +380,14 @@ repos:
           --cov-report=term-missing:skip-covered'
         language: system
         files: ^scripts/check_layer_imports/
+        pass_filenames: false
+
+      - id: pytest-check-rds-pending-modifications
+        name: pytest (check_rds_pending_modifications)
+        entry: >-
+          bash -c 'cd scripts/check_rds_pending_modifications && uv run pytest tests/ -q'
+        language: system
+        files: ^scripts/check_rds_pending_modifications/
         pass_filenames: false
 
   # Jest tests (JS)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Dev RDS class/storage/engine changes now apply during the deploy.** Both
+  the portal RDS module (`platform/terraform/modules/portal/rds/`) and the
+  Guacamole RDS module (`platform/terraform/modules/guacamole/`) now expose
+  an `apply_immediately` input. Dev environments set it to `true`; prod
+  keeps it `false` so prod RDS changes continue to land through the
+  configured maintenance window. The May 2026 `db.t3.small → db.m5.xlarge`
+  bump for `dev-portal-guacamole-db` was accepted by `terraform apply` but
+  queued in `PendingModifiedValues` for the maintenance window — the live
+  class never changed during the event (#1085). Note: `apply_immediately`
+  covers changes AWS can perform during the apply (class, storage, engine
+  version, dynamic parameter-group fields). Static parameter changes and
+  major version upgrades still require an explicit reboot.
+- **Post-apply RDS gate in CI (dev only).** A new check
+  (`scripts/check_rds_pending_modifications/`) runs after `terraform apply`
+  in the dev branch of `_shifter-platform.yml`. It reads the portal env's
+  Terraform outputs (every `*_db_instance_id` output), calls
+  `aws rds describe-db-instances`, and fails the deploy job if any managed
+  RDS instance still has non-empty `PendingModifiedValues`. A successful
+  apply that leaves pending mods is treated as an incomplete deploy. Prod
+  is exempt by design.
+
 ## [3.97.0] - 2026-05-07
 
 ### Changed

--- a/platform/terraform/environments/dev/portal/main.tf
+++ b/platform/terraform/environments/dev/portal/main.tf
@@ -112,6 +112,7 @@ module "rds" {
   backup_retention_days = var.db_backup_retention_days
   deletion_protection   = var.db_deletion_protection
   skip_final_snapshot   = var.db_skip_final_snapshot
+  apply_immediately     = var.db_apply_immediately
 
   # Phase 5: RDS Log Exports
   enable_log_exports = var.enable_rds_log_exports
@@ -610,6 +611,7 @@ module "guacamole" {
   db_backup_retention_days = var.guacamole_db_backup_retention_days
   db_deletion_protection   = var.guacamole_db_deletion_protection
   db_skip_final_snapshot   = var.guacamole_db_skip_final_snapshot
+  db_apply_immediately     = var.guacamole_db_apply_immediately
 
   # Autoscaling
   enable_autoscaling       = var.guacamole_enable_autoscaling

--- a/platform/terraform/environments/dev/portal/outputs.tf
+++ b/platform/terraform/environments/dev/portal/outputs.tf
@@ -38,6 +38,16 @@ output "private_route_table_id" {
 # RDS
 # ------------------------------------------------------------------------------
 
+output "db_instance_id" {
+  description = "DBInstanceIdentifier of the portal RDS instance (consumed by the post-apply pending-modifications check)"
+  value       = module.rds.db_instance_id
+}
+
+output "guacamole_db_instance_id" {
+  description = "DBInstanceIdentifier of the Guacamole RDS instance (consumed by the post-apply pending-modifications check)"
+  value       = module.guacamole.db_instance_id
+}
+
 output "db_instance_endpoint" {
   description = "Endpoint of the RDS instance"
   value       = module.rds.db_instance_endpoint

--- a/platform/terraform/environments/dev/portal/terraform.tfvars
+++ b/platform/terraform/environments/dev/portal/terraform.tfvars
@@ -34,6 +34,7 @@ db_multi_az              = true
 db_backup_retention_days = 1
 db_deletion_protection   = false
 db_skip_final_snapshot   = true
+db_apply_immediately     = true
 
 # ------------------------------------------------------------------------------
 # EC2
@@ -170,6 +171,7 @@ guacamole_db_multi_az              = false
 guacamole_db_backup_retention_days = 7
 guacamole_db_deletion_protection   = false
 guacamole_db_skip_final_snapshot   = true
+guacamole_db_apply_immediately     = true
 
 # Autoscaling (disabled for initial testing)
 guacamole_enable_autoscaling       = false

--- a/platform/terraform/environments/dev/portal/variables.tf
+++ b/platform/terraform/environments/dev/portal/variables.tf
@@ -97,6 +97,11 @@ variable "db_skip_final_snapshot" {
   type        = bool
 }
 
+variable "db_apply_immediately" {
+  description = "Apply portal RDS modifications during the deploy instead of queueing them for the maintenance window."
+  type        = bool
+}
+
 # ------------------------------------------------------------------------------
 # EC2
 # ------------------------------------------------------------------------------
@@ -451,6 +456,11 @@ variable "guacamole_db_deletion_protection" {
 
 variable "guacamole_db_skip_final_snapshot" {
   description = "Skip final snapshot for Guacamole RDS"
+  type        = bool
+}
+
+variable "guacamole_db_apply_immediately" {
+  description = "Apply Guacamole RDS modifications during the deploy instead of queueing them for the maintenance window."
   type        = bool
 }
 

--- a/platform/terraform/environments/prod/portal/main.tf
+++ b/platform/terraform/environments/prod/portal/main.tf
@@ -112,6 +112,7 @@ module "rds" {
   backup_retention_days = var.db_backup_retention_days
   deletion_protection   = var.db_deletion_protection
   skip_final_snapshot   = var.db_skip_final_snapshot
+  apply_immediately     = var.db_apply_immediately
 
   # Phase 5: RDS Log Exports
   enable_log_exports = var.enable_rds_log_exports
@@ -577,6 +578,7 @@ module "guacamole" {
   db_backup_retention_days = var.guacamole_db_backup_retention_days
   db_deletion_protection   = var.guacamole_db_deletion_protection
   db_skip_final_snapshot   = var.guacamole_db_skip_final_snapshot
+  db_apply_immediately     = var.guacamole_db_apply_immediately
 
   # Autoscaling
   enable_autoscaling       = var.guacamole_enable_autoscaling

--- a/platform/terraform/environments/prod/portal/outputs.tf
+++ b/platform/terraform/environments/prod/portal/outputs.tf
@@ -38,6 +38,16 @@ output "private_route_table_id" {
 # RDS
 # ------------------------------------------------------------------------------
 
+output "db_instance_id" {
+  description = "DBInstanceIdentifier of the portal RDS instance (consumed by the post-apply pending-modifications check)"
+  value       = module.rds.db_instance_id
+}
+
+output "guacamole_db_instance_id" {
+  description = "DBInstanceIdentifier of the Guacamole RDS instance (consumed by the post-apply pending-modifications check)"
+  value       = module.guacamole.db_instance_id
+}
+
 output "db_instance_endpoint" {
   description = "Endpoint of the RDS instance"
   value       = module.rds.db_instance_endpoint

--- a/platform/terraform/environments/prod/portal/terraform.tfvars
+++ b/platform/terraform/environments/prod/portal/terraform.tfvars
@@ -34,6 +34,7 @@ db_multi_az              = true
 db_backup_retention_days = 7
 db_deletion_protection   = true
 db_skip_final_snapshot   = false
+db_apply_immediately     = false
 
 # ------------------------------------------------------------------------------
 # EC2
@@ -151,6 +152,7 @@ guacamole_db_multi_az              = true
 guacamole_db_backup_retention_days = 14
 guacamole_db_deletion_protection   = true
 guacamole_db_skip_final_snapshot   = false
+guacamole_db_apply_immediately     = false
 
 # Autoscaling (disabled for initial testing)
 guacamole_enable_autoscaling       = false

--- a/platform/terraform/environments/prod/portal/variables.tf
+++ b/platform/terraform/environments/prod/portal/variables.tf
@@ -97,6 +97,11 @@ variable "db_skip_final_snapshot" {
   type        = bool
 }
 
+variable "db_apply_immediately" {
+  description = "Apply portal RDS modifications during the deploy instead of queueing them for the maintenance window."
+  type        = bool
+}
+
 # ------------------------------------------------------------------------------
 # EC2
 # ------------------------------------------------------------------------------
@@ -378,6 +383,11 @@ variable "guacamole_db_deletion_protection" {
 
 variable "guacamole_db_skip_final_snapshot" {
   description = "Skip final snapshot for Guacamole RDS"
+  type        = bool
+}
+
+variable "guacamole_db_apply_immediately" {
+  description = "Apply Guacamole RDS modifications during the deploy instead of queueing them for the maintenance window."
   type        = bool
 }
 

--- a/platform/terraform/modules/guacamole/outputs.tf
+++ b/platform/terraform/modules/guacamole/outputs.tf
@@ -54,6 +54,11 @@ output "rds_security_group_id" {
 # Database Outputs
 # ------------------------------------------------------------------------------
 
+output "db_instance_id" {
+  description = "DBInstanceIdentifier of the Guacamole RDS instance"
+  value       = aws_db_instance.guacamole.id
+}
+
 output "db_instance_address" {
   description = "Address of the Guacamole RDS instance"
   value       = aws_db_instance.guacamole.address

--- a/platform/terraform/modules/guacamole/rds.tf
+++ b/platform/terraform/modules/guacamole/rds.tf
@@ -134,6 +134,10 @@ resource "aws_db_instance" "guacamole" {
   # CloudWatch Log Exports
   enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"]
 
+  # Whether class/storage/parameter changes apply during the deploy or wait
+  # for the maintenance window. Set true in dev, false in prod.
+  apply_immediately = var.db_apply_immediately
+
   tags = merge(local.common_tags, {
     Name = "${var.name_prefix}-guacamole-db"
   })

--- a/platform/terraform/modules/guacamole/variables.tf
+++ b/platform/terraform/modules/guacamole/variables.tf
@@ -179,6 +179,11 @@ variable "db_skip_final_snapshot" {
   type        = bool
 }
 
+variable "db_apply_immediately" {
+  description = "Apply RDS modifications during the deploy instead of queueing them for the maintenance window. Required input — environments must choose explicitly."
+  type        = bool
+}
+
 # ------------------------------------------------------------------------------
 # Auto Scaling
 # ------------------------------------------------------------------------------

--- a/platform/terraform/modules/portal/rds/main.tf
+++ b/platform/terraform/modules/portal/rds/main.tf
@@ -144,6 +144,10 @@ resource "aws_db_instance" "this" {
   # CloudWatch Log Exports
   enabled_cloudwatch_logs_exports = var.enable_log_exports ? ["postgresql", "upgrade"] : []
 
+  # Whether class/storage/parameter changes apply during the deploy or wait
+  # for the maintenance window. Set true in dev, false in prod.
+  apply_immediately = var.apply_immediately
+
   tags = merge(var.tags, {
     Name   = "${var.name_prefix}-db"
     Module = "rds"

--- a/platform/terraform/modules/portal/rds/variables.tf
+++ b/platform/terraform/modules/portal/rds/variables.tf
@@ -81,6 +81,11 @@ variable "prevent_destroy" {
   default     = false
 }
 
+variable "apply_immediately" {
+  description = "Apply RDS modifications during the deploy instead of queueing them for the maintenance window. Required input — environments must choose explicitly."
+  type        = bool
+}
+
 # ------------------------------------------------------------------------------
 # Log Exports
 # ------------------------------------------------------------------------------

--- a/scripts/check_rds_pending_modifications/check_rds_pending_modifications.py
+++ b/scripts/check_rds_pending_modifications/check_rds_pending_modifications.py
@@ -48,9 +48,10 @@ import shutil
 import subprocess  # nosec B404 - aws CLI is the deploy-job interface
 import sys
 import time
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable, Iterable, TextIO
+from typing import TextIO
 
 
 @dataclass(frozen=True)
@@ -99,7 +100,7 @@ _TRANSITIONAL_STATUSES = frozenset(
     }
 )
 
-DEFAULT_MAX_ATTEMPTS = 20  # 20 × 30 s = 10 min — fits well under the CI cap.
+DEFAULT_MAX_ATTEMPTS = 20  # 20 x 30 s = 10 min — fits well under the CI cap.
 DEFAULT_POLL_INTERVAL = 30.0
 
 
@@ -134,9 +135,7 @@ def _default_aws_describe(instance_id: str) -> dict:
     if proc.returncode != 0:
         if "DBInstanceNotFound" in proc.stderr:
             return {"DBInstances": []}
-        raise RuntimeError(
-            f"aws rds describe-db-instances failed for {instance_id!r}: {proc.stderr.strip()}"
-        )
+        raise RuntimeError(f"aws rds describe-db-instances failed for {instance_id!r}: {proc.stderr.strip()}")
     return json.loads(proc.stdout)
 
 
@@ -157,9 +156,7 @@ def _filtered_pending(instance_payload: dict) -> dict:
     the `is_clean` check treat them uniformly.
     """
     pending = {
-        k: v
-        for k, v in (instance_payload.get("PendingModifiedValues") or {}).items()
-        if v not in (None, [], {}, "")
+        k: v for k, v in (instance_payload.get("PendingModifiedValues") or {}).items() if v not in (None, [], {}, "")
     }
     for group in instance_payload.get("DBParameterGroups") or []:
         status = group.get("ParameterApplyStatus")
@@ -212,9 +209,7 @@ def check_instance(
             break
         sleep(poll_interval)
 
-    status_msg = (
-        last_payload.get("DBInstanceStatus") if last_payload is not None else "unknown"
-    )
+    status_msg = last_payload.get("DBInstanceStatus") if last_payload is not None else "unknown"
     return InstanceCheck(
         instance_id=instance_id,
         pending=last_pending,
@@ -267,9 +262,7 @@ def _terraform_outputs_payload(working_dir: Path) -> dict:
         check=False,
     )
     if proc.returncode != 0:
-        raise RuntimeError(
-            f"terraform output -json failed in {working_dir}: {proc.stderr.strip()}"
-        )
+        raise RuntimeError(f"terraform output -json failed in {working_dir}: {proc.stderr.strip()}")
     return json.loads(proc.stdout)
 
 
@@ -284,8 +277,7 @@ def main(
     ids = [i for i in instance_ids if i]
     if not ids:
         out_stream.write(
-            "ERROR: no RDS instance IDs supplied. "
-            "Pass IDs as positional args or use --tf-outputs-from <dir>.\n"
+            "ERROR: no RDS instance IDs supplied. Pass IDs as positional args or use --tf-outputs-from <dir>.\n"
         )
         return 2
 

--- a/scripts/check_rds_pending_modifications/check_rds_pending_modifications.py
+++ b/scripts/check_rds_pending_modifications/check_rds_pending_modifications.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+"""Fail noisily if any RDS instance has unapplied pending modifications.
+
+After a Terraform apply, the AWS API will accept changes such as
+`instance_class`, `allocated_storage`, `engine_version`, or parameter-group
+membership but defer them into `PendingModifiedValues` if the underlying
+deploy did not request immediate application. The May 2026 Polaris guacamole
+flakiness was caused by exactly that — the `db.t3.small → db.m5.xlarge` bump
+was accepted by `terraform apply` and then queued for the maintenance window,
+so the live database stayed at the old class while the ops team believed the
+fix had landed.
+
+This check runs after `terraform apply` in the deploy job and fails the run
+if any of the named RDS instances still have non-empty `PendingModifiedValues`
+after the modify operation has had a reasonable chance to complete. A
+successful apply that leaves pending mods is an incomplete deploy.
+
+The `terraform apply` call returns when AWS *accepts* `ModifyDBInstance` —
+not when RDS reaches its final state. With `apply_immediately = true`, RDS
+typically transitions through `modifying` for some minutes while the change
+is being applied, with `PendingModifiedValues` still populated. We therefore
+poll: while `DBInstanceStatus` is non-terminal and pending values are present,
+wait. Once status is `available` the verdict is final — empty pending is a
+pass, non-empty pending is a fail (queued for maintenance window, or AWS is
+not accepting the change). We bound the poll so a stuck modify cannot hang CI.
+
+Usage from the workflow:
+
+    python3 scripts/check_rds_pending_modifications/check_rds_pending_modifications.py \
+        --tf-outputs-from <terraform-working-dir>
+
+    python3 scripts/check_rds_pending_modifications/check_rds_pending_modifications.py \
+        <db-instance-id> [<db-instance-id> ...]
+
+`--tf-outputs-from` runs `terraform output -json` in the given directory and
+extracts every output whose key ends with `db_instance_id`. Output is parsed
+in memory (it is not written to disk) so other Terraform output values, which
+may be marked sensitive, are not persisted alongside the IDs we actually use.
+
+Exit code 0 if every instance is clean, non-zero otherwise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess  # nosec B404 - aws CLI is the deploy-job interface
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Iterable, TextIO
+
+
+@dataclass(frozen=True)
+class InstanceCheck:
+    """Result of checking one RDS instance for pending modifications."""
+
+    instance_id: str
+    pending: dict = field(default_factory=dict)
+    error: str | None = None
+
+    @property
+    def is_clean(self) -> bool:
+        return self.error is None and not self.pending
+
+
+AwsDescribeFn = Callable[[str], dict]
+SleepFn = Callable[[float], None]
+
+# Fields in `PendingModifiedValues` whose VALUES carry secrets and must not be
+# echoed into CI logs. The presence of these keys is still useful signal — the
+# operator needs to know a master-password rotation is queued — so we report
+# the key but redact the value.
+_SECRET_PENDING_FIELDS = frozenset({"MasterUserPassword"})
+
+# DBInstanceStatus values that indicate AWS is still moving the instance to
+# its target state. While the status is one of these AND pending values are
+# present, we keep waiting; we do not fail. Sourced from the RDS DB Instance
+# Lifecycle docs. We intentionally treat unknown statuses as terminal — if AWS
+# adds a new transitional status we will surface it as a failure rather than
+# poll forever.
+_TRANSITIONAL_STATUSES = frozenset(
+    {
+        "creating",
+        "modifying",
+        "rebooting",
+        "backing-up",
+        "upgrading",
+        "configuring-enhanced-monitoring",
+        "configuring-iam-database-auth",
+        "configuring-log-exports",
+        "renaming",
+        "resetting-master-credentials",
+        "starting",
+        "storage-optimization",
+        "maintenance",
+    }
+)
+
+DEFAULT_MAX_ATTEMPTS = 20  # 20 × 30 s = 10 min — fits well under the CI cap.
+DEFAULT_POLL_INTERVAL = 30.0
+
+
+def _default_aws_describe(instance_id: str) -> dict:
+    """Call `aws rds describe-db-instances` and return the parsed JSON.
+
+    The AWS CLI is the contract used elsewhere in `_shifter-platform.yml`
+    (e.g. `aws ecs describe-services`); we keep that consistency so the
+    self-hosted runner does not need an additional Python AWS SDK install.
+    """
+    aws_bin = shutil.which("aws")
+    if aws_bin is None:
+        raise RuntimeError(
+            "aws CLI not found on PATH; this script is intended to run inside "
+            "the Terraform deploy job where AWS credentials are already configured."
+        )
+    proc = subprocess.run(  # nosec B603 - args list, no shell, fixed argv
+        [
+            aws_bin,
+            "rds",
+            "describe-db-instances",
+            "--db-instance-identifier",
+            instance_id,
+            "--no-cli-pager",
+            "--output",
+            "json",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        if "DBInstanceNotFound" in proc.stderr:
+            return {"DBInstances": []}
+        raise RuntimeError(
+            f"aws rds describe-db-instances failed for {instance_id!r}: {proc.stderr.strip()}"
+        )
+    return json.loads(proc.stdout)
+
+
+def _filtered_pending(instance_payload: dict) -> dict:
+    pending = instance_payload.get("PendingModifiedValues") or {}
+    return {k: v for k, v in pending.items() if v not in (None, [], {}, "")}
+
+
+def check_instance(
+    instance_id: str,
+    aws_describe: AwsDescribeFn = _default_aws_describe,
+    sleep: SleepFn = time.sleep,
+    max_attempts: int = DEFAULT_MAX_ATTEMPTS,
+    poll_interval: float = DEFAULT_POLL_INTERVAL,
+) -> InstanceCheck:
+    """Return an InstanceCheck describing whether `instance_id` has pending mods.
+
+    Polls AWS up to `max_attempts` times (sleeping `poll_interval` seconds
+    between attempts) while RDS reports a transitional `DBInstanceStatus` and
+    pending values are present. As soon as the status reaches a terminal value
+    or pending becomes empty, returns the verdict immediately. If the poll
+    budget is exhausted while the instance is still transitioning, returns a
+    failing InstanceCheck describing the timeout — that is treated as a real
+    deploy failure because operators need to investigate stuck modifies.
+    """
+    last_payload: dict | None = None
+    last_pending: dict = {}
+    for attempt in range(max(1, max_attempts)):
+        response = aws_describe(instance_id)
+        instances = response.get("DBInstances") or []
+        if not instances:
+            return InstanceCheck(
+                instance_id=instance_id,
+                error=f"RDS instance {instance_id!r} not found",
+            )
+        last_payload = instances[0]
+        last_pending = _filtered_pending(last_payload)
+        status = last_payload.get("DBInstanceStatus")
+
+        # Terminal verdict: either the instance settled (no pending values) or
+        # it left transitional states with pending values still queued.
+        if not last_pending:
+            return InstanceCheck(instance_id=instance_id, pending={})
+        if status not in _TRANSITIONAL_STATUSES:
+            return InstanceCheck(instance_id=instance_id, pending=last_pending)
+
+        is_last_attempt = attempt == max(1, max_attempts) - 1
+        if is_last_attempt:
+            break
+        sleep(poll_interval)
+
+    status_msg = (
+        last_payload.get("DBInstanceStatus") if last_payload is not None else "unknown"
+    )
+    return InstanceCheck(
+        instance_id=instance_id,
+        pending=last_pending,
+        error=(
+            f"RDS instance {instance_id!r} did not settle within "
+            f"{max_attempts * poll_interval:.0f}s (DBInstanceStatus={status_msg!r}); "
+            "pending modifications still present"
+        ),
+    )
+
+
+def collect_instance_ids_from_tf_outputs_payload(payload: dict) -> list[str]:
+    """Extract DB instance IDs from a parsed `terraform output -json` payload.
+
+    Returns the value of every output whose key equals or ends with
+    `db_instance_id`. Empty if no such outputs exist; the caller decides
+    whether that is an error.
+    """
+    ids: list[str] = []
+    for key, value in payload.items():
+        if not (key == "db_instance_id" or key.endswith("_db_instance_id")):
+            continue
+        raw = value.get("value") if isinstance(value, dict) else value
+        if isinstance(raw, str) and raw:
+            ids.append(raw)
+    return ids
+
+
+def collect_instance_ids_from_tf_outputs(outputs_path: Path) -> list[str]:
+    """Extract DB instance IDs from a `terraform output -json` JSON file."""
+    payload = json.loads(outputs_path.read_text(encoding="utf-8"))
+    return collect_instance_ids_from_tf_outputs_payload(payload)
+
+
+def _terraform_outputs_payload(working_dir: Path) -> dict:
+    """Run `terraform output -json` in `working_dir` and return the parsed dict.
+
+    The output is held in memory and never written to disk: Terraform's JSON
+    output may include outputs marked `sensitive`, and we have no need for
+    anything other than the DB instance IDs.
+    """
+    terraform_bin = shutil.which("terraform")
+    if terraform_bin is None:
+        raise RuntimeError("terraform CLI not found on PATH")
+    proc = subprocess.run(  # nosec B603 - args list, no shell, fixed argv
+        [terraform_bin, "output", "-json"],
+        capture_output=True,
+        text=True,
+        cwd=str(working_dir),
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"terraform output -json failed in {working_dir}: {proc.stderr.strip()}"
+        )
+    return json.loads(proc.stdout)
+
+
+def main(
+    instance_ids: Iterable[str],
+    aws_describe: AwsDescribeFn = _default_aws_describe,
+    out_stream: TextIO = sys.stdout,
+    sleep: SleepFn = time.sleep,
+    max_attempts: int = DEFAULT_MAX_ATTEMPTS,
+    poll_interval: float = DEFAULT_POLL_INTERVAL,
+) -> int:
+    ids = [i for i in instance_ids if i]
+    if not ids:
+        out_stream.write(
+            "ERROR: no RDS instance IDs supplied. "
+            "Pass IDs as positional args or use --tf-outputs-from <dir>.\n"
+        )
+        return 2
+
+    failures: list[InstanceCheck] = []
+    for instance_id in ids:
+        result = check_instance(
+            instance_id,
+            aws_describe=aws_describe,
+            sleep=sleep,
+            max_attempts=max_attempts,
+            poll_interval=poll_interval,
+        )
+        if result.is_clean:
+            out_stream.write(f"OK    {instance_id} — no pending modifications\n")
+            continue
+        failures.append(result)
+        if result.error:
+            out_stream.write(f"FAIL  {instance_id} — {result.error}\n")
+        else:
+            fields = ", ".join(
+                f"{k}=<redacted>" if k in _SECRET_PENDING_FIELDS else f"{k}={v!r}"
+                for k, v in sorted(result.pending.items())
+            )
+            out_stream.write(f"FAIL  {instance_id} — pending: {fields}\n")
+
+    if failures:
+        out_stream.write(
+            "\nOne or more RDS instances have unapplied changes after `terraform apply`.\n"
+            "This means the deploy is incomplete: AWS accepted the change but is\n"
+            "holding it for the maintenance window, or RDS did not finish the modify\n"
+            "within the bounded poll window. Either set the relevant module-level\n"
+            "`apply_immediately` input to `true` for this environment, or roll the\n"
+            "change forward through the configured maintenance window.\n"
+        )
+        return 1
+    return 0
+
+
+def _build_argv_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Fail if any named RDS instance has pending modifications.",
+    )
+    parser.add_argument(
+        "instance_ids",
+        nargs="*",
+        help="RDS DBInstanceIdentifier values to check",
+    )
+    parser.add_argument(
+        "--tf-outputs-from",
+        type=Path,
+        default=None,
+        help="Terraform working directory; runs `terraform output -json` and "
+        "uses every output whose key ends with `db_instance_id`.",
+    )
+    parser.add_argument(
+        "--max-attempts",
+        type=int,
+        default=DEFAULT_MAX_ATTEMPTS,
+        help=f"Maximum poll attempts per instance (default {DEFAULT_MAX_ATTEMPTS}).",
+    )
+    parser.add_argument(
+        "--poll-interval",
+        type=float,
+        default=DEFAULT_POLL_INTERVAL,
+        help=f"Seconds between poll attempts (default {DEFAULT_POLL_INTERVAL}).",
+    )
+    return parser
+
+
+def _entry() -> int:
+    parser = _build_argv_parser()
+    args = parser.parse_args()
+
+    ids: list[str] = list(args.instance_ids)
+    if args.tf_outputs_from is not None:
+        payload = _terraform_outputs_payload(args.tf_outputs_from)
+        ids.extend(collect_instance_ids_from_tf_outputs_payload(payload))
+
+    return main(
+        ids,
+        max_attempts=args.max_attempts,
+        poll_interval=args.poll_interval,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(_entry())

--- a/scripts/check_rds_pending_modifications/check_rds_pending_modifications.py
+++ b/scripts/check_rds_pending_modifications/check_rds_pending_modifications.py
@@ -140,9 +140,33 @@ def _default_aws_describe(instance_id: str) -> dict:
     return json.loads(proc.stdout)
 
 
+# Parameter-group apply states that mean the change is settled or in flight. Any
+# other state (pending-reboot, failed-to-apply, error, pending-database-upgrade,
+# removing) means a static parameter change was accepted but not yet applied —
+# the deploy is incomplete in the same sense as a populated PendingModifiedValues.
+_PARAMETER_GROUP_OK_STATUSES = frozenset({"in-sync", "applying"})
+
+
 def _filtered_pending(instance_payload: dict) -> dict:
-    pending = instance_payload.get("PendingModifiedValues") or {}
-    return {k: v for k, v in pending.items() if v not in (None, [], {}, "")}
+    """Build the pending-changes view for one DBInstance payload.
+
+    Combines two AWS surfaces: `PendingModifiedValues` for instance-level
+    fields (class, storage, engine version, dynamic params), and
+    `DBParameterGroups[].ParameterApplyStatus` for static parameter-group
+    fields. Both produce keys in the returned dict so downstream reporting and
+    the `is_clean` check treat them uniformly.
+    """
+    pending = {
+        k: v
+        for k, v in (instance_payload.get("PendingModifiedValues") or {}).items()
+        if v not in (None, [], {}, "")
+    }
+    for group in instance_payload.get("DBParameterGroups") or []:
+        status = group.get("ParameterApplyStatus")
+        if status and status not in _PARAMETER_GROUP_OK_STATUSES:
+            name = group.get("DBParameterGroupName") or "<unknown>"
+            pending[f"DBParameterGroup[{name}]"] = status
+    return pending
 
 
 def check_instance(

--- a/scripts/check_rds_pending_modifications/pyproject.toml
+++ b/scripts/check_rds_pending_modifications/pyproject.toml
@@ -23,7 +23,11 @@ exclude = [".venv", "__pycache__"]
 
 [tool.ruff.lint]
 select = ["E", "W", "F", "I", "B", "C4", "UP", "S", "T20", "SIM", "RUF"]
-ignore = ["S101", "T201"]  # T201: print allowed (CLI tool); S101 conflicts with pytest assert in tests
+# T201: print allowed (CLI tool).
+# S101: assert is the normal pytest idiom.
+# S603: subprocess.run is called with fixed-argv lists against the aws/terraform
+#   CLIs already on PATH inside the deploy job — no shell, no untrusted input.
+ignore = ["S101", "T201", "S603"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*.py" = ["S101", "S105", "S106"]

--- a/scripts/check_rds_pending_modifications/pyproject.toml
+++ b/scripts/check_rds_pending_modifications/pyproject.toml
@@ -1,0 +1,37 @@
+[project]
+name = "check-rds-pending-modifications"
+version = "0.1.0"
+description = "Post-apply gate that fails dev RDS deploys with unapplied PendingModifiedValues or pending-reboot parameter groups"
+requires-python = ">=3.12"
+dependencies = []
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.3",
+    "pytest-cov>=7.0.0",
+    "ruff>=0.14.10",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-q"
+
+[tool.ruff]
+target-version = "py312"
+line-length = 120
+exclude = [".venv", "__pycache__"]
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "B", "C4", "UP", "S", "T20", "SIM", "RUF"]
+ignore = ["S101", "T201"]  # T201: print allowed (CLI tool); S101 conflicts with pytest assert in tests
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = ["S101", "S105", "S106"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+
+[tool.bandit]
+exclude_dirs = [".venv", "tests"]
+skips = ["B101"]

--- a/scripts/check_rds_pending_modifications/test_check_rds_pending_modifications.py
+++ b/scripts/check_rds_pending_modifications/test_check_rds_pending_modifications.py
@@ -27,6 +27,7 @@ from check_rds_pending_modifications import (  # noqa: E402
 def _aws_response(
     pending_modified_values: dict | None = None,
     db_instance_status: str = "available",
+    parameter_groups: list[dict] | None = None,
 ) -> dict:
     return {
         "DBInstances": [
@@ -34,6 +35,14 @@ def _aws_response(
                 "DBInstanceIdentifier": "ignored",
                 "DBInstanceStatus": db_instance_status,
                 "PendingModifiedValues": pending_modified_values or {},
+                "DBParameterGroups": parameter_groups
+                if parameter_groups is not None
+                else [
+                    {
+                        "DBParameterGroupName": "default.postgres16",
+                        "ParameterApplyStatus": "in-sync",
+                    }
+                ],
             }
         ]
     }
@@ -228,6 +237,85 @@ def test_main_with_no_instance_ids_is_a_clear_error() -> None:
     """Calling main with an empty ID list is a misuse — should fail noisily."""
     rc = main([], aws_describe=mock.Mock(), out_stream=mock.Mock(), sleep=_no_sleep)
     assert rc != 0
+
+
+def test_pending_reboot_parameter_group_fails() -> None:
+    """A static parameter-group change settles into ParameterApplyStatus=pending-reboot.
+
+    This is NOT exposed via PendingModifiedValues — only via the per-DBInstance
+    DBParameterGroups list. The check must inspect both surfaces, otherwise the
+    documented contract ("post-apply check will surface that residual state")
+    is a lie and dev deploys will quietly leave static param changes unapplied.
+    """
+    aws = mock.Mock(
+        return_value=_aws_response(
+            pending_modified_values={},
+            parameter_groups=[
+                {
+                    "DBParameterGroupName": "shifter-dev-portal-pg16",
+                    "ParameterApplyStatus": "pending-reboot",
+                }
+            ],
+        )
+    )
+    result = check_instance("dev-portal-db", aws_describe=aws, sleep=_no_sleep)
+    assert result.is_clean is False
+    assert result.pending == {
+        "DBParameterGroup[shifter-dev-portal-pg16]": "pending-reboot"
+    }
+
+
+def test_parameter_group_in_sync_passes() -> None:
+    """`in-sync` parameter group is the steady state — no reason to fail."""
+    aws = mock.Mock(
+        return_value=_aws_response(
+            pending_modified_values={},
+            parameter_groups=[
+                {
+                    "DBParameterGroupName": "shifter-dev-portal-pg16",
+                    "ParameterApplyStatus": "in-sync",
+                }
+            ],
+        )
+    )
+    result = check_instance("dev-portal-db", aws_describe=aws, sleep=_no_sleep)
+    assert result.is_clean is True
+
+
+def test_parameter_group_applying_is_not_a_failure() -> None:
+    """`applying` is a transient mid-flight state; not a deploy-blocking signal."""
+    aws = mock.Mock(
+        return_value=_aws_response(
+            parameter_groups=[
+                {
+                    "DBParameterGroupName": "shifter-dev-portal-pg16",
+                    "ParameterApplyStatus": "applying",
+                }
+            ],
+        )
+    )
+    result = check_instance("dev-portal-db", aws_describe=aws, sleep=_no_sleep)
+    assert result.is_clean is True
+
+
+def test_parameter_group_failed_to_apply_fails() -> None:
+    """`failed-to-apply` is a hard failure state — surface it loudly."""
+    aws = mock.Mock(
+        return_value=_aws_response(
+            parameter_groups=[
+                {
+                    "DBParameterGroupName": "shifter-dev-portal-pg16",
+                    "ParameterApplyStatus": "failed-to-apply",
+                }
+            ],
+        )
+    )
+    result = check_instance("dev-portal-db", aws_describe=aws, sleep=_no_sleep)
+    assert result.is_clean is False
+    assert (
+        result.pending["DBParameterGroup[shifter-dev-portal-pg16]"]
+        == "failed-to-apply"
+    )
 
 
 def test_main_redacts_master_user_password_from_log_output() -> None:

--- a/scripts/check_rds_pending_modifications/test_check_rds_pending_modifications.py
+++ b/scripts/check_rds_pending_modifications/test_check_rds_pending_modifications.py
@@ -1,0 +1,260 @@
+"""Tests for check_rds_pending_modifications.py.
+
+Run from the repo root:
+    python3 -m pytest scripts/check_rds_pending_modifications/test_check_rds_pending_modifications.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from check_rds_pending_modifications import (  # noqa: E402
+    InstanceCheck,
+    check_instance,
+    collect_instance_ids_from_tf_outputs,
+    collect_instance_ids_from_tf_outputs_payload,
+    main,
+)
+
+
+def _aws_response(
+    pending_modified_values: dict | None = None,
+    db_instance_status: str = "available",
+) -> dict:
+    return {
+        "DBInstances": [
+            {
+                "DBInstanceIdentifier": "ignored",
+                "DBInstanceStatus": db_instance_status,
+                "PendingModifiedValues": pending_modified_values or {},
+            }
+        ]
+    }
+
+
+def _no_sleep(_: float) -> None:
+    return None
+
+
+def test_clean_instance_passes() -> None:
+    """An RDS instance with no pending modifications passes the check."""
+    aws = mock.Mock(return_value=_aws_response({}))
+    result = check_instance("dev-portal-db", aws_describe=aws, sleep=_no_sleep)
+    assert isinstance(result, InstanceCheck)
+    assert result.instance_id == "dev-portal-db"
+    assert result.pending == {}
+    assert result.is_clean is True
+    # First call already terminal; should not poll.
+    assert aws.call_count == 1
+
+
+def test_pending_class_change_on_terminal_status_fails() -> None:
+    """An available instance with a pending class change is reported as failing.
+
+    `available` is terminal, so we do not wait — the modify has either landed
+    or been queued for the maintenance window.
+    """
+    aws = mock.Mock(
+        return_value=_aws_response(
+            {"DBInstanceClass": "db.m5.xlarge"}, db_instance_status="available"
+        )
+    )
+    result = check_instance(
+        "dev-portal-guacamole-db", aws_describe=aws, sleep=_no_sleep
+    )
+    assert result.is_clean is False
+    assert result.pending == {"DBInstanceClass": "db.m5.xlarge"}
+    assert aws.call_count == 1
+
+
+def test_modifying_then_available_clears_to_pass() -> None:
+    """If the instance is mid-modify, we wait until it settles; clean = pass.
+
+    This is the core fix for the false-positive failure when `apply_immediately`
+    is true: `terraform apply` returns while RDS is still applying, so the
+    first describe call still shows pending. After the change lands, pending
+    clears and the gate passes.
+    """
+    sequence = [
+        _aws_response({"DBInstanceClass": "db.m5.xlarge"}, db_instance_status="modifying"),
+        _aws_response({"DBInstanceClass": "db.m5.xlarge"}, db_instance_status="modifying"),
+        _aws_response({}, db_instance_status="available"),
+    ]
+    aws = mock.Mock(side_effect=sequence)
+    sleep = mock.Mock()
+
+    result = check_instance(
+        "dev-portal-db",
+        aws_describe=aws,
+        sleep=sleep,
+        max_attempts=5,
+        poll_interval=1.0,
+    )
+
+    assert result.is_clean is True
+    assert aws.call_count == 3
+    # Slept twice (between attempts 1→2 and 2→3); the post-success attempt
+    # does not sleep.
+    assert sleep.call_count == 2
+
+
+def test_stuck_modifying_times_out_as_failure() -> None:
+    """If the instance never leaves the transitional state, fail with timeout."""
+    aws = mock.Mock(
+        return_value=_aws_response(
+            {"DBInstanceClass": "db.m5.xlarge"}, db_instance_status="modifying"
+        )
+    )
+
+    result = check_instance(
+        "dev-portal-db",
+        aws_describe=aws,
+        sleep=_no_sleep,
+        max_attempts=4,
+        poll_interval=0.0,
+    )
+
+    assert result.is_clean is False
+    assert result.error is not None
+    assert "did not settle" in result.error
+    assert aws.call_count == 4
+
+
+def test_multiple_pending_fields_all_reported() -> None:
+    """All pending fields surface, not just the first one."""
+    aws = mock.Mock(
+        return_value=_aws_response(
+            {
+                "DBInstanceClass": "db.m5.xlarge",
+                "AllocatedStorage": 100,
+                "EngineVersion": "16.3",
+            }
+        )
+    )
+    result = check_instance("dev-portal-db", aws_describe=aws, sleep=_no_sleep)
+    assert result.is_clean is False
+    assert set(result.pending.keys()) == {
+        "DBInstanceClass",
+        "AllocatedStorage",
+        "EngineVersion",
+    }
+
+
+def test_missing_instance_fails_clearly() -> None:
+    """If AWS returns no matching DBInstances, the check fails with a clear error."""
+    aws = mock.Mock(return_value={"DBInstances": []})
+    result = check_instance("does-not-exist", aws_describe=aws, sleep=_no_sleep)
+    assert result.is_clean is False
+    assert result.error is not None
+    assert "not found" in result.error.lower()
+
+
+def test_collect_instance_ids_from_tf_outputs_payload_picks_db_instance_id_keys() -> None:
+    """Helper extracts every db_instance_id-style output value, ignoring everything else."""
+    payload = {
+        "db_instance_id": {"value": "dev-portal-db", "type": "string"},
+        "guacamole_db_instance_id": {
+            "value": "dev-portal-guacamole-db",
+            "type": "string",
+        },
+        "db_instance_endpoint": {
+            "value": "dev-portal-db.xxxx.rds.amazonaws.com:5432",
+            "type": "string",
+        },
+        "vpc_id": {"value": "vpc-abc", "type": "string"},
+    }
+    ids = collect_instance_ids_from_tf_outputs_payload(payload)
+    assert sorted(ids) == sorted(["dev-portal-db", "dev-portal-guacamole-db"])
+
+
+def test_collect_instance_ids_from_tf_outputs_empty_when_none() -> None:
+    """No db_instance_id outputs → empty list (helper does not invent IDs)."""
+    payload = {"vpc_id": {"value": "vpc-abc"}}
+    assert collect_instance_ids_from_tf_outputs_payload(payload) == []
+
+
+def test_collect_instance_ids_from_tf_outputs_path_wrapper(tmp_path: Path) -> None:
+    """The Path wrapper preserves the in-memory parser's behavior."""
+    out_file = tmp_path / "outputs.json"
+    out_file.write_text(
+        json.dumps({"db_instance_id": {"value": "dev-portal-db", "type": "string"}})
+    )
+    assert collect_instance_ids_from_tf_outputs(out_file) == ["dev-portal-db"]
+
+
+def test_main_succeeds_when_all_instances_clean() -> None:
+    """End-to-end: every instance clean → exit 0."""
+    aws = mock.Mock(side_effect=[_aws_response({}), _aws_response({})])
+    rc = main(
+        ["dev-portal-db", "dev-portal-guacamole-db"],
+        aws_describe=aws,
+        out_stream=mock.Mock(),
+        sleep=_no_sleep,
+        max_attempts=1,
+    )
+    assert rc == 0
+
+
+def test_main_fails_when_any_instance_pending() -> None:
+    """End-to-end: one clean + one pending → non-zero exit. Both reported."""
+    out = mock.Mock()
+    aws = mock.Mock(
+        side_effect=[
+            _aws_response({}),
+            _aws_response({"DBInstanceClass": "db.m5.xlarge"}),
+        ]
+    )
+    rc = main(
+        ["dev-portal-db", "dev-portal-guacamole-db"],
+        aws_describe=aws,
+        out_stream=out,
+        sleep=_no_sleep,
+        max_attempts=1,
+    )
+    assert rc != 0
+    written = "\n".join(call.args[0] for call in out.write.call_args_list)
+    assert "dev-portal-guacamole-db" in written
+    assert "DBInstanceClass" in written
+
+
+def test_main_with_no_instance_ids_is_a_clear_error() -> None:
+    """Calling main with an empty ID list is a misuse — should fail noisily."""
+    rc = main([], aws_describe=mock.Mock(), out_stream=mock.Mock(), sleep=_no_sleep)
+    assert rc != 0
+
+
+def test_main_redacts_master_user_password_from_log_output() -> None:
+    """A pending master-password rotation must not echo the new password into logs.
+
+    AWS surfaces `MasterUserPassword` in `PendingModifiedValues` while a password
+    rotation is in flight (per the AWS RDS API reference). Anyone with read access
+    to the deploy job logs would otherwise get the plaintext credential.
+    """
+    out = mock.Mock()
+    aws = mock.Mock(
+        return_value=_aws_response(
+            {
+                "MasterUserPassword": "hunter2-very-secret",
+                "DBInstanceClass": "db.m5.xlarge",
+            }
+        )
+    )
+    rc = main(
+        ["dev-portal-db"],
+        aws_describe=aws,
+        out_stream=out,
+        sleep=_no_sleep,
+        max_attempts=1,
+    )
+    written = "\n".join(call.args[0] for call in out.write.call_args_list)
+    assert rc != 0
+    assert "hunter2-very-secret" not in written
+    assert "MasterUserPassword=<redacted>" in written
+    assert "DBInstanceClass" in written

--- a/scripts/check_rds_pending_modifications/tests/test_check_rds_pending_modifications.py
+++ b/scripts/check_rds_pending_modifications/tests/test_check_rds_pending_modifications.py
@@ -11,6 +11,8 @@ import sys
 from pathlib import Path
 from unittest import mock
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from check_rds_pending_modifications import (
@@ -225,78 +227,39 @@ def test_main_with_no_instance_ids_is_a_clear_error() -> None:
     assert rc != 0
 
 
-def test_pending_reboot_parameter_group_fails() -> None:
-    """A static parameter-group change settles into ParameterApplyStatus=pending-reboot.
-
-    This is NOT exposed via PendingModifiedValues — only via the per-DBInstance
-    DBParameterGroups list. The check must inspect both surfaces, otherwise the
-    documented contract ("post-apply check will surface that residual state")
-    is a lie and dev deploys will quietly leave static param changes unapplied.
-    """
+@pytest.mark.parametrize(
+    ("apply_status", "expected_clean"),
+    [
+        # Settled or in-flight states — not deploy-blocking.
+        ("in-sync", True),
+        ("applying", True),
+        # Failure states — must surface as deploy-blocking. Static parameter
+        # changes only show up here, never in PendingModifiedValues, so any
+        # gap in this set is a silent-incomplete-deploy bug
+        # (per the dev/terraform.md "RDS Change Application" contract).
+        ("pending-reboot", False),
+        ("failed-to-apply", False),
+        ("error", False),
+        ("pending-database-upgrade", False),
+        ("removing", False),
+    ],
+)
+def test_parameter_group_status_classification(apply_status: str, expected_clean: bool) -> None:
     aws = mock.Mock(
         return_value=_aws_response(
             pending_modified_values={},
             parameter_groups=[
                 {
                     "DBParameterGroupName": "shifter-dev-portal-pg16",
-                    "ParameterApplyStatus": "pending-reboot",
+                    "ParameterApplyStatus": apply_status,
                 }
             ],
         )
     )
     result = check_instance("dev-portal-db", aws_describe=aws, sleep=_no_sleep)
-    assert result.is_clean is False
-    assert result.pending == {"DBParameterGroup[shifter-dev-portal-pg16]": "pending-reboot"}
-
-
-def test_parameter_group_in_sync_passes() -> None:
-    """`in-sync` parameter group is the steady state — no reason to fail."""
-    aws = mock.Mock(
-        return_value=_aws_response(
-            pending_modified_values={},
-            parameter_groups=[
-                {
-                    "DBParameterGroupName": "shifter-dev-portal-pg16",
-                    "ParameterApplyStatus": "in-sync",
-                }
-            ],
-        )
-    )
-    result = check_instance("dev-portal-db", aws_describe=aws, sleep=_no_sleep)
-    assert result.is_clean is True
-
-
-def test_parameter_group_applying_is_not_a_failure() -> None:
-    """`applying` is a transient mid-flight state; not a deploy-blocking signal."""
-    aws = mock.Mock(
-        return_value=_aws_response(
-            parameter_groups=[
-                {
-                    "DBParameterGroupName": "shifter-dev-portal-pg16",
-                    "ParameterApplyStatus": "applying",
-                }
-            ],
-        )
-    )
-    result = check_instance("dev-portal-db", aws_describe=aws, sleep=_no_sleep)
-    assert result.is_clean is True
-
-
-def test_parameter_group_failed_to_apply_fails() -> None:
-    """`failed-to-apply` is a hard failure state — surface it loudly."""
-    aws = mock.Mock(
-        return_value=_aws_response(
-            parameter_groups=[
-                {
-                    "DBParameterGroupName": "shifter-dev-portal-pg16",
-                    "ParameterApplyStatus": "failed-to-apply",
-                }
-            ],
-        )
-    )
-    result = check_instance("dev-portal-db", aws_describe=aws, sleep=_no_sleep)
-    assert result.is_clean is False
-    assert result.pending["DBParameterGroup[shifter-dev-portal-pg16]"] == "failed-to-apply"
+    assert result.is_clean is expected_clean
+    if not expected_clean:
+        assert result.pending["DBParameterGroup[shifter-dev-portal-pg16]"] == apply_status
 
 
 def test_main_redacts_master_user_password_from_log_output() -> None:

--- a/scripts/check_rds_pending_modifications/tests/test_check_rds_pending_modifications.py
+++ b/scripts/check_rds_pending_modifications/tests/test_check_rds_pending_modifications.py
@@ -1,7 +1,7 @@
 """Tests for check_rds_pending_modifications.py.
 
-Run from the repo root:
-    python3 -m pytest scripts/check_rds_pending_modifications/test_check_rds_pending_modifications.py -v
+Run via the package's uv environment from the repo root:
+    cd scripts/check_rds_pending_modifications && uv run pytest tests/ -v
 """
 
 from __future__ import annotations
@@ -11,11 +11,9 @@ import sys
 from pathlib import Path
 from unittest import mock
 
-import pytest
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-sys.path.insert(0, str(Path(__file__).resolve().parent))
-
-from check_rds_pending_modifications import (  # noqa: E402
+from check_rds_pending_modifications import (
     InstanceCheck,
     check_instance,
     collect_instance_ids_from_tf_outputs,
@@ -70,14 +68,8 @@ def test_pending_class_change_on_terminal_status_fails() -> None:
     `available` is terminal, so we do not wait — the modify has either landed
     or been queued for the maintenance window.
     """
-    aws = mock.Mock(
-        return_value=_aws_response(
-            {"DBInstanceClass": "db.m5.xlarge"}, db_instance_status="available"
-        )
-    )
-    result = check_instance(
-        "dev-portal-guacamole-db", aws_describe=aws, sleep=_no_sleep
-    )
+    aws = mock.Mock(return_value=_aws_response({"DBInstanceClass": "db.m5.xlarge"}, db_instance_status="available"))
+    result = check_instance("dev-portal-guacamole-db", aws_describe=aws, sleep=_no_sleep)
     assert result.is_clean is False
     assert result.pending == {"DBInstanceClass": "db.m5.xlarge"}
     assert aws.call_count == 1
@@ -116,11 +108,7 @@ def test_modifying_then_available_clears_to_pass() -> None:
 
 def test_stuck_modifying_times_out_as_failure() -> None:
     """If the instance never leaves the transitional state, fail with timeout."""
-    aws = mock.Mock(
-        return_value=_aws_response(
-            {"DBInstanceClass": "db.m5.xlarge"}, db_instance_status="modifying"
-        )
-    )
+    aws = mock.Mock(return_value=_aws_response({"DBInstanceClass": "db.m5.xlarge"}, db_instance_status="modifying"))
 
     result = check_instance(
         "dev-portal-db",
@@ -192,9 +180,7 @@ def test_collect_instance_ids_from_tf_outputs_empty_when_none() -> None:
 def test_collect_instance_ids_from_tf_outputs_path_wrapper(tmp_path: Path) -> None:
     """The Path wrapper preserves the in-memory parser's behavior."""
     out_file = tmp_path / "outputs.json"
-    out_file.write_text(
-        json.dumps({"db_instance_id": {"value": "dev-portal-db", "type": "string"}})
-    )
+    out_file.write_text(json.dumps({"db_instance_id": {"value": "dev-portal-db", "type": "string"}}))
     assert collect_instance_ids_from_tf_outputs(out_file) == ["dev-portal-db"]
 
 
@@ -260,9 +246,7 @@ def test_pending_reboot_parameter_group_fails() -> None:
     )
     result = check_instance("dev-portal-db", aws_describe=aws, sleep=_no_sleep)
     assert result.is_clean is False
-    assert result.pending == {
-        "DBParameterGroup[shifter-dev-portal-pg16]": "pending-reboot"
-    }
+    assert result.pending == {"DBParameterGroup[shifter-dev-portal-pg16]": "pending-reboot"}
 
 
 def test_parameter_group_in_sync_passes() -> None:
@@ -312,10 +296,7 @@ def test_parameter_group_failed_to_apply_fails() -> None:
     )
     result = check_instance("dev-portal-db", aws_describe=aws, sleep=_no_sleep)
     assert result.is_clean is False
-    assert (
-        result.pending["DBParameterGroup[shifter-dev-portal-pg16]"]
-        == "failed-to-apply"
-    )
+    assert result.pending["DBParameterGroup[shifter-dev-portal-pg16]"] == "failed-to-apply"
 
 
 def test_main_redacts_master_user_password_from_log_output() -> None:

--- a/scripts/check_rds_pending_modifications/uv.lock
+++ b/scripts/check_rds_pending_modifications/uv.lock
@@ -1,0 +1,208 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "check-rds-pending-modifications"
+version = "0.1.0"
+source = { virtual = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-cov", specifier = ">=7.0.0" },
+    { name = "ruff", specifier = ">=0.14.10" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.13.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/e0/70553e3000e345daff267cec284ce4cbf3fc141b6da229ac52775b5428f1/coverage-7.13.5.tar.gz", hash = "sha256:c81f6515c4c40141f83f502b07bbfa5c240ba25bbe73da7b33f1e5b6120ff179", size = 915967, upload-time = "2026-03-17T10:33:18.341Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c3/a396306ba7db865bf96fc1fb3b7fd29bcbf3d829df642e77b13555163cd6/coverage-7.13.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:460cf0114c5016fa841214ff5564aa4864f11948da9440bc97e21ad1f4ba1e01", size = 219554, upload-time = "2026-03-17T10:30:42.208Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/16/a68a19e5384e93f811dccc51034b1fd0b865841c390e3c931dcc4699e035/coverage-7.13.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e223ce4b4ed47f065bfb123687686512e37629be25cc63728557ae7db261422", size = 219908, upload-time = "2026-03-17T10:30:43.906Z" },
+    { url = "https://files.pythonhosted.org/packages/29/72/20b917c6793af3a5ceb7fb9c50033f3ec7865f2911a1416b34a7cfa0813b/coverage-7.13.5-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:6e3370441f4513c6252bf042b9c36d22491142385049243253c7e48398a15a9f", size = 251419, upload-time = "2026-03-17T10:30:45.545Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/49/cd14b789536ac6a4778c453c6a2338bc0a2fb60c5a5a41b4008328b9acc1/coverage-7.13.5-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:03ccc709a17a1de074fb1d11f217342fb0d2b1582ed544f554fc9fc3f07e95f5", size = 254159, upload-time = "2026-03-17T10:30:47.204Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/00/7b0edcfe64e2ed4c0340dac14a52ad0f4c9bd0b8b5e531af7d55b703db7c/coverage-7.13.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3f4818d065964db3c1c66dc0fbdac5ac692ecbc875555e13374fdbe7eedb4376", size = 255270, upload-time = "2026-03-17T10:30:48.812Z" },
+    { url = "https://files.pythonhosted.org/packages/93/89/7ffc4ba0f5d0a55c1e84ea7cee39c9fc06af7b170513d83fbf3bbefce280/coverage-7.13.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:012d5319e66e9d5a218834642d6c35d265515a62f01157a45bcc036ecf947256", size = 257538, upload-time = "2026-03-17T10:30:50.77Z" },
+    { url = "https://files.pythonhosted.org/packages/81/bd/73ddf85f93f7e6fa83e77ccecb6162d9415c79007b4bc124008a4995e4a7/coverage-7.13.5-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8dd02af98971bdb956363e4827d34425cb3df19ee550ef92855b0acb9c7ce51c", size = 251821, upload-time = "2026-03-17T10:30:52.5Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/81/278aff4e8dec4926a0bcb9486320752811f543a3ce5b602cc7a29978d073/coverage-7.13.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f08fd75c50a760c7eb068ae823777268daaf16a80b918fa58eea888f8e3919f5", size = 253191, upload-time = "2026-03-17T10:30:54.543Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ee/fe1621488e2e0a58d7e94c4800f0d96f79671553488d401a612bebae324b/coverage-7.13.5-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:843ea8643cf967d1ac7e8ecd4bb00c99135adf4816c0c0593fdcc47b597fcf09", size = 251337, upload-time = "2026-03-17T10:30:56.663Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a6/f79fb37aa104b562207cc23cb5711ab6793608e246cae1e93f26b2236ed9/coverage-7.13.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:9d44d7aa963820b1b971dbecd90bfe5fe8f81cff79787eb6cca15750bd2f79b9", size = 255404, upload-time = "2026-03-17T10:30:58.427Z" },
+    { url = "https://files.pythonhosted.org/packages/75/f0/ed15262a58ec81ce457ceb717b7f78752a1713556b19081b76e90896e8d4/coverage-7.13.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7132bed4bd7b836200c591410ae7d97bf7ae8be6fc87d160b2bd881df929e7bf", size = 250903, upload-time = "2026-03-17T10:31:00.093Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/e9/9129958f20e7e9d4d56d51d42ccf708d15cac355ff4ac6e736e97a9393d2/coverage-7.13.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a698e363641b98843c517817db75373c83254781426e94ada3197cabbc2c919c", size = 252780, upload-time = "2026-03-17T10:31:01.916Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/d7/0ad9b15812d81272db94379fe4c6df8fd17781cc7671fdfa30c76ba5ff7b/coverage-7.13.5-cp312-cp312-win32.whl", hash = "sha256:bdba0a6b8812e8c7df002d908a9a2ea3c36e92611b5708633c50869e6d922fdf", size = 222093, upload-time = "2026-03-17T10:31:03.642Z" },
+    { url = "https://files.pythonhosted.org/packages/29/3d/821a9a5799fac2556bcf0bd37a70d1d11fa9e49784b6d22e92e8b2f85f18/coverage-7.13.5-cp312-cp312-win_amd64.whl", hash = "sha256:d2c87e0c473a10bffe991502eac389220533024c8082ec1ce849f4218dded810", size = 222900, upload-time = "2026-03-17T10:31:05.651Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/fa/2238c2ad08e35cf4f020ea721f717e09ec3152aea75d191a7faf3ef009a8/coverage-7.13.5-cp312-cp312-win_arm64.whl", hash = "sha256:bf69236a9a81bdca3bff53796237aab096cdbf8d78a66ad61e992d9dac7eb2de", size = 221515, upload-time = "2026-03-17T10:31:07.293Z" },
+    { url = "https://files.pythonhosted.org/packages/74/8c/74fedc9663dcf168b0a059d4ea756ecae4da77a489048f94b5f512a8d0b3/coverage-7.13.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5ec4af212df513e399cf11610cc27063f1586419e814755ab362e50a85ea69c1", size = 219576, upload-time = "2026-03-17T10:31:09.045Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/c9/44fb661c55062f0818a6ffd2685c67aa30816200d5f2817543717d4b92eb/coverage-7.13.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:941617e518602e2d64942c88ec8499f7fbd49d3f6c4327d3a71d43a1973032f3", size = 219942, upload-time = "2026-03-17T10:31:10.708Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/13/93419671cee82b780bab7ea96b67c8ef448f5f295f36bf5031154ec9a790/coverage-7.13.5-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:da305e9937617ee95c2e39d8ff9f040e0487cbf1ac174f777ed5eddd7a7c1f26", size = 250935, upload-time = "2026-03-17T10:31:12.392Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/68/1666e3a4462f8202d836920114fa7a5ee9275d1fa45366d336c551a162dd/coverage-7.13.5-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:78e696e1cc714e57e8b25760b33a8b1026b7048d270140d25dafe1b0a1ee05a3", size = 253541, upload-time = "2026-03-17T10:31:14.247Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/5e/3ee3b835647be646dcf3c65a7c6c18f87c27326a858f72ab22c12730773d/coverage-7.13.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:02ca0eed225b2ff301c474aeeeae27d26e2537942aa0f87491d3e147e784a82b", size = 254780, upload-time = "2026-03-17T10:31:16.193Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b3/cb5bd1a04cfcc49ede6cd8409d80bee17661167686741e041abc7ee1b9a9/coverage-7.13.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:04690832cbea4e4663d9149e05dba142546ca05cb1848816760e7f58285c970a", size = 256912, upload-time = "2026-03-17T10:31:17.89Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/66/c1dceb7b9714473800b075f5c8a84f4588f887a90eb8645282031676e242/coverage-7.13.5-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0590e44dd2745c696a778f7bab6aa95256de2cbc8b8cff4f7db8ff09813d6969", size = 251165, upload-time = "2026-03-17T10:31:19.605Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/62/5502b73b97aa2e53ea22a39cf8649ff44827bef76d90bf638777daa27a9d/coverage-7.13.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d7cfad2d6d81dd298ab6b89fe72c3b7b05ec7544bdda3b707ddaecff8d25c161", size = 252908, upload-time = "2026-03-17T10:31:21.312Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/37/7792c2d69854397ca77a55c4646e5897c467928b0e27f2d235d83b5d08c6/coverage-7.13.5-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:e092b9499de38ae0fbfbc603a74660eb6ff3e869e507b50d85a13b6db9863e15", size = 250873, upload-time = "2026-03-17T10:31:23.565Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/23/bc866fb6163be52a8a9e5d708ba0d3b1283c12158cefca0a8bbb6e247a43/coverage-7.13.5-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:48c39bc4a04d983a54a705a6389512883d4a3b9862991b3617d547940e9f52b1", size = 255030, upload-time = "2026-03-17T10:31:25.58Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/8b/ef67e1c222ef49860701d346b8bbb70881bef283bd5f6cbba68a39a086c7/coverage-7.13.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:2d3807015f138ffea1ed9afeeb8624fd781703f2858b62a8dd8da5a0994c57b6", size = 250694, upload-time = "2026-03-17T10:31:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/46/0d/866d1f74f0acddbb906db212e096dee77a8e2158ca5e6bb44729f9d93298/coverage-7.13.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ee2aa19e03161671ec964004fb74b2257805d9710bf14a5c704558b9d8dbaf17", size = 252469, upload-time = "2026-03-17T10:31:29.472Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/f5/be742fec31118f02ce42b21c6af187ad6a344fed546b56ca60caacc6a9a0/coverage-7.13.5-cp313-cp313-win32.whl", hash = "sha256:ce1998c0483007608c8382f4ff50164bfc5bd07a2246dd272aa4043b75e61e85", size = 222112, upload-time = "2026-03-17T10:31:31.526Z" },
+    { url = "https://files.pythonhosted.org/packages/66/40/7732d648ab9d069a46e686043241f01206348e2bbf128daea85be4d6414b/coverage-7.13.5-cp313-cp313-win_amd64.whl", hash = "sha256:631efb83f01569670a5e866ceb80fe483e7c159fac6f167e6571522636104a0b", size = 222923, upload-time = "2026-03-17T10:31:33.633Z" },
+    { url = "https://files.pythonhosted.org/packages/48/af/fea819c12a095781f6ccd504890aaddaf88b8fab263c4940e82c7b770124/coverage-7.13.5-cp313-cp313-win_arm64.whl", hash = "sha256:f4cd16206ad171cbc2470dbea9103cf9a7607d5fe8c242fdf1edf36174020664", size = 221540, upload-time = "2026-03-17T10:31:35.445Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d2/17879af479df7fbbd44bd528a31692a48f6b25055d16482fdf5cdb633805/coverage-7.13.5-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0428cbef5783ad91fe240f673cc1f76b25e74bbfe1a13115e4aa30d3f538162d", size = 220262, upload-time = "2026-03-17T10:31:37.184Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/4c/d20e554f988c8f91d6a02c5118f9abbbf73a8768a3048cb4962230d5743f/coverage-7.13.5-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e0b216a19534b2427cc201a26c25da4a48633f29a487c61258643e89d28200c0", size = 220617, upload-time = "2026-03-17T10:31:39.245Z" },
+    { url = "https://files.pythonhosted.org/packages/29/9c/f9f5277b95184f764b24e7231e166dfdb5780a46d408a2ac665969416d61/coverage-7.13.5-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:972a9cd27894afe4bc2b1480107054e062df08e671df7c2f18c205e805ccd806", size = 261912, upload-time = "2026-03-17T10:31:41.324Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/f6/7f1ab39393eeb50cfe4747ae8ef0e4fc564b989225aa1152e13a180d74f8/coverage-7.13.5-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4b59148601efcd2bac8c4dbf1f0ad6391693ccf7a74b8205781751637076aee3", size = 263987, upload-time = "2026-03-17T10:31:43.724Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/d7/62c084fb489ed9c6fbdf57e006752e7c516ea46fd690e5ed8b8617c7d52e/coverage-7.13.5-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:505d7083c8b0c87a8fa8c07370c285847c1f77739b22e299ad75a6af6c32c5c9", size = 266416, upload-time = "2026-03-17T10:31:45.769Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f6/df63d8660e1a0bff6125947afda112a0502736f470d62ca68b288ea762d8/coverage-7.13.5-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:60365289c3741e4db327e7baff2a4aaacf22f788e80fa4683393891b70a89fbd", size = 267558, upload-time = "2026-03-17T10:31:48.293Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/02/353ca81d36779bd108f6d384425f7139ac3c58c750dcfaafe5d0bee6436b/coverage-7.13.5-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1b88c69c8ef5d4b6fe7dea66d6636056a0f6a7527c440e890cf9259011f5e606", size = 261163, upload-time = "2026-03-17T10:31:50.125Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/16/2e79106d5749bcaf3aee6d309123548e3276517cd7851faa8da213bc61bf/coverage-7.13.5-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:5b13955d31d1633cf9376908089b7cebe7d15ddad7aeaabcbe969a595a97e95e", size = 263981, upload-time = "2026-03-17T10:31:51.961Z" },
+    { url = "https://files.pythonhosted.org/packages/29/c7/c29e0c59ffa6942030ae6f50b88ae49988e7e8da06de7ecdbf49c6d4feae/coverage-7.13.5-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:f70c9ab2595c56f81a89620e22899eea8b212a4041bd728ac6f4a28bf5d3ddd0", size = 261604, upload-time = "2026-03-17T10:31:53.872Z" },
+    { url = "https://files.pythonhosted.org/packages/40/48/097cdc3db342f34006a308ab41c3a7c11c3f0d84750d340f45d88a782e00/coverage-7.13.5-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:084b84a8c63e8d6fc7e3931b316a9bcafca1458d753c539db82d31ed20091a87", size = 265321, upload-time = "2026-03-17T10:31:55.997Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/1f/4994af354689e14fd03a75f8ec85a9a68d94e0188bbdab3fc1516b55e512/coverage-7.13.5-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ad14385487393e386e2ea988b09d62dd42c397662ac2dabc3832d71253eee479", size = 260502, upload-time = "2026-03-17T10:31:58.308Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c6/9bb9ef55903e628033560885f5c31aa227e46878118b63ab15dc7ba87797/coverage-7.13.5-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:7f2c47b36fe7709a6e83bfadf4eefb90bd25fbe4014d715224c4316f808e59a2", size = 262688, upload-time = "2026-03-17T10:32:00.141Z" },
+    { url = "https://files.pythonhosted.org/packages/14/4f/f5df9007e50b15e53e01edea486814783a7f019893733d9e4d6caad75557/coverage-7.13.5-cp313-cp313t-win32.whl", hash = "sha256:67e9bc5449801fad0e5dff329499fb090ba4c5800b86805c80617b4e29809b2a", size = 222788, upload-time = "2026-03-17T10:32:02.246Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/98/aa7fccaa97d0f3192bec013c4e6fd6d294a6ed44b640e6bb61f479e00ed5/coverage-7.13.5-cp313-cp313t-win_amd64.whl", hash = "sha256:da86cdcf10d2519e10cabb8ac2de03da1bcb6e4853790b7fbd48523332e3a819", size = 223851, upload-time = "2026-03-17T10:32:04.416Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/8b/e5c469f7352651e5f013198e9e21f97510b23de957dd06a84071683b4b60/coverage-7.13.5-cp313-cp313t-win_arm64.whl", hash = "sha256:0ecf12ecb326fe2c339d93fc131816f3a7367d223db37817208905c89bded911", size = 222104, upload-time = "2026-03-17T10:32:06.65Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/77/39703f0d1d4b478bfd30191d3c14f53caf596fac00efb3f8f6ee23646439/coverage-7.13.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fbabfaceaeb587e16f7008f7795cd80d20ec548dc7f94fbb0d4ec2e038ce563f", size = 219621, upload-time = "2026-03-17T10:32:08.589Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/3e/51dff36d99ae14639a133d9b164d63e628532e2974d8b1edb99dd1ebc733/coverage-7.13.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9bb2a28101a443669a423b665939381084412b81c3f8c0fcfbac57f4e30b5b8e", size = 219953, upload-time = "2026-03-17T10:32:10.507Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6c/1f1917b01eb647c2f2adc9962bd66c79eb978951cab61bdc1acab3290c07/coverage-7.13.5-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:bd3a2fbc1c6cccb3c5106140d87cc6a8715110373ef42b63cf5aea29df8c217a", size = 250992, upload-time = "2026-03-17T10:32:12.41Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e5/06b1f88f42a5a99df42ce61208bdec3bddb3d261412874280a19796fc09c/coverage-7.13.5-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6c36ddb64ed9d7e496028d1d00dfec3e428e0aabf4006583bb1839958d280510", size = 253503, upload-time = "2026-03-17T10:32:14.449Z" },
+    { url = "https://files.pythonhosted.org/packages/80/28/2a148a51e5907e504fa7b85490277734e6771d8844ebcc48764a15e28155/coverage-7.13.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:380e8e9084d8eb38db3a9176a1a4f3c0082c3806fa0dc882d1d87abc3c789247", size = 254852, upload-time = "2026-03-17T10:32:16.56Z" },
+    { url = "https://files.pythonhosted.org/packages/61/77/50e8d3d85cc0b7ebe09f30f151d670e302c7ff4a1bf6243f71dd8b0981fa/coverage-7.13.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e808af52a0513762df4d945ea164a24b37f2f518cbe97e03deaa0ee66139b4d6", size = 257161, upload-time = "2026-03-17T10:32:19.004Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/c4/b5fd1d4b7bf8d0e75d997afd3925c59ba629fc8616f1b3aae7605132e256/coverage-7.13.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e301d30dd7e95ae068671d746ba8c34e945a82682e62918e41b2679acd2051a0", size = 251021, upload-time = "2026-03-17T10:32:21.344Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/66/6ea21f910e92d69ef0b1c3346ea5922a51bad4446c9126db2ae96ee24c4c/coverage-7.13.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:800bc829053c80d240a687ceeb927a94fd108bbdc68dfbe505d0d75ab578a882", size = 252858, upload-time = "2026-03-17T10:32:23.506Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ea/879c83cb5d61aa2a35fb80e72715e92672daef8191b84911a643f533840c/coverage-7.13.5-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:0b67af5492adb31940ee418a5a655c28e48165da5afab8c7fa6fd72a142f8740", size = 250823, upload-time = "2026-03-17T10:32:25.516Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/fb/616d95d3adb88b9803b275580bdeee8bd1b69a886d057652521f83d7322f/coverage-7.13.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:c9136ff29c3a91e25b1d1552b5308e53a1e0653a23e53b6366d7c2dcbbaf8a16", size = 255099, upload-time = "2026-03-17T10:32:27.944Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/93/25e6917c90ec1c9a56b0b26f6cad6408e5f13bb6b35d484a0d75c9cf000d/coverage-7.13.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:cff784eef7f0b8f6cb28804fbddcfa99f89efe4cc35fb5627e3ac58f91ed3ac0", size = 250638, upload-time = "2026-03-17T10:32:29.914Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/7b/dc1776b0464145a929deed214aef9fb1493f159b59ff3c7eeeedf91eddd0/coverage-7.13.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:68a4953be99b17ac3c23b6efbc8a38330d99680c9458927491d18700ef23ded0", size = 252295, upload-time = "2026-03-17T10:32:31.981Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/fb/99cbbc56a26e07762a2740713f3c8f9f3f3106e3a3dd8cc4474954bccd34/coverage-7.13.5-cp314-cp314-win32.whl", hash = "sha256:35a31f2b1578185fbe6aa2e74cea1b1d0bbf4c552774247d9160d29b80ed56cc", size = 222360, upload-time = "2026-03-17T10:32:34.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/b7/4758d4f73fb536347cc5e4ad63662f9d60ba9118cb6785e9616b2ce5d7fa/coverage-7.13.5-cp314-cp314-win_amd64.whl", hash = "sha256:2aa055ae1857258f9e0045be26a6d62bdb47a72448b62d7b55f4820f361a2633", size = 223174, upload-time = "2026-03-17T10:32:36.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/f2/24d84e1dfe70f8ac9fdf30d338239860d0d1d5da0bda528959d0ebc9da28/coverage-7.13.5-cp314-cp314-win_arm64.whl", hash = "sha256:1b11eef33edeae9d142f9b4358edb76273b3bfd30bc3df9a4f95d0e49caf94e8", size = 221739, upload-time = "2026-03-17T10:32:38.736Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5b/4a168591057b3668c2428bff25dd3ebc21b629d666d90bcdfa0217940e84/coverage-7.13.5-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:10a0c37f0b646eaff7cce1874c31d1f1ccb297688d4c747291f4f4c70741cc8b", size = 220351, upload-time = "2026-03-17T10:32:41.196Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/21/1fd5c4dbfe4a58b6b99649125635df46decdfd4a784c3cd6d410d303e370/coverage-7.13.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b5db73ba3c41c7008037fa731ad5459fc3944cb7452fc0aa9f822ad3533c583c", size = 220612, upload-time = "2026-03-17T10:32:43.204Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/fe/2a924b3055a5e7e4512655a9d4609781b0d62334fa0140c3e742926834e2/coverage-7.13.5-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:750db93a81e3e5a9831b534be7b1229df848b2e125a604fe6651e48aa070e5f9", size = 261985, upload-time = "2026-03-17T10:32:45.514Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/c8928f2bd518c45990fe1a2ab8db42e914ef9b726c975facc4282578c3eb/coverage-7.13.5-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9ddb4f4a5479f2539644be484da179b653273bca1a323947d48ab107b3ed1f29", size = 264107, upload-time = "2026-03-17T10:32:47.971Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/ae/4ae35bbd9a0af9d820362751f0766582833c211224b38665c0f8de3d487f/coverage-7.13.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d8a7a2049c14f413163e2bdabd37e41179b1d1ccb10ffc6ccc4b7a718429c607", size = 266513, upload-time = "2026-03-17T10:32:50.1Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/20/d326174c55af36f74eac6ae781612d9492f060ce8244b570bb9d50d9d609/coverage-7.13.5-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1c85e0b6c05c592ea6d8768a66a254bfb3874b53774b12d4c89c481eb78cb90", size = 267650, upload-time = "2026-03-17T10:32:52.391Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/5e/31484d62cbd0eabd3412e30d74386ece4a0837d4f6c3040a653878bfc019/coverage-7.13.5-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:777c4d1eff1b67876139d24288aaf1817f6c03d6bae9c5cc8d27b83bcfe38fe3", size = 261089, upload-time = "2026-03-17T10:32:54.544Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d8/49a72d6de146eebb0b7e48cc0f4bc2c0dd858e3d4790ab2b39a2872b62bd/coverage-7.13.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6697e29b93707167687543480a40f0db8f356e86d9f67ddf2e37e2dfd91a9dab", size = 263982, upload-time = "2026-03-17T10:32:56.803Z" },
+    { url = "https://files.pythonhosted.org/packages/06/3b/0351f1bd566e6e4dd39e978efe7958bde1d32f879e85589de147654f57bb/coverage-7.13.5-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:8fdf453a942c3e4d99bd80088141c4c6960bb232c409d9c3558e2dbaa3998562", size = 261579, upload-time = "2026-03-17T10:32:59.466Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ce/796a2a2f4017f554d7810f5c573449b35b1e46788424a548d4d19201b222/coverage-7.13.5-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:32ca0c0114c9834a43f045a87dcebd69d108d8ffb666957ea65aa132f50332e2", size = 265316, upload-time = "2026-03-17T10:33:01.847Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/16/d5ae91455541d1a78bc90abf495be600588aff8f6db5c8b0dae739fa39c9/coverage-7.13.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:8769751c10f339021e2638cd354e13adeac54004d1941119b2c96fe5276d45ea", size = 260427, upload-time = "2026-03-17T10:33:03.945Z" },
+    { url = "https://files.pythonhosted.org/packages/48/11/07f413dba62db21fb3fad5d0de013a50e073cc4e2dc4306e770360f6dfc8/coverage-7.13.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cec2d83125531bd153175354055cdb7a09987af08a9430bd173c937c6d0fba2a", size = 262745, upload-time = "2026-03-17T10:33:06.285Z" },
+    { url = "https://files.pythonhosted.org/packages/91/15/d792371332eb4663115becf4bad47e047d16234b1aff687b1b18c58d60ae/coverage-7.13.5-cp314-cp314t-win32.whl", hash = "sha256:0cd9ed7a8b181775459296e402ca4fb27db1279740a24e93b3b41942ebe4b215", size = 223146, upload-time = "2026-03-17T10:33:08.756Z" },
+    { url = "https://files.pythonhosted.org/packages/db/51/37221f59a111dca5e85be7dbf09696323b5b9f13ff65e0641d535ed06ea8/coverage-7.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:301e3b7dfefecaca37c9f1aa6f0049b7d4ab8dd933742b607765d757aca77d43", size = 224254, upload-time = "2026-03-17T10:33:11.174Z" },
+    { url = "https://files.pythonhosted.org/packages/54/83/6acacc889de8987441aa7d5adfbdbf33d288dad28704a67e574f1df9bcbb/coverage-7.13.5-cp314-cp314t-win_arm64.whl", hash = "sha256:9dacc2ad679b292709e0f5fc1ac74a6d4d5562e424058962c7bb0c658ad25e45", size = 222276, upload-time = "2026-03-17T10:33:13.466Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ee/a4cf96b8ce1e566ed238f0659ac2d3f007ed1d14b181bcb684e19561a69a/coverage-7.13.5-py3-none-any.whl", hash = "sha256:34b02417cf070e173989b3db962f7ed56d2f644307b2cf9d5a0f258e13084a61", size = 211346, upload-time = "2026-03-17T10:33:15.691Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852, upload-time = "2026-04-24T18:17:14.305Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713, upload-time = "2026-04-24T18:17:22.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c", size = 11069267, upload-time = "2026-04-24T18:17:30.105Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5", size = 10397182, upload-time = "2026-04-24T18:17:07.177Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/3310fc6d1b5e1fdea22bf3b1b807c7e187b581021b0d7d4514cccdb5fb71/ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002", size = 10758012, upload-time = "2026-04-24T18:16:55.759Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c1/a606911aee04c324ddaa883ae418f3569792fd3c4a10c50e0dd0a2311e1e/ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5", size = 10447479, upload-time = "2026-04-24T18:16:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/68/4201e8444f0894f21ab4aeeaee68aa4f10b51613514a20d80bd628d57e88/ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6", size = 11234040, upload-time = "2026-04-24T18:17:16.529Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ff/8a6d6cf4ccc23fd67060874e832c18919d1557a0611ebef03fdb01fff11e/ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33", size = 12087377, upload-time = "2026-04-24T18:17:04.944Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f6/c669cf73f5152f623d34e69866a46d5e6185816b19fcd5b6dd8a2d299922/ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847", size = 11367784, upload-time = "2026-04-24T18:17:25.409Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088, upload-time = "2026-04-24T18:17:12.258Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/8d/49afab3645e31e12c590acb6d3b5b69d7aab5b81926dbaf7461f9441f37a/ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339", size = 11271770, upload-time = "2026-04-24T18:17:02.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/06/33f41fe94403e2b755481cdfb9b7ef3e4e0ed031c4581124658d935d52b4/ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5", size = 10719355, upload-time = "2026-04-24T18:17:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/59/18aa4e014debbf559670e4048e39260a85c7fcee84acfd761ac01e7b8d35/ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd", size = 10462758, upload-time = "2026-04-24T18:17:32.347Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e7/cc9f16fd0f3b5fddcbd7ec3d6ae30c8f3fde1047f32a4093a98d633c6570/ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b", size = 10953498, upload-time = "2026-04-24T18:17:20.674Z" },
+    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765, upload-time = "2026-04-24T18:17:09.755Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
+]

--- a/shifter/shifter_platform/documentation/docs/technical/dev/adr-enforcement.md
+++ b/shifter/shifter_platform/documentation/docs/technical/dev/adr-enforcement.md
@@ -112,6 +112,15 @@ The first slice intentionally stays small:
   Architecture check ensuring namespace manifests carry Pod Security Standards
   `pod-security.kubernetes.io/enforce` labels. Enforces ADR-006-R1.
 
+- `rds-pending-modifications`
+  Post-`terraform apply` gate in `_shifter-platform.yml`. Reads the portal
+  Terraform outputs, then calls `aws rds describe-db-instances` for each
+  `*_db_instance_id` output and fails the deploy job if any RDS instance
+  still has non-empty `PendingModifiedValues`. Catches the failure mode
+  documented in `dev/terraform.md` ("RDS Change Application") where a
+  successful apply silently queues class/parameter changes for the
+  maintenance window. Implementation: `scripts/check_rds_pending_modifications/`.
+
 ## Local Usage
 
 Run the fast profile on the full repo:

--- a/shifter/shifter_platform/documentation/docs/technical/dev/adr-enforcement.md
+++ b/shifter/shifter_platform/documentation/docs/technical/dev/adr-enforcement.md
@@ -116,10 +116,15 @@ The first slice intentionally stays small:
   Post-`terraform apply` gate in `_shifter-platform.yml`. Reads the portal
   Terraform outputs, then calls `aws rds describe-db-instances` for each
   `*_db_instance_id` output and fails the deploy job if any RDS instance
-  still has non-empty `PendingModifiedValues`. Catches the failure mode
+  still has non-empty `PendingModifiedValues` or non-`in-sync`/`applying`
+  `DBParameterGroups[].ParameterApplyStatus`. Catches the failure mode
   documented in `dev/terraform.md` ("RDS Change Application") where a
   successful apply silently queues class/parameter changes for the
-  maintenance window. Implementation: `scripts/check_rds_pending_modifications/`.
+  maintenance window. Implementation: `scripts/check_rds_pending_modifications/`,
+  with its own uv-managed dev environment, dedicated CI lint+test jobs
+  (`check-rds-pending-modifications-lint` / `-tests` in `_quality.yml`),
+  and matching pre-commit hooks (ruff + pytest). Same pattern as
+  `scripts/check_layer_imports/`.
 
 ## Local Usage
 

--- a/shifter/shifter_platform/documentation/docs/technical/dev/terraform.md
+++ b/shifter/shifter_platform/documentation/docs/technical/dev/terraform.md
@@ -128,6 +128,34 @@ AWS_PROFILE=$PANW_SHIFTER_DEV_PROFILE terraform apply
 
 **Never apply to prod locally** - use the CI/CD pipeline.
 
+### RDS Change Application
+
+RDS changes that AWS can apply during a deploy — instance class, storage
+size, engine version, and dynamic parameter-group fields — must not be
+treated as complete until AWS reports no pending modifications for the
+affected instance. For dev-only RDS resources, prefer explicit
+`apply_immediately` module inputs that default to applying intended changes
+during the current deploy. Production must keep change timing deliberate:
+either pass an explicit maintenance-window choice through the same module
+surface or use a separate reviewed change flow.
+
+`apply_immediately` does NOT remediate every RDS change. Static
+parameter-group fields and major version upgrades still require an instance
+reboot to take effect, and modify-class operations can still leave
+`PendingModifiedValues` populated until the underlying maintenance action
+completes. The post-apply check will surface that residual state, but it does
+not by itself drive a reboot. When you change one of those fields, plan a
+follow-up reboot (or a maintenance-window-gated path) explicitly.
+
+Post-apply checks belong at the Terraform workflow boundary, after
+`terraform apply`, where the existing AWS credentials and environment context
+are already present. Reuse Terraform outputs or module outputs to identify
+the managed DB instances; do not hardcode names such as `dev-portal-db`
+inside a generic checker. For dev portal deploys, a successful apply that
+leaves non-empty `PendingModifiedValues` is treated as an incomplete deploy
+and fails the job loudly. Prod intentionally skips the check because prod
+relies on the maintenance-window path.
+
 ## Configuration vs Secrets
 
 ### In terraform.tfvars (Committed)

--- a/shifter/shifter_platform/static/js/terminal.test.js
+++ b/shifter/shifter_platform/static/js/terminal.test.js
@@ -96,6 +96,8 @@ describe('TerminalManager', () => {
             dispose: jest.fn(),
             onData: jest.fn(),
             onResize: jest.fn(),
+            attachCustomKeyEventHandler: jest.fn(),
+            getSelection: jest.fn(() => ''),
             cols: 80,
             rows: 24,
         };


### PR DESCRIPTION
## Summary

Both shared RDS modules (`platform/terraform/modules/portal/rds/` and `platform/terraform/modules/guacamole/`) now expose an `apply_immediately` input. Dev environments set it `true`; prod keeps it `false` and continues to flow RDS changes through the configured maintenance window.

A new post-apply gate (`scripts/check_rds_pending_modifications/`) runs after `terraform apply` in the dev branch of `_shifter-platform.yml`. It:

- Discovers DB instance IDs from the env's terraform outputs (no hardcoded names — any future `*_db_instance_id` output is automatically covered).
- Polls `DBInstanceStatus` with a bounded 10 min timeout to distinguish "still applying" from "queued for maintenance window".
- Redacts `MasterUserPassword` from log output if a master-password rotation is in flight (operator still sees the key, value is `<redacted>`).
- Fails the deploy job if any portal-managed RDS instance still has non-empty `PendingModifiedValues` after settling.

Prod intentionally skips the gate because prod relies on the maintenance-window path.

## Background

The May 2026 `db.t3.small → db.m5.xlarge` bump for `dev-portal-guacamole-db` (commit `c7b3af2db`) was accepted by `terraform apply` but queued in `PendingModifiedValues` for the maintenance window. Participants hit the same Guacamole flakiness BSides Ottawa identified the t3.small for. Same root cause as #651, no actual remediation.

## Test plan

- [x] Unit tests under `scripts/check_rds_pending_modifications/` — 13 tests cover clean instance, terminal-state pending mods, modifying-then-available clears, stuck-modifying timeout, missing instance, multi-field reporting, ID extraction (payload + path wrappers), `MasterUserPassword` redaction, and end-to-end `main` entry points.
- [x] ADR guard at `--level ci`
- [x] `tflint --recursive` on `platform/terraform`
- [x] `terraform fmt -check -recursive platform/terraform`
- [x] `terraform validate` in both `environments/dev/portal` and `environments/prod/portal`
- [x] `actionlint .github/workflows/_shifter-platform.yml`
- [x] `pre-commit run` clean (16 hooks)
- [ ] CI green on this PR (PR runs Plan only; full Apply runs on dev branch merge).
- [ ] On the next dev RDS class change, confirm the post-apply gate either passes (mod settled in window) or fails loudly (stuck-modifying / queued).

## Cycles 1–3 review history

See https://github.com/Brad-Edwards/shifter/issues/1085#issuecomment-4411080119 for the full pre-push codex review history (gating-on-dev fix, generic outputs path, doc/changelog scoping, MasterUserPassword redaction, polling vs single-shot describe, in-memory output parsing).

Closes #1085
