### PR TITLE
Remove hardcoded prebaked DC Administrator password from committed sources (#760)

### DIFF
--- a/.github/workflows/_shifter-platform.yml
+++ b/.github/workflows/_shifter-platform.yml
@@ -417,6 +417,7 @@ jobs:
           APP_SECRET_ARN=$(get_param "$PS_PREFIX/app-secret-arn")
           COGNITO_SECRET_ARN=$(get_param "$PS_PREFIX/cognito-secret-arn")
           GUACAMOLE_SECRET_ARN=$(get_param "$PS_PREFIX/guacamole-secret-arn" || echo "")
+          DC_DOMAIN_PASSWORD_SECRET_ARN=$(get_param "$PS_PREFIX/dc-domain-password-secret-arn" || echo "")
           GUACAMOLE_BASE_URL=$(get_param "$PS_PREFIX/guacamole-base-url" || echo "")
           GUACAMOLE_API_BASE_URL=$(get_param "$PS_PREFIX/guacamole-api-base-url" || echo "")
           ENGINE_ECS_CLUSTER_ARN=$(get_param "$PS_PREFIX/engine-ecs-cluster-arn")
@@ -438,6 +439,7 @@ jobs:
           [ -n "$GUACAMOLE_SECRET_ARN" ] && COMMON_ENV="$COMMON_ENV -e GUACAMOLE_SECRET_ARN=$GUACAMOLE_SECRET_ARN"
           [ -n "$GUACAMOLE_BASE_URL" ] && COMMON_ENV="$COMMON_ENV -e GUACAMOLE_BASE_URL=$GUACAMOLE_BASE_URL"
           [ -n "$GUACAMOLE_API_BASE_URL" ] && COMMON_ENV="$COMMON_ENV -e GUACAMOLE_API_BASE_URL=$GUACAMOLE_API_BASE_URL"
+          [ -n "$DC_DOMAIN_PASSWORD_SECRET_ARN" ] && COMMON_ENV="$COMMON_ENV -e DC_DOMAIN_PASSWORD_SECRET_ARN=$DC_DOMAIN_PASSWORD_SECRET_ARN"
           # Add localhost to ALLOWED_HOSTS for dev (enables SSM tunnel testing)
           # PS_PREFIX comes from Parameter Store, not user input - safe to use
           if [[ "$PS_PREFIX" == *"/dev/"* ]]; then
@@ -456,6 +458,23 @@ jobs:
           [ -n "$CTF_FROM_EMAIL" ] && COMMON_ENV="$COMMON_ENV -e CTF_FROM_EMAIL=$CTF_FROM_EMAIL"
 
           docker pull "$IMAGE"
+          # Preflight: confirm the DC domain password secret is populated
+          # before tearing down running containers. The Terraform-managed
+          # secret container exists with no AWSCURRENT until an operator
+          # seeds the value out-of-band (see secrets.md "Bootstrap (fresh
+          # environment)"); deploying without a value would leave the
+          # entrypoint unable to resolve DC_DOMAIN_PASSWORD and the
+          # restarted portal in a crash-restart loop.
+          if [ -n "$DC_DOMAIN_PASSWORD_SECRET_ARN" ]; then
+            if ! aws secretsmanager get-secret-value \
+                  --secret-id "$DC_DOMAIN_PASSWORD_SECRET_ARN" \
+                  --region "$AWS_REGION" \
+                  --query SecretString --output text >/dev/null 2>&1; then
+              echo "ERROR: DC domain password secret has no AWSCURRENT value." >&2
+              echo "Seed the value via 'aws secretsmanager put-secret-value' before deploying." >&2
+              exit 1
+            fi
+          fi
           docker stop portal worker-cms worker-engine worker-mc ctf-scheduler 2>/dev/null || true
           docker rm portal worker-cms worker-engine worker-mc ctf-scheduler 2>/dev/null || true
           eval docker run -d --name portal --restart unless-stopped -p 8000:8000 $COMMON_ENV "$IMAGE"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -294,7 +294,7 @@ repos:
         name: architecture (adr guard fast)
         entry: python3 scripts/adr_guard/adr_guard.py --changed --level fast
         language: system
-        files: ^(docs/adr/|scripts/adr_guard/|\.github/workflows/|\.github/(CODEOWNERS|pull_request_template\.md|copilot-instructions\.md)$|\.claude/|shifter/shifter_platform/.*\.py$|shifter/engine/provisioner/cloud/.*\.py$|\.pre-commit-config\.yaml$|AGENTS\.md$|\.importlinter$|\.tflint\.hcl$|\.gitleaks\.toml$|\.kube-linter\.yaml$|mcp/.*\.(js|mjs|cjs)$)
+        files: ^(docs/adr/|scripts/adr_guard/|\.github/workflows/|\.github/(CODEOWNERS|pull_request_template\.md|copilot-instructions\.md)$|\.claude/|shifter/shifter_platform/.*\.py$|shifter/engine/provisioner/cloud/.*\.py$|platform/terraform/environments/.*\.tfvars$|\.pre-commit-config\.yaml$|AGENTS\.md$|\.importlinter$|\.tflint\.hcl$|\.gitleaks\.toml$|\.kube-linter\.yaml$|mcp/.*\.(js|mjs|cjs)$)
         pass_filenames: false
         verbose: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -215,6 +215,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   test that verifies the running container's UID, HOME, and writable
   cache paths. Source: GCP Red Team Report (CRITICAL-01).
 
+### Security
+
+- **Removed hardcoded prebaked Domain Controller Administrator password
+  from committed sources (#760).** The literal `dc_domain_password`
+  value previously committed in
+  `platform/terraform/environments/prod/portal/terraform.tfvars` and
+  `platform/terraform/environments/dev/portal/terraform.tfvars`, plus
+  the matching Python fallback in
+  `shifter/shifter_platform/engine/services.py:_get_windows_rdp_fallback`,
+  has been removed. The engine-provisioner module now references an
+  out-of-band-managed `aws_secretsmanager_secret` named
+  `shifter-{env}-portal-dc-domain` via a `data` source; operators
+  create AND populate the secret with `aws secretsmanager create-secret`
+  before the first `terraform apply` (see `secrets.md` "Bootstrap
+  (fresh environment)"). The engine ECS task injects the value via the
+  task definition's `secrets = [...]` block; the portal Django
+  container reads the same secret at startup through `entrypoint.sh`
+  and the `DC_DOMAIN_PASSWORD_SECRET_ARN` env var plumbed through the
+  `portal/ssm` and `portal/ec2` modules. The Windows-DC RDP credential
+  lookup in `engine.services` is now provider-scoped via the portal's
+  `CLOUD_PROVIDER` env, fail-loud (raises `ValueError` mapped to HTTP
+  400 by mission_control) when the secret is unconfigured or when an
+  instance's provider does not match the portal's deployment provider
+  (closes the cross-provider leak). The GDC VM Runtime DC provisioner
+  (`gdc_vmruntime_assets._get_windows_admin_password`) requires the
+  same `DC_DOMAIN_PASSWORD` env (no literal fallback for the DC role).
+  The previously exposed value must be rotated operationally; the
+  prebaked DC AMI Administrator password and the Secrets Manager value
+  must match. Adds an `adr_guard` check
+  `no-plaintext-secrets-in-tfvars` (ADR-004-R7) that scans
+  `platform/terraform/environments/**/*.tfvars` for string-literal
+  assignments to `*_password` / `*_secret` / `*_token` / `*_key` /
+  `*_credentials` variables and fails the architecture gate if any
+  re-appear; complements gitleaks (which catches high-entropy random
+  strings) by catching low-entropy committed credentials gitleaks
+  ignores. Public-key fragments (`public_key`, `public_cert`,
+  `pubkey`, `authorized_keys`) are exempt; `*.tfvars.example` files
+  are skipped.
+
 ### Changed
 
 - **Stripped Cortex/Palo branding from UI surfaces (#1101).** Renamed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,51 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.99.1] - 2026-05-10
+
+### Security
+
+- **Removed hardcoded prebaked Domain Controller Administrator password
+  from committed sources (#760).** The literal `dc_domain_password`
+  value previously committed in
+  `platform/terraform/environments/{prod,dev}/portal/terraform.tfvars`,
+  the matching Python fallback in
+  `shifter/shifter_platform/engine/services._get_windows_rdp_fallback`,
+  and the GDC VM Runtime DC fallback in
+  `shifter/engine/provisioner/gdc_vmruntime_assets._get_windows_admin_password`
+  have been removed. The engine-provisioner Terraform module now
+  references an out-of-band-managed `aws_secretsmanager_secret` named
+  `shifter-{env}-portal-dc-domain` via a `data` source; operators
+  create AND populate the secret with `aws secretsmanager create-secret`
+  before the first `terraform apply` (see `secrets.md` "Bootstrap (fresh
+  environment)"). The engine ECS task injects the value via the task
+  definition's `secrets = [...]` block; the portal Django container
+  reads the same secret at startup through `entrypoint.sh` and the
+  `DC_DOMAIN_PASSWORD_SECRET_ARN` env var plumbed through the
+  `portal/ssm` and `portal/ec2` modules. The Windows-DC RDP credential
+  lookup in `engine.services` is provider-scoped via the portal's
+  `CLOUD_PROVIDER` env, fail-loud (raises `ValueError` mapped to HTTP
+  400 by mission_control) when the secret is unconfigured or when an
+  instance's provider does not match the portal's deployment provider
+  (closes the cross-provider leak). The GDC VM Runtime DC provisioner
+  requires the same `DC_DOMAIN_PASSWORD` env (no literal fallback for
+  the DC role; non-DC Windows victim fallback remains pending separate
+  follow-up). Adds an `adr_guard` check `no-plaintext-secrets-in-tfvars`
+  (ADR-004-R7) that scans
+  `platform/terraform/environments/**/*.tfvars` for string-literal
+  assignments to `*_password` / `*_secret` / `*_token` / `*_key` /
+  `*_credentials` variables (with multi-line wrapper, HCL `#`/`//`/`/* */`
+  comment, and object/array detection) and fails the architecture gate
+  if any re-appear; complements gitleaks (which catches high-entropy
+  random strings) by catching low-entropy committed credentials
+  gitleaks ignores. Variables whose name ENDS WITH a public-material
+  suffix (`public_key`, `public_cert`, `pubkey`, `authorized_keys`,
+  etc.) are exempt; `public_key_password` and similar names that mix
+  a public-material fragment with a secret suffix stay flagged.
+  `*.tfvars.example` files are skipped. The previously exposed value
+  must be rotated operationally; the prebaked DC AMI Administrator
+  password and the Secrets Manager value must match.
+
 ## [3.99.0] - 2026-05-10
 
 ### Added
@@ -263,49 +308,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   RDS instance still has non-empty `PendingModifiedValues`. A successful
   apply that leaves pending mods is treated as an incomplete deploy. Prod
   is exempt by design.
-
-### Security
-
-- **Removed hardcoded prebaked Domain Controller Administrator password
-  from committed sources (#760).** The literal `dc_domain_password`
-  value previously committed in
-  `platform/terraform/environments/{prod,dev}/portal/terraform.tfvars`,
-  the matching Python fallback in
-  `shifter/shifter_platform/engine/services._get_windows_rdp_fallback`,
-  and the GDC VM Runtime DC fallback in
-  `shifter/engine/provisioner/gdc_vmruntime_assets._get_windows_admin_password`
-  have been removed. The engine-provisioner Terraform module now
-  references an out-of-band-managed `aws_secretsmanager_secret` named
-  `shifter-{env}-portal-dc-domain` via a `data` source; operators
-  create AND populate the secret with `aws secretsmanager create-secret`
-  before the first `terraform apply` (see `secrets.md` "Bootstrap (fresh
-  environment)"). The engine ECS task injects the value via the task
-  definition's `secrets = [...]` block; the portal Django container
-  reads the same secret at startup through `entrypoint.sh` and the
-  `DC_DOMAIN_PASSWORD_SECRET_ARN` env var plumbed through the
-  `portal/ssm` and `portal/ec2` modules. The Windows-DC RDP credential
-  lookup in `engine.services` is provider-scoped via the portal's
-  `CLOUD_PROVIDER` env, fail-loud (raises `ValueError` mapped to HTTP
-  400 by mission_control) when the secret is unconfigured or when an
-  instance's provider does not match the portal's deployment provider
-  (closes the cross-provider leak). The GDC VM Runtime DC provisioner
-  requires the same `DC_DOMAIN_PASSWORD` env (no literal fallback for
-  the DC role; non-DC Windows victim fallback remains pending separate
-  follow-up). Adds an `adr_guard` check `no-plaintext-secrets-in-tfvars`
-  (ADR-004-R7) that scans
-  `platform/terraform/environments/**/*.tfvars` for string-literal
-  assignments to `*_password` / `*_secret` / `*_token` / `*_key` /
-  `*_credentials` variables (with multi-line wrapper, HCL `#`/`//`/`/* */`
-  comment, and object/array detection) and fails the architecture gate
-  if any re-appear; complements gitleaks (which catches high-entropy
-  random strings) by catching low-entropy committed credentials
-  gitleaks ignores. Variables whose name ENDS WITH a public-material
-  suffix (`public_key`, `public_cert`, `pubkey`, `authorized_keys`,
-  etc.) are exempt; `public_key_password` and similar names that mix
-  a public-material fragment with a secret suffix stay flagged.
-  `*.tfvars.example` files are skipped. The previously exposed value
-  must be rotated operationally; the prebaked DC AMI Administrator
-  password and the Secrets Manager value must match.
 
 ## [3.97.0] - 2026-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -215,45 +215,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   test that verifies the running container's UID, HOME, and writable
   cache paths. Source: GCP Red Team Report (CRITICAL-01).
 
-### Security
-
-- **Removed hardcoded prebaked Domain Controller Administrator password
-  from committed sources (#760).** The literal `dc_domain_password`
-  value previously committed in
-  `platform/terraform/environments/prod/portal/terraform.tfvars` and
-  `platform/terraform/environments/dev/portal/terraform.tfvars`, plus
-  the matching Python fallback in
-  `shifter/shifter_platform/engine/services.py:_get_windows_rdp_fallback`,
-  has been removed. The engine-provisioner module now references an
-  out-of-band-managed `aws_secretsmanager_secret` named
-  `shifter-{env}-portal-dc-domain` via a `data` source; operators
-  create AND populate the secret with `aws secretsmanager create-secret`
-  before the first `terraform apply` (see `secrets.md` "Bootstrap
-  (fresh environment)"). The engine ECS task injects the value via the
-  task definition's `secrets = [...]` block; the portal Django
-  container reads the same secret at startup through `entrypoint.sh`
-  and the `DC_DOMAIN_PASSWORD_SECRET_ARN` env var plumbed through the
-  `portal/ssm` and `portal/ec2` modules. The Windows-DC RDP credential
-  lookup in `engine.services` is now provider-scoped via the portal's
-  `CLOUD_PROVIDER` env, fail-loud (raises `ValueError` mapped to HTTP
-  400 by mission_control) when the secret is unconfigured or when an
-  instance's provider does not match the portal's deployment provider
-  (closes the cross-provider leak). The GDC VM Runtime DC provisioner
-  (`gdc_vmruntime_assets._get_windows_admin_password`) requires the
-  same `DC_DOMAIN_PASSWORD` env (no literal fallback for the DC role).
-  The previously exposed value must be rotated operationally; the
-  prebaked DC AMI Administrator password and the Secrets Manager value
-  must match. Adds an `adr_guard` check
-  `no-plaintext-secrets-in-tfvars` (ADR-004-R7) that scans
-  `platform/terraform/environments/**/*.tfvars` for string-literal
-  assignments to `*_password` / `*_secret` / `*_token` / `*_key` /
-  `*_credentials` variables and fails the architecture gate if any
-  re-appear; complements gitleaks (which catches high-entropy random
-  strings) by catching low-entropy committed credentials gitleaks
-  ignores. Public-key fragments (`public_key`, `public_cert`,
-  `pubkey`, `authorized_keys`) are exempt; `*.tfvars.example` files
-  are skipped.
-
 ### Changed
 
 - **Stripped Cortex/Palo branding from UI surfaces (#1101).** Renamed
@@ -302,6 +263,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   RDS instance still has non-empty `PendingModifiedValues`. A successful
   apply that leaves pending mods is treated as an incomplete deploy. Prod
   is exempt by design.
+
+### Security
+
+- **Removed hardcoded prebaked Domain Controller Administrator password
+  from committed sources (#760).** The literal `dc_domain_password`
+  value previously committed in
+  `platform/terraform/environments/{prod,dev}/portal/terraform.tfvars`,
+  the matching Python fallback in
+  `shifter/shifter_platform/engine/services._get_windows_rdp_fallback`,
+  and the GDC VM Runtime DC fallback in
+  `shifter/engine/provisioner/gdc_vmruntime_assets._get_windows_admin_password`
+  have been removed. The engine-provisioner Terraform module now
+  references an out-of-band-managed `aws_secretsmanager_secret` named
+  `shifter-{env}-portal-dc-domain` via a `data` source; operators
+  create AND populate the secret with `aws secretsmanager create-secret`
+  before the first `terraform apply` (see `secrets.md` "Bootstrap (fresh
+  environment)"). The engine ECS task injects the value via the task
+  definition's `secrets = [...]` block; the portal Django container
+  reads the same secret at startup through `entrypoint.sh` and the
+  `DC_DOMAIN_PASSWORD_SECRET_ARN` env var plumbed through the
+  `portal/ssm` and `portal/ec2` modules. The Windows-DC RDP credential
+  lookup in `engine.services` is provider-scoped via the portal's
+  `CLOUD_PROVIDER` env, fail-loud (raises `ValueError` mapped to HTTP
+  400 by mission_control) when the secret is unconfigured or when an
+  instance's provider does not match the portal's deployment provider
+  (closes the cross-provider leak). The GDC VM Runtime DC provisioner
+  requires the same `DC_DOMAIN_PASSWORD` env (no literal fallback for
+  the DC role; non-DC Windows victim fallback remains pending separate
+  follow-up). Adds an `adr_guard` check `no-plaintext-secrets-in-tfvars`
+  (ADR-004-R7) that scans
+  `platform/terraform/environments/**/*.tfvars` for string-literal
+  assignments to `*_password` / `*_secret` / `*_token` / `*_key` /
+  `*_credentials` variables (with multi-line wrapper, HCL `#`/`//`/`/* */`
+  comment, and object/array detection) and fails the architecture gate
+  if any re-appear; complements gitleaks (which catches high-entropy
+  random strings) by catching low-entropy committed credentials
+  gitleaks ignores. Variables whose name ENDS WITH a public-material
+  suffix (`public_key`, `public_cert`, `pubkey`, `authorized_keys`,
+  etc.) are exempt; `public_key_password` and similar names that mix
+  a public-material fragment with a secret suffix stay flagged.
+  `*.tfvars.example` files are skipped. The previously exposed value
+  must be rotated operationally; the prebaked DC AMI Administrator
+  password and the Secrets Manager value must match.
 
 ## [3.97.0] - 2026-05-07
 

--- a/docs/adr/index.yaml
+++ b/docs/adr/index.yaml
@@ -100,6 +100,11 @@
         "id": "ADR-004-R6",
         "description": "GCP Terraform is linted with the tflint-ruleset-google plugin.",
         "checks": []
+      },
+      {
+        "id": "ADR-004-R7",
+        "description": "Committed Terraform variable files under platform/terraform/environments/ must not assign string literals to *_password / *_secret / *_token / *_key / *_credentials variables; reference an out-of-band secret store (Secrets Manager, SSM, environment) instead. Backstops gitleaks for low-entropy committed credentials it ignores.",
+        "checks": ["no-plaintext-secrets-in-tfvars"]
       }
     ],
     "exceptions": [],
@@ -110,7 +115,8 @@
       ".gitleaks.toml",
       ".kube-linter.yaml",
       ".pre-commit-config.yaml",
-      ".github/workflows/_quality.yml"
+      ".github/workflows/_quality.yml",
+      "scripts/adr_guard/adr_guard.py"
     ]
   },
   {

--- a/platform/terraform/environments/dev/portal/main.tf
+++ b/platform/terraform/environments/dev/portal/main.tf
@@ -253,12 +253,13 @@ module "ssm" {
   ecr_repository_name = split("/", data.terraform_remote_state.foundation.outputs.portal_ecr_url)[1]
 
   # Secrets Manager ARNs
-  db_secret_arn          = module.rds.db_credentials_secret_arn
-  app_secret_arn         = aws_secretsmanager_secret.app.arn
-  cognito_secret_arn     = module.cognito.cognito_secret_arn
-  guacamole_secret_arn   = module.guacamole.json_auth_secret_arn
-  guacamole_base_url     = "https://${var.domain_name}/guacamole"
-  guacamole_api_base_url = module.guacamole.guacamole_client_internal_url
+  db_secret_arn                 = module.rds.db_credentials_secret_arn
+  app_secret_arn                = aws_secretsmanager_secret.app.arn
+  cognito_secret_arn            = module.cognito.cognito_secret_arn
+  guacamole_secret_arn          = module.guacamole.json_auth_secret_arn
+  guacamole_base_url            = "https://${var.domain_name}/guacamole"
+  guacamole_api_base_url        = module.guacamole.guacamole_client_internal_url
+  dc_domain_password_secret_arn = module.engine_provisioner.dc_domain_password_secret_arn
 
   # Application configuration
   domain_name       = var.domain_name
@@ -311,6 +312,7 @@ module "ec2" {
     aws_secretsmanager_secret.app.arn,
     module.cognito.cognito_secret_arn,
     module.guacamole.json_auth_secret_arn,
+    module.engine_provisioner.dc_domain_password_secret_arn,
   ]
   s3_bucket_arn    = module.s3.bucket_arn
   app_port         = var.app_port
@@ -523,9 +525,10 @@ module "engine_provisioner" {
   windows_ami_id = data.aws_ssm_parameter.windows_ami.value
   dc_ami_id      = data.aws_ssm_parameter.dc_ami.value
 
-  # Prebaked DC configuration
-  dc_domain_name     = var.dc_domain_name
-  dc_domain_password = var.dc_domain_password
+  # Prebaked DC configuration. dc_domain_password is sourced from
+  # aws_secretsmanager_secret.dc_domain_password inside the
+  # engine-provisioner module; no plaintext input from this stack.
+  dc_domain_name = var.dc_domain_name
 
   # Instance types
   kali_instance_type   = var.kali_instance_type

--- a/platform/terraform/environments/dev/portal/terraform.tfvars
+++ b/platform/terraform/environments/dev/portal/terraform.tfvars
@@ -146,8 +146,11 @@ engine_container_tag = "latest"
 # Windows/DC AMIs also managed via SSM Parameter Store
 
 dc_domain_name = "internal.shifter"
-# nosec B105 - Ephemeral isolated range, not a production credential
-dc_domain_password = "Sh1fterDC2026" # pragma: allowlist secret
+# Domain Controller Administrator password is sourced from
+# aws_secretsmanager_secret.dc_domain_password (engine-provisioner module)
+# at runtime; the value is managed out-of-band and is intentionally not
+# present in Terraform configuration. See
+# shifter/shifter_platform/documentation/docs/technical/dev/secrets.md.
 
 # ------------------------------------------------------------------------------
 # Guacamole

--- a/platform/terraform/environments/dev/portal/variables.tf
+++ b/platform/terraform/environments/dev/portal/variables.tf
@@ -368,12 +368,12 @@ variable "dc_domain_name" {
   default     = "internal.shifter"
 }
 
-variable "dc_domain_password" {
-  description = "Domain admin password for prebaked DC"
-  type        = string
-  sensitive   = true
-  default     = ""
-}
+# The DC Administrator password is intentionally not a Terraform variable.
+# It lives in aws_secretsmanager_secret.dc_domain_password (created by
+# the engine-provisioner module) with the value managed out-of-band, and
+# is plumbed to the engine task via ECS `secrets = [...]` and to the
+# portal Django container via the portal/ssm + ec2 modules and
+# entrypoint.sh.
 
 # ------------------------------------------------------------------------------
 # Guacamole

--- a/platform/terraform/environments/prod/portal/main.tf
+++ b/platform/terraform/environments/prod/portal/main.tf
@@ -249,12 +249,13 @@ module "ssm" {
   ecr_repository_name = split("/", data.terraform_remote_state.foundation.outputs.portal_ecr_url)[1]
 
   # Secrets Manager ARNs
-  db_secret_arn          = module.rds.db_credentials_secret_arn
-  app_secret_arn         = aws_secretsmanager_secret.app.arn
-  cognito_secret_arn     = module.cognito.cognito_secret_arn
-  guacamole_secret_arn   = module.guacamole.json_auth_secret_arn
-  guacamole_base_url     = "https://${var.domain_name}/guacamole"
-  guacamole_api_base_url = module.guacamole.guacamole_client_internal_url
+  db_secret_arn                 = module.rds.db_credentials_secret_arn
+  app_secret_arn                = aws_secretsmanager_secret.app.arn
+  cognito_secret_arn            = module.cognito.cognito_secret_arn
+  guacamole_secret_arn          = module.guacamole.json_auth_secret_arn
+  guacamole_base_url            = "https://${var.domain_name}/guacamole"
+  guacamole_api_base_url        = module.guacamole.guacamole_client_internal_url
+  dc_domain_password_secret_arn = module.engine_provisioner.dc_domain_password_secret_arn
 
   # Application configuration
   domain_name    = var.domain_name
@@ -306,6 +307,7 @@ module "ec2" {
     aws_secretsmanager_secret.app.arn,
     module.cognito.cognito_secret_arn,
     module.guacamole.json_auth_secret_arn,
+    module.engine_provisioner.dc_domain_password_secret_arn,
   ]
   s3_bucket_arn    = module.s3.bucket_arn
   app_port         = var.app_port
@@ -486,9 +488,10 @@ module "engine_provisioner" {
   windows_ami_id = data.aws_ssm_parameter.windows_ami.value
   dc_ami_id      = data.aws_ssm_parameter.dc_ami.value
 
-  # Prebaked DC configuration
-  dc_domain_name     = var.dc_domain_name
-  dc_domain_password = var.dc_domain_password
+  # Prebaked DC configuration. dc_domain_password is sourced from
+  # aws_secretsmanager_secret.dc_domain_password inside the
+  # engine-provisioner module; no plaintext input from this stack.
+  dc_domain_name = var.dc_domain_name
 
   # Instance types
   kali_instance_type   = var.kali_instance_type

--- a/platform/terraform/environments/prod/portal/terraform.tfvars
+++ b/platform/terraform/environments/prod/portal/terraform.tfvars
@@ -127,8 +127,11 @@ engine_container_tag = "latest"
 # Windows/DC AMIs also managed via SSM Parameter Store
 
 dc_domain_name = "internal.shifter"
-# nosec B105 - Ephemeral isolated range, not a production credential
-dc_domain_password = "Sh1fterDC2026" # pragma: allowlist secret
+# Domain Controller Administrator password is sourced from
+# aws_secretsmanager_secret.dc_domain_password (engine-provisioner module)
+# at runtime; the value is managed out-of-band and is intentionally not
+# present in Terraform configuration. See
+# shifter/shifter_platform/documentation/docs/technical/dev/secrets.md.
 
 # ------------------------------------------------------------------------------
 # Guacamole

--- a/platform/terraform/environments/prod/portal/variables.tf
+++ b/platform/terraform/environments/prod/portal/variables.tf
@@ -296,12 +296,12 @@ variable "dc_domain_name" {
   default     = "internal.shifter"
 }
 
-variable "dc_domain_password" {
-  description = "Domain admin password for prebaked DC"
-  type        = string
-  sensitive   = true
-  default     = ""
-}
+# The DC Administrator password is intentionally not a Terraform variable.
+# It lives in aws_secretsmanager_secret.dc_domain_password (created by
+# the engine-provisioner module) with the value managed out-of-band, and
+# is plumbed to the engine task via ECS `secrets = [...]` and to the
+# portal Django container via the portal/ssm + ec2 modules and
+# entrypoint.sh.
 
 # Guacamole
 # ------------------------------------------------------------------------------

--- a/platform/terraform/modules/engine-provisioner/iam.tf
+++ b/platform/terraform/modules/engine-provisioner/iam.tf
@@ -44,6 +44,27 @@ resource "aws_iam_role_policy" "ecs_execution_ecr" {
   })
 }
 
+# Allow the ECS execution role to fetch the DC domain password secret so
+# ECS can hydrate the DC_DOMAIN_PASSWORD container env var via the
+# `secrets = [...]` block in task_definition.tf.
+resource "aws_iam_role_policy" "ecs_execution_secrets" {
+  name = "secrets-read"
+  role = aws_iam_role.ecs_execution.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "secretsmanager:GetSecretValue"
+      ]
+      Resource = [
+        data.aws_secretsmanager_secret.dc_domain_password.arn
+      ]
+    }]
+  })
+}
+
 # ------------------------------------------------------------------------------
 # ECS Task Role
 # ------------------------------------------------------------------------------

--- a/platform/terraform/modules/engine-provisioner/outputs.tf
+++ b/platform/terraform/modules/engine-provisioner/outputs.tf
@@ -46,6 +46,15 @@ output "ecs_task_role_arn" {
 }
 
 # ------------------------------------------------------------------------------
+# Secrets Manager Outputs
+# ------------------------------------------------------------------------------
+
+output "dc_domain_password_secret_arn" {
+  description = "ARN of the Secrets Manager secret holding the prebaked DC Administrator password (created and managed out-of-band; resolved via data source)"
+  value       = data.aws_secretsmanager_secret.dc_domain_password.arn
+}
+
+# ------------------------------------------------------------------------------
 # CloudWatch Outputs
 # ------------------------------------------------------------------------------
 

--- a/platform/terraform/modules/engine-provisioner/secrets.tf
+++ b/platform/terraform/modules/engine-provisioner/secrets.tf
@@ -1,0 +1,31 @@
+# ------------------------------------------------------------------------------
+# Secrets Manager
+# ------------------------------------------------------------------------------
+# Reference to the prebaked Domain Controller's Administrator password.
+# The secret container AND its value are created out-of-band BEFORE
+# `terraform apply` runs (see "Bootstrap (fresh environment)" in
+# shifter/shifter_platform/documentation/docs/technical/dev/secrets.md).
+# Terraform reads the existing secret via `data` rather than creating it,
+# which avoids the chicken-and-egg case where the same apply that creates
+# the empty secret container also stands up an ASG whose launch hook
+# requires the value — the ASG would ABANDON every first launch until the
+# operator seeded the value, which is not a recoverable bootstrap.
+#
+# Operator pre-bootstrap step (one-time per environment):
+#   aws secretsmanager create-secret \
+#     --name "shifter-${env}-portal-dc-domain" \
+#     --description "Prebaked DC Administrator password" \
+#     --secret-string "$DC_DOMAIN_PASSWORD"
+#
+# After that, `terraform apply` resolves the secret ARN, wires it into
+# the engine provisioner ECS task (via `secrets = [...]` in
+# task_definition.tf) and into the portal Django container (via the
+# portal/ssm + portal/ec2 modules and entrypoint.sh).
+#
+# Rotation / value updates use `aws secretsmanager put-secret-value`;
+# Terraform never touches the value, so the cleartext credential never
+# lands in Terraform state.
+
+data "aws_secretsmanager_secret" "dc_domain_password" {
+  name = "shifter-${var.environment}-portal-dc-domain"
+}

--- a/platform/terraform/modules/engine-provisioner/task_definition.tf
+++ b/platform/terraform/modules/engine-provisioner/task_definition.tf
@@ -82,7 +82,6 @@ resource "aws_ecs_task_definition" "engine_provisioner" {
       { name = "WINDOWS_AMI_ID", value = var.windows_ami_id },
       { name = "DC_AMI_ID", value = var.dc_ami_id },
       { name = "DC_DOMAIN_NAME", value = var.dc_domain_name },
-      { name = "DC_DOMAIN_PASSWORD", value = var.dc_domain_password },
       { name = "AGENT_S3_BUCKET", value = var.agent_s3_bucket },
       { name = "S3_ENDPOINT_ID", value = var.s3_endpoint_id },
       { name = "FIREWALL_ENDPOINT_ID", value = var.firewall_endpoint_id },
@@ -103,6 +102,13 @@ resource "aws_ecs_task_definition" "engine_provisioner" {
       { name = "NGFW_INSTANCE_PROFILE_NAME", value = var.ngfw_instance_profile_name },
       # Messaging (SNS for range events)
       { name = "SNS_RANGE_EVENTS_ARN", value = var.sns_topic_arn },
+    ]
+
+    secrets = [
+      {
+        name      = "DC_DOMAIN_PASSWORD"
+        valueFrom = data.aws_secretsmanager_secret.dc_domain_password.arn
+      }
     ]
 
     logConfiguration = {

--- a/platform/terraform/modules/engine-provisioner/variables.tf
+++ b/platform/terraform/modules/engine-provisioner/variables.tf
@@ -200,12 +200,13 @@ variable "dc_domain_name" {
   default     = "internal.shifter"
 }
 
-variable "dc_domain_password" {
-  description = "Domain admin password for prebaked DC"
-  type        = string
-  sensitive   = true
-  default     = ""
-}
+# The DC Administrator password is intentionally NOT a Terraform variable.
+# It lives in aws_secretsmanager_secret.dc_domain_password (see secrets.tf)
+# with the value managed out-of-band, and is injected into the engine
+# provisioner ECS task via the `secrets = [...]` block in
+# task_definition.tf. The portal Django container receives the value
+# through the same secret, plumbed through the portal/ssm and portal/ec2
+# modules and resolved at startup by entrypoint.sh.
 
 # ------------------------------------------------------------------------------
 # Instance Types

--- a/platform/terraform/modules/portal/ec2/user_data.sh
+++ b/platform/terraform/modules/portal/ec2/user_data.sh
@@ -133,6 +133,7 @@ SQS_ENGINE_URL=$(get_param "$PS_PREFIX/sqs-engine-url")
 SQS_MC_URL=$(get_param "$PS_PREFIX/sqs-mc-url")
 REDIS_ENDPOINT=$(get_param "$PS_PREFIX/redis-endpoint" || echo "")
 GUACAMOLE_SECRET_ARN=$(get_param "$PS_PREFIX/guacamole-secret-arn" 2>/dev/null || echo "")
+DC_DOMAIN_PASSWORD_SECRET_ARN=$(get_param "$PS_PREFIX/dc-domain-password-secret-arn" 2>/dev/null || echo "")
 GUACAMOLE_BASE_URL=$(get_param "$PS_PREFIX/guacamole-base-url" 2>/dev/null || echo "")
 GUACAMOLE_API_BASE_URL=$(get_param "$PS_PREFIX/guacamole-api-base-url" 2>/dev/null || echo "")
 DB_HOST_OVERRIDE=$(get_param "$PS_PREFIX/db-host-override" 2>/dev/null || echo "")
@@ -176,6 +177,28 @@ if [[ -n "$GUACAMOLE_BASE_URL" ]]; then
 fi
 if [[ -n "$GUACAMOLE_API_BASE_URL" ]]; then
   COMMON_ENV="$COMMON_ENV -e GUACAMOLE_API_BASE_URL=$GUACAMOLE_API_BASE_URL"
+fi
+
+# Pass the DC domain password secret ARN through; the container's
+# entrypoint resolves it to the DC_DOMAIN_PASSWORD env var used by the
+# portal's Windows-DC RDP credential lookup.
+if [[ -n "$DC_DOMAIN_PASSWORD_SECRET_ARN" ]]; then
+  # Preflight: refuse to start containers if the Terraform-managed
+  # secret has no AWSCURRENT value yet (a fresh environment requires
+  # an out-of-band `aws secretsmanager put-secret-value` step before
+  # the portal will start; see secrets.md "Bootstrap (fresh
+  # environment)"). Without this guard, docker run -d returns 0 and
+  # the lifecycle hook continues while the containers crash-loop.
+  if ! aws secretsmanager get-secret-value \
+        --secret-id "$DC_DOMAIN_PASSWORD_SECRET_ARN" \
+        --region "$AWS_REGION" \
+        --query SecretString --output text >/dev/null 2>&1; then
+    echo "ERROR: DC domain password secret has no AWSCURRENT value." >&2
+    echo "Seed the value via 'aws secretsmanager put-secret-value' before bootstrap." >&2
+    complete_lifecycle_action ABANDON
+    exit 1
+  fi
+  COMMON_ENV="$COMMON_ENV -e DC_DOMAIN_PASSWORD_SECRET_ARN=$DC_DOMAIN_PASSWORD_SECRET_ARN"
 fi
 
 # Add DB host override if configured

--- a/platform/terraform/modules/portal/ssm/main.tf
+++ b/platform/terraform/modules/portal/ssm/main.tf
@@ -105,6 +105,15 @@ resource "aws_ssm_parameter" "guacamole_secret_arn" {
   tags = local.common_tags
 }
 
+resource "aws_ssm_parameter" "dc_domain_password_secret_arn" {
+  name        = "${local.ps_prefix}/dc-domain-password-secret-arn"
+  description = "ARN of the Secrets Manager secret holding the prebaked DC Administrator password (resolved at portal startup)"
+  type        = "String"
+  value       = var.dc_domain_password_secret_arn
+
+  tags = local.common_tags
+}
+
 resource "aws_ssm_parameter" "guacamole_base_url" {
   name        = "${local.ps_prefix}/guacamole-base-url"
   description = "Guacamole public URL for browser (e.g., https://domain.com/guacamole)"

--- a/platform/terraform/modules/portal/ssm/variables.tf
+++ b/platform/terraform/modules/portal/ssm/variables.tf
@@ -68,6 +68,12 @@ variable "guacamole_secret_arn" {
   default     = ""
 }
 
+variable "dc_domain_password_secret_arn" {
+  description = "ARN of the Secrets Manager secret holding the prebaked DC Administrator password. The portal Django container resolves this at startup (entrypoint.sh) to populate the DC_DOMAIN_PASSWORD env var used by Windows-DC RDP credential display."
+  type        = string
+  default     = ""
+}
+
 variable "guacamole_base_url" {
   description = "Public base URL for Guacamole (browser URL, e.g., https://domain.com/guacamole)"
   type        = string

--- a/scripts/adr_guard/adr_guard.py
+++ b/scripts/adr_guard/adr_guard.py
@@ -1473,6 +1473,19 @@ def _wrapped_rhs_has_literal(
     return _lines_have_string_literal(lines, idx + 1, close_idx)
 
 
+def _block_assignment_has_literal(
+    lines: list[str], idx: int, opener: str
+) -> bool:
+    """``True`` if the object/array block opened on ``lines[idx]`` carries a
+    string literal somewhere between the opener and its matching close (an
+    empty block, or one composed solely of var/local/data references, is
+    acceptable). A block whose close is never found scans to end-of-file.
+    """
+    close_idx = _find_block_close_index(lines, idx, opener)
+    end_idx = close_idx if close_idx is not None else len(lines) - 1
+    return _lines_have_string_literal(lines, idx, end_idx)
+
+
 def _flagged_secret_var(lines: list[str], idx: int) -> str | None:
     """Return the secret-bearing variable on ``lines[idx]`` that is assigned a
     plaintext string literal — directly, via a heredoc, via an object/array
@@ -1480,26 +1493,23 @@ def _flagged_secret_var(lines: list[str], idx: int) -> str | None:
     clean or the variable name is public material.
     """
     line = lines[idx]
+    # Priority: a direct ``= "..."`` / heredoc literal, then an object/array
+    # block, then any other RHS expression. ``_SECRET_ASSIGNMENT_PATTERN`` is
+    # the catch-all, so it is consulted last.
     direct = _SECRET_VAR_PATTERN.match(line) or _SECRET_HEREDOC_PATTERN.match(line)
-    if direct is not None:
-        return None if _is_public_material_name(direct.group(1)) else direct.group(1)
     block_match = _SECRET_BLOCK_OPEN_PATTERN.match(line)
-    if block_match is not None:
-        var_name = block_match.group(1)
-        if _is_public_material_name(var_name):
-            return None
-        close_idx = _find_block_close_index(lines, idx, block_match.group(2))
-        end_idx = close_idx if close_idx is not None else len(lines) - 1
-        return var_name if _lines_have_string_literal(lines, idx, end_idx) else None
     wrapped = _SECRET_ASSIGNMENT_PATTERN.match(line)
-    if wrapped is not None:
-        var_name = wrapped.group(1)
-        if _is_public_material_name(var_name):
-            return None
-        if _wrapped_rhs_has_literal(lines, idx, line, wrapped.group(2)):
-            return var_name
+    match = direct or block_match or wrapped
+    if match is None:
         return None
-    return None
+    var_name = match.group(1)
+    if _is_public_material_name(var_name):
+        return None
+    if direct is not None:
+        return var_name
+    if block_match is not None:
+        return var_name if _block_assignment_has_literal(lines, idx, block_match.group(2)) else None
+    return var_name if _wrapped_rhs_has_literal(lines, idx, line, wrapped.group(2)) else None
 
 
 def _scan_tfvars_file(path: Path, repo_root: Path) -> list[Violation]:

--- a/scripts/adr_guard/adr_guard.py
+++ b/scripts/adr_guard/adr_guard.py
@@ -1315,40 +1315,78 @@ def _strip_trailing_line_comment(line: str) -> str:
     return line
 
 
+def _balance_scan(chars: str, depth: int) -> tuple[int, bool, bool]:
+    """Scan ``chars`` updating the ``()``/``[]``/``{}`` ``depth``.
+
+    Returns ``(new_depth, saw_delimiter, closed_to_zero)``. ``closed_to_zero``
+    is ``True`` the moment depth drops to ``<= 0`` — the expression closed
+    within ``chars``.
+    """
+    saw = False
+    for ch in chars:
+        if ch in "([{":
+            depth += 1
+            saw = True
+        elif ch in ")]}":
+            depth -= 1
+            saw = True
+            if depth <= 0:
+                return depth, saw, True
+    return depth, saw, False
+
+
+def _block_depth_scan(
+    chars: str, depth: int, opener: str, closer: str
+) -> tuple[int, bool]:
+    """Scan ``chars`` updating the ``opener``/``closer`` ``depth``.
+
+    Returns ``(new_depth, closed_to_zero)``; ``closed_to_zero`` is ``True``
+    the moment depth returns to ``0``.
+    """
+    for ch in chars:
+        if ch == opener:
+            depth += 1
+        elif ch == closer:
+            depth -= 1
+            if depth == 0:
+                return depth, True
+    return depth, False
+
+
+def _scrub_line(line: str) -> str:
+    """Blank out ``"..."`` string contents and drop the trailing ``#``/``//``
+    line comment so brace/paren counting ignores both.
+    """
+    return _strip_trailing_line_comment(_STRING_LITERAL_PATTERN.sub('""', line))
+
+
 def _find_balanced_close_index(
     lines: list[str], start_idx: int, start_pos: int
 ) -> int | None:
-    """Walk forward from `lines[start_idx][start_pos:]` tracking the
-    running depth of `()`/`[]`/`{}` (string-literal- and line-comment-aware)
+    """Walk forward from ``lines[start_idx][start_pos:]`` tracking the
+    running depth of ``()``/``[]``/``{}`` (string-literal- and line-comment-aware)
     until the depth returns to zero. Returns the line index containing
-    the closing delimiter, or None if no balance by end-of-file.
+    the closing delimiter, or ``None`` if no balance by end-of-file. A start
+    line with no delimiter at all is treated as the close (nothing to balance).
 
     Used by the wrapped-expression arm of the secrets check so multi-line
-    wrappers like `db_password = jsonencode({\\n  password = "leak"\\n})`
+    wrappers like ``db_password = jsonencode({\\n  password = "leak"\\n})``
     are walked across newlines and scanned for inner string literals.
     """
-    pairs_open = "([{"
-    pairs_close = ")]}"
     depth = 0
     started = False
     for idx in range(start_idx, len(lines)):
         line = lines[idx]
         if _is_line_commented(line):
             continue
-        scrubbed = _STRING_LITERAL_PATTERN.sub('""', line)
-        scrubbed = _strip_trailing_line_comment(scrubbed)
         offset = start_pos if idx == start_idx else 0
-        for ch in scrubbed[offset:]:
-            if ch in pairs_open:
-                depth += 1
-                started = True
-            elif ch in pairs_close:
-                depth -= 1
-                started = True
-                if depth <= 0:
-                    return idx
+        depth, saw, closed = _balance_scan(_scrub_line(line)[offset:], depth)
+        if saw:
+            started = True
+        if closed:
+            return idx
         if not started:
-            return idx  # no opener at all on the start line
+            return idx  # no opener on the start line — nothing to balance
     return None
 
 
@@ -1357,10 +1395,10 @@ def _find_block_close_index(
 ) -> int | None:
     """Return the line index containing the brace/bracket that closes the block.
 
-    `opener` is `"{"` or `"["`; matched closer is `"}"` / `"]"`. The walk
-    treats string literals and `#` / `//` line comments as inert (their
-    contents don't change the brace count). Returns the matching line
-    index, or None if no close is found by end-of-file.
+    ``opener`` is ``"{"`` or ``"["``; matched closer is ``"}"`` / ``"]"``. The
+    walk treats string literals and ``#`` / ``//`` line comments as inert
+    (their contents don't change the brace count). Returns the matching line
+    index, or ``None`` if no close is found by end-of-file.
     """
     closer = "}" if opener == "{" else "]"
     depth = 0
@@ -1368,21 +1406,133 @@ def _find_block_close_index(
         line = lines[idx]
         if _is_line_commented(line):
             continue
-        # Drop string-literal contents so braces inside strings don't count.
-        scrubbed = _STRING_LITERAL_PATTERN.sub('""', line)
-        # Drop trailing line comments.
-        for marker in ("#", "//"):
-            pos = scrubbed.find(marker)
-            if pos != -1:
-                scrubbed = scrubbed[:pos]
-        for ch in scrubbed:
-            if ch == opener:
-                depth += 1
-            elif ch == closer:
-                depth -= 1
-                if depth == 0:
-                    return idx
+        depth, closed = _block_depth_scan(_scrub_line(line), depth, opener, closer)
+        if closed:
+            return idx
     return None
+
+
+def _collect_tfvars_candidates(
+    repo_root: Path, files: list[str] | None
+) -> list[Path]:
+    """Resolve the ``*.tfvars`` files in scope: the subset of ``files`` that
+    sits under ``platform/terraform/environments/`` when an explicit list is
+    given, otherwise every ``*.tfvars`` file under that tree.
+    """
+    if files is not None:
+        in_scope = [
+            p for p in files if p.startswith(_TFVARS_SCOPE) and p.endswith(".tfvars")
+        ]
+        return [repo_root / p for p in in_scope]
+    candidates: list[Path] = []
+    for scope in _TFVARS_SCOPE:
+        base = repo_root / scope
+        if not base.exists():
+            continue
+        candidates.extend(p for p in base.rglob("*.tfvars") if p.is_file())
+    return candidates
+
+
+def _is_public_material_name(var_name: str) -> bool:
+    """``True`` for names ending in a public-material suffix (``*_public_key``,
+    ``*_authorized_keys``, ``*_pubkey``, …) — material that is share-only by
+    design, so a string literal there is not a leaked secret.
+    """
+    return any(var_name.endswith(suffix) for suffix in _NON_SECRET_NAME_SUFFIXES)
+
+
+def _lines_have_string_literal(
+    lines: list[str], start_idx: int, end_idx: int
+) -> bool:
+    """``True`` if any line in ``lines[start_idx:end_idx + 1]`` carries a
+    ``"..."`` literal once full-line comments are skipped and trailing
+    ``#``/``//`` comment tails are stripped.
+    """
+    for idx in range(start_idx, end_idx + 1):
+        inner = lines[idx]
+        if _is_line_commented(inner):
+            continue
+        if _STRING_LITERAL_PATTERN.search(_strip_trailing_line_comment(inner)):
+            return True
+    return False
+
+
+def _wrapped_rhs_has_literal(
+    lines: list[str], idx: int, line: str, rhs: str
+) -> bool:
+    """``True`` if a function-wrapped / expression RHS of a secret assignment
+    materializes a string literal — scanning the RHS on the assignment line
+    and, when it opens a balanced ``()``/``[]``/``{}`` that spans lines, the
+    rest of the multi-line expression.
+    """
+    if _STRING_LITERAL_PATTERN.search(_strip_trailing_line_comment(rhs)):
+        return True
+    close_idx = _find_balanced_close_index(lines, idx, line.find("=") + 1)
+    if close_idx is None or close_idx <= idx:
+        return False
+    return _lines_have_string_literal(lines, idx + 1, close_idx)
+
+
+def _flagged_secret_var(lines: list[str], idx: int) -> str | None:
+    """Return the secret-bearing variable on ``lines[idx]`` that is assigned a
+    plaintext string literal — directly, via a heredoc, via an object/array
+    block, or wrapped in a function/expression — or ``None`` when the line is
+    clean or the variable name is public material.
+    """
+    line = lines[idx]
+    direct = _SECRET_VAR_PATTERN.match(line) or _SECRET_HEREDOC_PATTERN.match(line)
+    if direct is not None:
+        return None if _is_public_material_name(direct.group(1)) else direct.group(1)
+    block_match = _SECRET_BLOCK_OPEN_PATTERN.match(line)
+    if block_match is not None:
+        var_name = block_match.group(1)
+        if _is_public_material_name(var_name):
+            return None
+        close_idx = _find_block_close_index(lines, idx, block_match.group(2))
+        end_idx = close_idx if close_idx is not None else len(lines) - 1
+        return var_name if _lines_have_string_literal(lines, idx, end_idx) else None
+    wrapped = _SECRET_ASSIGNMENT_PATTERN.match(line)
+    if wrapped is not None:
+        var_name = wrapped.group(1)
+        if _is_public_material_name(var_name):
+            return None
+        if _wrapped_rhs_has_literal(lines, idx, line, wrapped.group(2)):
+            return var_name
+        return None
+    return None
+
+
+def _scan_tfvars_file(path: Path, repo_root: Path) -> list[Violation]:
+    """Scan one ``*.tfvars`` file for plaintext-secret assignments (ADR-004-R7).
+
+    Block comments are spanned BEFORE line splitting so their contents
+    (including any ``password = "..."`` examples) cannot trigger the regex;
+    line numbers are preserved.
+    """
+    try:
+        raw_text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+    lines = _strip_hcl_comments(raw_text).splitlines()
+    rel = _repo_relative(path, repo_root)
+    violations: list[Violation] = []
+    for idx, line in enumerate(lines):
+        if _is_line_commented(line):
+            continue
+        var_name = _flagged_secret_var(lines, idx)
+        if var_name is None:
+            continue
+        violations.append(
+            Violation(
+                "no-plaintext-secrets-in-tfvars",
+                "ADR-004-R7",
+                rel,
+                f"Line {idx + 1}: {var_name!r} is assigned a "
+                f"plaintext string literal; reference an out-of-band "
+                f"secret store (Secrets Manager, SSM, environment) instead",
+            )
+        )
+    return violations
 
 
 def check_no_plaintext_secrets_in_tfvars(
@@ -1390,134 +1540,21 @@ def check_no_plaintext_secrets_in_tfvars(
 ) -> list[Violation]:
     """Forbid string literals on secret-bearing tfvars assignments (ADR-004-R7).
 
-    Scans `*.tfvars` files committed under `platform/terraform/environments/`
+    Scans ``*.tfvars`` files committed under ``platform/terraform/environments/``
     and flags any line that assigns a quoted string to a variable whose name
-    ends in `_password`, `_secret`, `_token`, `_key`, `_credentials`, or
-    `_credential`. Var/local/data references and empty strings are allowed
-    (they don't materialize a credential in source). `*.tfvars.example`
-    files and full-line comments are skipped.
+    ends in ``_password``, ``_secret``, ``_token``, ``_key``, ``_credentials``,
+    or ``_credential``. Var/local/data references and empty strings are allowed
+    (they don't materialize a credential in source). ``*.tfvars.example`` files
+    and full-line comments are skipped.
 
-    gitleaks catches high-entropy random strings; this is the
-    complementary backstop for low-entropy committed credentials that
-    gitleaks ignores (e.g. human-typed passwords with mixed case and
-    a single digit suffix).
+    gitleaks catches high-entropy random strings; this is the complementary
+    backstop for low-entropy committed credentials that gitleaks ignores
+    (e.g. human-typed passwords with mixed case and a single digit suffix).
     """
-    if files is not None:
-        candidate_paths = [
-            repo_root / path
-            for path in files
-            if path.startswith(_TFVARS_SCOPE)
-            and path.endswith(".tfvars")
-        ]
-    else:
-        candidate_paths = []
-        for scope in _TFVARS_SCOPE:
-            base = repo_root / scope
-            if not base.exists():
-                continue
-            for p in base.rglob("*.tfvars"):
-                if p.is_file():
-                    candidate_paths.append(p)
-
     violations: list[Violation] = []
-    for path in candidate_paths:
-        if not path.exists():
-            continue
-        try:
-            raw_text = path.read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError):
-            continue
-        # Block comments are spanned BEFORE line splitting so their
-        # contents (including any `password = "..."` examples) cannot
-        # trigger the regex. Line numbers are preserved.
-        text = _strip_hcl_comments(raw_text)
-        rel = _repo_relative(path, repo_root)
-        lines = text.splitlines()
-        for idx, line in enumerate(lines):
-            lineno = idx + 1
-            if _is_line_commented(line):
-                continue
-            match = _SECRET_VAR_PATTERN.match(line) or _SECRET_HEREDOC_PATTERN.match(line)
-            block_match = None
-            wrapped_match = None
-            if match is None:
-                block_match = _SECRET_BLOCK_OPEN_PATTERN.match(line)
-                if block_match is None:
-                    # Last-resort scan: a secret-bearing variable
-                    # whose RHS is a function call or other expression
-                    # containing a string literal (e.g.
-                    # `db_password = trimspace("...")`,
-                    # `api_token = sensitive("...")`,
-                    # `db_credentials = jsonencode({password = "..."})`).
-                    # When the RHS opens a balanced expression (`(`,
-                    # `[`, `{`) that doesn't close on the same line,
-                    # walk forward to the matching close and scan the
-                    # full multi-line expression for string literals.
-                    wrapped_match = _SECRET_ASSIGNMENT_PATTERN.match(line)
-                    if wrapped_match is None:
-                        continue
-                    rhs = wrapped_match.group(2)
-                    rhs_no_comment = _strip_trailing_line_comment(rhs)
-                    contains_literal = bool(
-                        _STRING_LITERAL_PATTERN.search(rhs_no_comment)
-                    )
-                    if not contains_literal:
-                        rhs_start = line.find("=") + 1
-                        balanced_close = _find_balanced_close_index(
-                            lines, idx, rhs_start
-                        )
-                        if balanced_close is not None and balanced_close > idx:
-                            for inner_idx in range(idx + 1, balanced_close + 1):
-                                inner = lines[inner_idx]
-                                if _is_line_commented(inner):
-                                    continue
-                                stripped_inner = _strip_trailing_line_comment(inner)
-                                if _STRING_LITERAL_PATTERN.search(stripped_inner):
-                                    contains_literal = True
-                                    break
-                    if not contains_literal:
-                        continue
-                    var_name = wrapped_match.group(1)
-                else:
-                    var_name = block_match.group(1)
-            else:
-                var_name = match.group(1)
-            if any(var_name.endswith(suffix) for suffix in _NON_SECRET_NAME_SUFFIXES):
-                continue
-            if block_match is not None:
-                # Object/array assignment to a secret-bearing variable.
-                # Walk forward to the matching close; only flag if any
-                # nested line carries a string literal (an empty object,
-                # or one composed solely of var/local/data references,
-                # is acceptable).
-                close_idx = _find_block_close_index(lines, idx, block_match.group(2))
-                end_idx = close_idx if close_idx is not None else len(lines) - 1
-                contains_string_literal = False
-                for inner_idx in range(idx, end_idx + 1):
-                    inner = lines[inner_idx]
-                    if _is_line_commented(inner):
-                        continue
-                    # Strip trailing # / // comments so a comment that
-                    # contains a "quoted example" is not treated as a
-                    # secret value. The block-open line itself contains
-                    # no value (it ends with `{`/`[`), so stripping its
-                    # trailing comment is also safe.
-                    stripped_inner = _strip_trailing_line_comment(inner)
-                    if _STRING_LITERAL_PATTERN.search(stripped_inner):
-                        contains_string_literal = True
-                        break
-                if not contains_string_literal:
-                    continue
-            violations.append(
-                Violation(
-                    "no-plaintext-secrets-in-tfvars",
-                    "ADR-004-R7",
-                    rel,
-                    f"Line {lineno}: {var_name!r} is assigned a "
-                    f"plaintext string literal; reference an out-of-band "
-                    f"secret store (Secrets Manager, SSM, environment) instead",
-                )
-            )
+    for path in _collect_tfvars_candidates(repo_root, files):
+        if path.exists():
+            violations.extend(_scan_tfvars_file(path, repo_root))
     return violations
 
 

--- a/scripts/adr_guard/adr_guard.py
+++ b/scripts/adr_guard/adr_guard.py
@@ -1206,6 +1206,321 @@ def check_k8s_deployment_security_context(
     return violations
 
 
+_TFVARS_SCOPE = ("platform/terraform/environments",)
+_SECRET_NAME_GROUP = (
+    r'([A-Za-z_][A-Za-z0-9_]*'
+    r'(?:_passwords?|_secrets?|_tokens?|_keys?|_credentials?))'
+)
+_SECRET_VAR_PATTERN = re.compile(
+    r'^\s*' + _SECRET_NAME_GROUP + r'\s*=\s*"[^"]+"',
+)
+# HCL also supports heredoc string literals (`name = <<EOF` /
+# `name = <<-EOF`), which would otherwise bypass the line regex above.
+_SECRET_HEREDOC_PATTERN = re.compile(
+    r'^\s*' + _SECRET_NAME_GROUP + r'\s*=\s*<<-?[A-Za-z_][A-Za-z0-9_]*\s*$',
+)
+# Object / array assignments to secret-bearing variables. These are
+# walked forward to the matching brace/bracket and flagged when any
+# string literal appears inside.
+_SECRET_BLOCK_OPEN_PATTERN = re.compile(
+    r'^\s*' + _SECRET_NAME_GROUP + r'\s*=\s*([\{\[])',
+)
+# Generic single-line assignment to a secret-bearing variable. Used to
+# catch function-wrapped string literals like
+# `db_password = trimspace("...")` or `api_token = sensitive("...")`
+# that the bare-string and block-open patterns above don't cover. The
+# RHS is whatever follows `=` on the same line; the violation walker
+# then scans for a string literal in that RHS (after stripping trailing
+# # / // comments) and flags when present.
+_SECRET_ASSIGNMENT_PATTERN = re.compile(
+    r'^\s*' + _SECRET_NAME_GROUP + r'\s*=\s*(.+)$',
+)
+_STRING_LITERAL_PATTERN = re.compile(r'"[^"]+"')
+_BLOCK_COMMENT_PATTERN = re.compile(r'/\*.*?\*/', re.DOTALL)
+# Variable-name suffixes that mark share-only material (SSH/JWT public
+# keys, authorized_keys files, public certificates) so the suffix-based
+# regex doesn't over-flag them. Matched against `var_name.endswith(...)`
+# so a variable like `public_key_password` is NOT exempted (the secret
+# suffix `_password` still wins, even though `public_key` appears in
+# the name).
+_NON_SECRET_NAME_SUFFIXES = (
+    "_public_key",
+    "_public_keys",
+    "_public_cert",
+    "_public_certs",
+    "_pub_key",
+    "_pub_keys",
+    "_pubkey",
+    "_pubkeys",
+    "_authorized_keys",
+    "public_key",
+    "public_keys",
+    "public_cert",
+    "public_certs",
+    "pub_key",
+    "pub_keys",
+    "pubkey",
+    "pubkeys",
+    "authorized_keys",
+)
+
+
+def _strip_hcl_comments(text: str) -> str:
+    """Replace HCL block comments with whitespace (preserving newlines).
+
+    Line comments (`#`, `//`) are handled per-line by the caller so it can
+    keep line numbers aligned for violation reporting. Block comments are
+    stripped here because they can span lines; we replace each character
+    with whitespace except newlines so subsequent regexes still see the
+    same line numbers.
+    """
+
+    def _blank(match: re.Match[str]) -> str:
+        return "".join("\n" if ch == "\n" else " " for ch in match.group(0))
+
+    return _BLOCK_COMMENT_PATTERN.sub(_blank, text)
+
+
+def _is_line_commented(line: str) -> bool:
+    stripped = line.lstrip()
+    return stripped.startswith("#") or stripped.startswith("//")
+
+
+def _strip_trailing_line_comment(line: str) -> str:
+    """Drop trailing `#` or `//` line-comment tail from an HCL line.
+
+    Walks the line keeping track of whether we're inside a `"..."`
+    string so a `#` or `//` inside a string is preserved.
+    """
+    in_string = False
+    escape = False
+    i = 0
+    while i < len(line):
+        ch = line[i]
+        if in_string:
+            if escape:
+                escape = False
+            elif ch == "\\":
+                escape = True
+            elif ch == '"':
+                in_string = False
+        else:
+            if ch == '"':
+                in_string = True
+            elif ch == "#":
+                return line[:i]
+            elif ch == "/" and i + 1 < len(line) and line[i + 1] == "/":
+                return line[:i]
+        i += 1
+    return line
+
+
+def _find_balanced_close_index(
+    lines: list[str], start_idx: int, start_pos: int
+) -> int | None:
+    """Walk forward from `lines[start_idx][start_pos:]` tracking the
+    running depth of `()`/`[]`/`{}` (string-literal- and line-comment-aware)
+    until the depth returns to zero. Returns the line index containing
+    the closing delimiter, or None if no balance by end-of-file.
+
+    Used by the wrapped-expression arm of the secrets check so multi-line
+    wrappers like `db_password = jsonencode({\\n  password = "leak"\\n})`
+    are walked across newlines and scanned for inner string literals.
+    """
+    pairs_open = "([{"
+    pairs_close = ")]}"
+    depth = 0
+    started = False
+    for idx in range(start_idx, len(lines)):
+        line = lines[idx]
+        if _is_line_commented(line):
+            continue
+        scrubbed = _STRING_LITERAL_PATTERN.sub('""', line)
+        scrubbed = _strip_trailing_line_comment(scrubbed)
+        offset = start_pos if idx == start_idx else 0
+        for ch in scrubbed[offset:]:
+            if ch in pairs_open:
+                depth += 1
+                started = True
+            elif ch in pairs_close:
+                depth -= 1
+                started = True
+                if depth <= 0:
+                    return idx
+        if not started:
+            return idx  # no opener at all on the start line
+    return None
+
+
+def _find_block_close_index(
+    lines: list[str], start_idx: int, opener: str
+) -> int | None:
+    """Return the line index containing the brace/bracket that closes the block.
+
+    `opener` is `"{"` or `"["`; matched closer is `"}"` / `"]"`. The walk
+    treats string literals and `#` / `//` line comments as inert (their
+    contents don't change the brace count). Returns the matching line
+    index, or None if no close is found by end-of-file.
+    """
+    closer = "}" if opener == "{" else "]"
+    depth = 0
+    for idx in range(start_idx, len(lines)):
+        line = lines[idx]
+        if _is_line_commented(line):
+            continue
+        # Drop string-literal contents so braces inside strings don't count.
+        scrubbed = _STRING_LITERAL_PATTERN.sub('""', line)
+        # Drop trailing line comments.
+        for marker in ("#", "//"):
+            pos = scrubbed.find(marker)
+            if pos != -1:
+                scrubbed = scrubbed[:pos]
+        for ch in scrubbed:
+            if ch == opener:
+                depth += 1
+            elif ch == closer:
+                depth -= 1
+                if depth == 0:
+                    return idx
+    return None
+
+
+def check_no_plaintext_secrets_in_tfvars(
+    repo_root: Path, files: list[str] | None
+) -> list[Violation]:
+    """Forbid string literals on secret-bearing tfvars assignments (ADR-004-R7).
+
+    Scans `*.tfvars` files committed under `platform/terraform/environments/`
+    and flags any line that assigns a quoted string to a variable whose name
+    ends in `_password`, `_secret`, `_token`, `_key`, `_credentials`, or
+    `_credential`. Var/local/data references and empty strings are allowed
+    (they don't materialize a credential in source). `*.tfvars.example`
+    files and full-line comments are skipped.
+
+    gitleaks catches high-entropy random strings; this is the
+    complementary backstop for low-entropy committed credentials that
+    gitleaks ignores (e.g. human-typed passwords with mixed case and
+    a single digit suffix).
+    """
+    if files is not None:
+        candidate_paths = [
+            repo_root / path
+            for path in files
+            if path.startswith(_TFVARS_SCOPE)
+            and path.endswith(".tfvars")
+        ]
+    else:
+        candidate_paths = []
+        for scope in _TFVARS_SCOPE:
+            base = repo_root / scope
+            if not base.exists():
+                continue
+            for p in base.rglob("*.tfvars"):
+                if p.is_file():
+                    candidate_paths.append(p)
+
+    violations: list[Violation] = []
+    for path in candidate_paths:
+        if not path.exists():
+            continue
+        try:
+            raw_text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        # Block comments are spanned BEFORE line splitting so their
+        # contents (including any `password = "..."` examples) cannot
+        # trigger the regex. Line numbers are preserved.
+        text = _strip_hcl_comments(raw_text)
+        rel = _repo_relative(path, repo_root)
+        lines = text.splitlines()
+        for idx, line in enumerate(lines):
+            lineno = idx + 1
+            if _is_line_commented(line):
+                continue
+            match = _SECRET_VAR_PATTERN.match(line) or _SECRET_HEREDOC_PATTERN.match(line)
+            block_match = None
+            wrapped_match = None
+            if match is None:
+                block_match = _SECRET_BLOCK_OPEN_PATTERN.match(line)
+                if block_match is None:
+                    # Last-resort scan: a secret-bearing variable
+                    # whose RHS is a function call or other expression
+                    # containing a string literal (e.g.
+                    # `db_password = trimspace("...")`,
+                    # `api_token = sensitive("...")`,
+                    # `db_credentials = jsonencode({password = "..."})`).
+                    # When the RHS opens a balanced expression (`(`,
+                    # `[`, `{`) that doesn't close on the same line,
+                    # walk forward to the matching close and scan the
+                    # full multi-line expression for string literals.
+                    wrapped_match = _SECRET_ASSIGNMENT_PATTERN.match(line)
+                    if wrapped_match is None:
+                        continue
+                    rhs = wrapped_match.group(2)
+                    rhs_no_comment = _strip_trailing_line_comment(rhs)
+                    contains_literal = bool(
+                        _STRING_LITERAL_PATTERN.search(rhs_no_comment)
+                    )
+                    if not contains_literal:
+                        rhs_start = line.find("=") + 1
+                        balanced_close = _find_balanced_close_index(
+                            lines, idx, rhs_start
+                        )
+                        if balanced_close is not None and balanced_close > idx:
+                            for inner_idx in range(idx + 1, balanced_close + 1):
+                                inner = lines[inner_idx]
+                                if _is_line_commented(inner):
+                                    continue
+                                stripped_inner = _strip_trailing_line_comment(inner)
+                                if _STRING_LITERAL_PATTERN.search(stripped_inner):
+                                    contains_literal = True
+                                    break
+                    if not contains_literal:
+                        continue
+                    var_name = wrapped_match.group(1)
+                else:
+                    var_name = block_match.group(1)
+            else:
+                var_name = match.group(1)
+            if any(var_name.endswith(suffix) for suffix in _NON_SECRET_NAME_SUFFIXES):
+                continue
+            if block_match is not None:
+                # Object/array assignment to a secret-bearing variable.
+                # Walk forward to the matching close; only flag if any
+                # nested line carries a string literal (an empty object,
+                # or one composed solely of var/local/data references,
+                # is acceptable).
+                close_idx = _find_block_close_index(lines, idx, block_match.group(2))
+                end_idx = close_idx if close_idx is not None else len(lines) - 1
+                contains_string_literal = False
+                for inner_idx in range(idx, end_idx + 1):
+                    inner = lines[inner_idx]
+                    if _is_line_commented(inner):
+                        continue
+                    # Strip trailing # / // comments so a comment that
+                    # contains a "quoted example" is not treated as a
+                    # secret value. The block-open line itself contains
+                    # no value (it ends with `{`/`[`), so stripping its
+                    # trailing comment is also safe.
+                    stripped_inner = _strip_trailing_line_comment(inner)
+                    if _STRING_LITERAL_PATTERN.search(stripped_inner):
+                        contains_string_literal = True
+                        break
+                if not contains_string_literal:
+                    continue
+            violations.append(
+                Violation(
+                    "no-plaintext-secrets-in-tfvars",
+                    "ADR-004-R7",
+                    rel,
+                    f"Line {lineno}: {var_name!r} is assigned a "
+                    f"plaintext string literal; reference an out-of-band "
+                    f"secret store (Secrets Manager, SSM, environment) instead",
+                )
+            )
+    return violations
+
+
 CHECKS = {
     "adr-registry": check_adr_registry,
     "layer-imports": check_layer_imports,
@@ -1214,6 +1529,7 @@ CHECKS = {
     "cloud-factory-seam": check_cloud_factory_seam,
     "mcp-no-shell-exec": check_mcp_no_shell_exec,
     "k8s-deployment-security-context": check_k8s_deployment_security_context,
+    "no-plaintext-secrets-in-tfvars": check_no_plaintext_secrets_in_tfvars,
 }
 CHECK_LEVELS = {
     "fast": [
@@ -1223,6 +1539,7 @@ CHECK_LEVELS = {
         "guardrail-docs",
         "cloud-factory-seam",
         "mcp-no-shell-exec",
+        "no-plaintext-secrets-in-tfvars",
     ],
     "ci": [
         "adr-registry",
@@ -1231,6 +1548,7 @@ CHECK_LEVELS = {
         "cloud-factory-seam",
         "mcp-no-shell-exec",
         "k8s-deployment-security-context",
+        "no-plaintext-secrets-in-tfvars",
     ],
     "all": list(CHECKS),
 }

--- a/scripts/adr_guard/tests/test_adr_guard.py
+++ b/scripts/adr_guard/tests/test_adr_guard.py
@@ -520,6 +520,410 @@ class McpNoShellExecTests(unittest.TestCase):
                 [v.path for v in filtered], ["mcp/fresh/index.js"]
             )
 
+    def test_no_plaintext_secrets_flags_literal_assignment(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            tfvars_dir = repo_root / "platform" / "terraform" / "environments" / "prod" / "portal"
+            tfvars_dir.mkdir(parents=True)
+            (tfvars_dir / "terraform.tfvars").write_text(
+                'dc_domain_name = "internal.example"\n'
+                'dc_domain_password = "P@ssw0rd!"  # pragma: allowlist secret\n',
+                encoding="utf-8",
+            )
+
+            violations = ADR_GUARD.check_no_plaintext_secrets_in_tfvars(repo_root, None)
+
+            self.assertEqual(len(violations), 1)
+            self.assertEqual(violations[0].rule_id, "ADR-004-R7")
+            self.assertEqual(
+                violations[0].path,
+                "platform/terraform/environments/prod/portal/terraform.tfvars",
+            )
+            self.assertIn("dc_domain_password", violations[0].message)
+
+    def test_no_plaintext_secrets_allows_var_reference(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            tfvars_dir = repo_root / "platform" / "terraform" / "environments" / "dev" / "portal"
+            tfvars_dir.mkdir(parents=True)
+            (tfvars_dir / "terraform.tfvars").write_text(
+                "dc_domain_password = var.dc_domain_password\n"
+                "db_password         = local.db_password\n"
+                'app_secret_arn      = data.aws_secretsmanager_secret.app.arn\n',
+                encoding="utf-8",
+            )
+
+            violations = ADR_GUARD.check_no_plaintext_secrets_in_tfvars(repo_root, None)
+
+            self.assertEqual(violations, [])
+
+    def test_no_plaintext_secrets_allows_empty_string(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            tfvars_dir = repo_root / "platform" / "terraform" / "environments" / "dev" / "portal"
+            tfvars_dir.mkdir(parents=True)
+            (tfvars_dir / "terraform.tfvars").write_text(
+                'dc_domain_password = ""\n',
+                encoding="utf-8",
+            )
+
+            violations = ADR_GUARD.check_no_plaintext_secrets_in_tfvars(repo_root, None)
+
+            self.assertEqual(violations, [])
+
+    def test_no_plaintext_secrets_ignores_non_secret_vars(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            tfvars_dir = repo_root / "platform" / "terraform" / "environments" / "prod" / "portal"
+            tfvars_dir.mkdir(parents=True)
+            (tfvars_dir / "terraform.tfvars").write_text(
+                'dc_domain_name = "internal.example"\n'
+                'environment    = "prod"\n'
+                'aws_region     = "us-east-2"\n',
+                encoding="utf-8",
+            )
+
+            violations = ADR_GUARD.check_no_plaintext_secrets_in_tfvars(repo_root, None)
+
+            self.assertEqual(violations, [])
+
+    def test_no_plaintext_secrets_flags_heredoc_assignment(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            tfvars_dir = repo_root / "platform" / "terraform" / "environments" / "prod" / "portal"
+            tfvars_dir.mkdir(parents=True)
+            (tfvars_dir / "terraform.tfvars").write_text(
+                'dc_domain_password = <<EOF\n'
+                "P@ssw0rd!\n"
+                "EOF\n",
+                encoding="utf-8",
+            )
+
+            violations = ADR_GUARD.check_no_plaintext_secrets_in_tfvars(repo_root, None)
+
+            self.assertEqual(len(violations), 1)
+            self.assertEqual(violations[0].rule_id, "ADR-004-R7")
+            self.assertIn("dc_domain_password", violations[0].message)
+
+    def test_no_plaintext_secrets_flags_indented_heredoc_assignment(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            tfvars_dir = repo_root / "platform" / "terraform" / "environments" / "prod" / "portal"
+            tfvars_dir.mkdir(parents=True)
+            (tfvars_dir / "terraform.tfvars").write_text(
+                "db_password = <<-MARKER\n"
+                "  hunter2\n"
+                "  MARKER\n",
+                encoding="utf-8",
+            )
+
+            violations = ADR_GUARD.check_no_plaintext_secrets_in_tfvars(repo_root, None)
+
+            self.assertEqual(len(violations), 1)
+            self.assertEqual(violations[0].rule_id, "ADR-004-R7")
+            self.assertIn("db_password", violations[0].message)
+
+    def test_no_plaintext_secrets_allows_public_key_assignments(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            tfvars_dir = repo_root / "platform" / "terraform" / "environments" / "dev" / "portal"
+            tfvars_dir.mkdir(parents=True)
+            (tfvars_dir / "terraform.tfvars").write_text(
+                'ctfd_ssh_public_key  = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQ== user@host"\n'
+                'jwt_public_cert      = "-----BEGIN PUBLIC KEY-----..."\n'
+                'authorized_keys      = "ssh-ed25519 AAAA..."\n'
+                'pubkey               = "ssh-rsa AAAA..."\n',
+                encoding="utf-8",
+            )
+
+            violations = ADR_GUARD.check_no_plaintext_secrets_in_tfvars(repo_root, None)
+
+            self.assertEqual(violations, [])
+
+    def test_no_plaintext_secrets_flags_multiline_jsonencode_with_string(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            tfvars_dir = repo_root / "platform" / "terraform" / "environments" / "prod" / "portal"
+            tfvars_dir.mkdir(parents=True)
+            (tfvars_dir / "terraform.tfvars").write_text(
+                "db_credentials = jsonencode({\n"
+                '  password = "leak"\n'
+                "})\n",
+                encoding="utf-8",
+            )
+
+            violations = ADR_GUARD.check_no_plaintext_secrets_in_tfvars(repo_root, None)
+
+            self.assertEqual(len(violations), 1)
+            self.assertEqual(violations[0].rule_id, "ADR-004-R7")
+            self.assertIn("db_credentials", violations[0].message)
+
+    def test_no_plaintext_secrets_allows_multiline_jsonencode_with_var(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            tfvars_dir = repo_root / "platform" / "terraform" / "environments" / "prod" / "portal"
+            tfvars_dir.mkdir(parents=True)
+            (tfvars_dir / "terraform.tfvars").write_text(
+                "db_credentials = jsonencode({\n"
+                "  password = var.db_password\n"
+                "  username = var.db_username\n"
+                "})\n",
+                encoding="utf-8",
+            )
+
+            violations = ADR_GUARD.check_no_plaintext_secrets_in_tfvars(repo_root, None)
+
+            self.assertEqual(violations, [])
+
+    def test_no_plaintext_secrets_flags_multiline_function_chain(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            tfvars_dir = repo_root / "platform" / "terraform" / "environments" / "prod" / "portal"
+            tfvars_dir.mkdir(parents=True)
+            (tfvars_dir / "terraform.tfvars").write_text(
+                "api_token = sensitive(\n"
+                '  trimspace("ghp_AAAAAAAAAAAA")\n'
+                ")\n",
+                encoding="utf-8",
+            )
+
+            violations = ADR_GUARD.check_no_plaintext_secrets_in_tfvars(repo_root, None)
+
+            self.assertEqual(len(violations), 1)
+            self.assertEqual(violations[0].rule_id, "ADR-004-R7")
+            self.assertIn("api_token", violations[0].message)
+
+    def test_no_plaintext_secrets_does_not_exempt_secret_after_public_key(self) -> None:
+        # Regression: the public-key exemption used to be a substring
+        # match, which let `public_key_password = "..."` and
+        # `authorized_keys_token = "..."` slip through even though the
+        # secret-suffix regex matched. The exemption is now suffix-based
+        # so these names stay flagged.
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            tfvars_dir = repo_root / "platform" / "terraform" / "environments" / "prod" / "portal"
+            tfvars_dir.mkdir(parents=True)
+            (tfvars_dir / "terraform.tfvars").write_text(
+                'public_key_password   = "leak1"\n'
+                'authorized_keys_token = "leak2"\n'
+                'pubkey_secret         = "leak3"\n',
+                encoding="utf-8",
+            )
+
+            violations = ADR_GUARD.check_no_plaintext_secrets_in_tfvars(repo_root, None)
+
+            self.assertEqual(len(violations), 3)
+            for violation in violations:
+                self.assertEqual(violation.rule_id, "ADR-004-R7")
+
+    def test_no_plaintext_secrets_excludes_example_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            tfvars_dir = repo_root / "platform" / "terraform" / "environments" / "prod" / "portal"
+            tfvars_dir.mkdir(parents=True)
+            (tfvars_dir / "terraform.tfvars.example").write_text(
+                'dc_domain_password = "REPLACE_ME"\n',
+                encoding="utf-8",
+            )
+
+            violations = ADR_GUARD.check_no_plaintext_secrets_in_tfvars(repo_root, None)
+
+            self.assertEqual(violations, [])
+
+    def test_no_plaintext_secrets_ignores_commented_lines(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            tfvars_dir = repo_root / "platform" / "terraform" / "environments" / "prod" / "portal"
+            tfvars_dir.mkdir(parents=True)
+            (tfvars_dir / "terraform.tfvars").write_text(
+                '# dc_domain_password = "old-value"\n'
+                '#   db_password = "another-old"\n',
+                encoding="utf-8",
+            )
+
+            violations = ADR_GUARD.check_no_plaintext_secrets_in_tfvars(repo_root, None)
+
+            self.assertEqual(violations, [])
+
+    def test_no_plaintext_secrets_ignores_double_slash_comments(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            tfvars_dir = repo_root / "platform" / "terraform" / "environments" / "prod" / "portal"
+            tfvars_dir.mkdir(parents=True)
+            (tfvars_dir / "terraform.tfvars").write_text(
+                '// dc_domain_password = "old-value"\n'
+                '//   db_password         = "another-old"\n',
+                encoding="utf-8",
+            )
+
+            violations = ADR_GUARD.check_no_plaintext_secrets_in_tfvars(repo_root, None)
+
+            self.assertEqual(violations, [])
+
+    def test_no_plaintext_secrets_ignores_block_comments(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            tfvars_dir = repo_root / "platform" / "terraform" / "environments" / "prod" / "portal"
+            tfvars_dir.mkdir(parents=True)
+            (tfvars_dir / "terraform.tfvars").write_text(
+                "/* historical example:\n"
+                'dc_domain_password = "obsolete-literal"\n'
+                "*/\n"
+                'dc_domain_name = "internal.shifter"\n',
+                encoding="utf-8",
+            )
+
+            violations = ADR_GUARD.check_no_plaintext_secrets_in_tfvars(repo_root, None)
+
+            self.assertEqual(violations, [])
+
+    def test_no_plaintext_secrets_flags_object_with_string_value(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            tfvars_dir = repo_root / "platform" / "terraform" / "environments" / "prod" / "portal"
+            tfvars_dir.mkdir(parents=True)
+            (tfvars_dir / "terraform.tfvars").write_text(
+                "db_credentials = {\n"
+                '  username = "admin"\n'
+                '  password = "hunter2"\n'
+                "}\n",
+                encoding="utf-8",
+            )
+
+            violations = ADR_GUARD.check_no_plaintext_secrets_in_tfvars(repo_root, None)
+
+            self.assertEqual(len(violations), 1)
+            self.assertEqual(violations[0].rule_id, "ADR-004-R7")
+            self.assertIn("db_credentials", violations[0].message)
+
+    def test_no_plaintext_secrets_allows_object_with_only_var_references(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            tfvars_dir = repo_root / "platform" / "terraform" / "environments" / "prod" / "portal"
+            tfvars_dir.mkdir(parents=True)
+            (tfvars_dir / "terraform.tfvars").write_text(
+                "db_credentials = {\n"
+                "  username = var.db_username\n"
+                "  password = data.aws_secretsmanager_secret_version.db.secret_string\n"
+                "}\n",
+                encoding="utf-8",
+            )
+
+            violations = ADR_GUARD.check_no_plaintext_secrets_in_tfvars(repo_root, None)
+
+            self.assertEqual(violations, [])
+
+    def test_no_plaintext_secrets_flags_list_with_string_value(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            tfvars_dir = repo_root / "platform" / "terraform" / "environments" / "prod" / "portal"
+            tfvars_dir.mkdir(parents=True)
+            (tfvars_dir / "terraform.tfvars").write_text(
+                "api_tokens = [\n"
+                '  "token-one",\n'
+                '  "token-two",\n'
+                "]\n",
+                encoding="utf-8",
+            )
+
+            violations = ADR_GUARD.check_no_plaintext_secrets_in_tfvars(repo_root, None)
+
+            self.assertEqual(len(violations), 1)
+            self.assertEqual(violations[0].rule_id, "ADR-004-R7")
+            self.assertIn("api_tokens", violations[0].message)
+
+    def test_no_plaintext_secrets_flags_function_wrapped_string(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            tfvars_dir = repo_root / "platform" / "terraform" / "environments" / "prod" / "portal"
+            tfvars_dir.mkdir(parents=True)
+            (tfvars_dir / "terraform.tfvars").write_text(
+                'db_password = trimspace("hunter2")\n'
+                'api_token   = sensitive("ghp_AAAA")\n',
+                encoding="utf-8",
+            )
+
+            violations = ADR_GUARD.check_no_plaintext_secrets_in_tfvars(repo_root, None)
+
+            self.assertEqual(len(violations), 2)
+            for violation in violations:
+                self.assertEqual(violation.rule_id, "ADR-004-R7")
+
+    def test_no_plaintext_secrets_flags_jsonencode_with_string(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            tfvars_dir = repo_root / "platform" / "terraform" / "environments" / "prod" / "portal"
+            tfvars_dir.mkdir(parents=True)
+            (tfvars_dir / "terraform.tfvars").write_text(
+                'db_credentials = jsonencode({ password = "hunter2" })\n',
+                encoding="utf-8",
+            )
+
+            violations = ADR_GUARD.check_no_plaintext_secrets_in_tfvars(repo_root, None)
+
+            self.assertEqual(len(violations), 1)
+            self.assertEqual(violations[0].rule_id, "ADR-004-R7")
+            self.assertIn("db_credentials", violations[0].message)
+
+    def test_no_plaintext_secrets_allows_function_with_var_reference(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            tfvars_dir = repo_root / "platform" / "terraform" / "environments" / "prod" / "portal"
+            tfvars_dir.mkdir(parents=True)
+            (tfvars_dir / "terraform.tfvars").write_text(
+                "db_password = trimspace(var.db_password_raw)\n"
+                "api_token   = sensitive(local.token)\n",
+                encoding="utf-8",
+            )
+
+            violations = ADR_GUARD.check_no_plaintext_secrets_in_tfvars(repo_root, None)
+
+            self.assertEqual(violations, [])
+
+    def test_no_plaintext_secrets_ignores_inline_comment_in_block(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            tfvars_dir = repo_root / "platform" / "terraform" / "environments" / "prod" / "portal"
+            tfvars_dir.mkdir(parents=True)
+            (tfvars_dir / "terraform.tfvars").write_text(
+                "db_credentials = {\n"
+                '  username = var.db_username  # "old example"\n'
+                "  password = var.db_password  // legacy: was a literal once\n"
+                "}\n",
+                encoding="utf-8",
+            )
+
+            violations = ADR_GUARD.check_no_plaintext_secrets_in_tfvars(repo_root, None)
+
+            self.assertEqual(violations, [])
+
+    def test_no_plaintext_secrets_honors_explicit_file_list(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            scoped_dir = repo_root / "platform" / "terraform" / "environments" / "prod" / "portal"
+            scoped_dir.mkdir(parents=True)
+            (scoped_dir / "terraform.tfvars").write_text(
+                'dc_domain_password = "leak"\n',
+                encoding="utf-8",
+            )
+            other_dir = repo_root / "platform" / "terraform" / "environments" / "dev" / "portal"
+            other_dir.mkdir(parents=True)
+            (other_dir / "terraform.tfvars").write_text(
+                'dc_domain_password = "also-leak"\n',
+                encoding="utf-8",
+            )
+
+            violations = ADR_GUARD.check_no_plaintext_secrets_in_tfvars(
+                repo_root,
+                ["platform/terraform/environments/prod/portal/terraform.tfvars"],
+            )
+
+            self.assertEqual(len(violations), 1)
+            self.assertEqual(
+                violations[0].path,
+                "platform/terraform/environments/prod/portal/terraform.tfvars",
+            )
+
 
 class K8sDeploymentSecurityContextTests(unittest.TestCase):
     """Tests for the k8s-deployment-security-context ADR-006-R2 check."""

--- a/shifter/engine/provisioner/gdc_vmruntime_assets.py
+++ b/shifter/engine/provisioner/gdc_vmruntime_assets.py
@@ -143,11 +143,21 @@ def _get_linux_access_password(os_type: str) -> str:
 
 def _get_windows_admin_password(role: str) -> str:
     if role == "dc":
-        return os.environ.get("DC_DOMAIN_PASSWORD") or os.environ.get(
-            "GDC_WINDOWS_ADMIN_PASSWORD",
-            "CortexSavesTheDay!",
-        )
-    return os.environ.get("GDC_WINDOWS_ADMIN_PASSWORD", "CortexSavesTheDay!")
+        # DC role: read DC_DOMAIN_PASSWORD only. Same env var contract
+        # as the AWS provisioner (`main.py`) and the portal RDP
+        # credential lookup (`shifter_platform/engine/services.py`).
+        # Fail-loud when unset (matches `main.py:1816`'s SetupError on
+        # the AWS path) instead of falling back to a literal credential
+        # — committing the DC admin password as a default is the
+        # vulnerability class #760 closed.
+        password = os.environ.get("DC_DOMAIN_PASSWORD")
+        if not password:
+            raise RuntimeError(
+                "DC_DOMAIN_PASSWORD is not configured for the GDC VM Runtime DC; "
+                "seed the DC domain password secret before provisioning"
+            )
+        return password
+    return os.environ.get("GDC_WINDOWS_ADMIN_PASSWORD", "CortexSavesTheDay!")  # nosec B105 - non-DC fallback (separate follow-up)
 
 
 def _render_user_data(instance: dict[str, Any], hostname: str, public_key: str) -> str:

--- a/shifter/engine/provisioner/tests/test_gdc_vmruntime_assets.py
+++ b/shifter/engine/provisioner/tests/test_gdc_vmruntime_assets.py
@@ -64,6 +64,24 @@ class TestRenderUserData:
 
         assert "DomainPass123!" in result
 
+    def test_dc_render_raises_when_dc_domain_password_unset(self, monkeypatch):
+        # The DC role's password must come from DC_DOMAIN_PASSWORD only.
+        # No fallback to GDC_WINDOWS_ADMIN_PASSWORD or a literal — the
+        # vulnerability class #760 closed.
+        monkeypatch.delenv("DC_DOMAIN_PASSWORD", raising=False)
+        monkeypatch.setenv("GDC_WINDOWS_ADMIN_PASSWORD", "GenericWinAdminPass!")
+
+        try:
+            _render_user_data(
+                {"role": "dc", "os_type": "windows"},
+                hostname="dc-01",
+                public_key="ssh-rsa AAAA",
+            )
+        except RuntimeError as exc:
+            assert "DC_DOMAIN_PASSWORD" in str(exc)
+        else:
+            raise AssertionError("GDC DC render must raise when DC_DOMAIN_PASSWORD is unset")
+
 
 class TestApplyRangeAssets:
     @patch("gdc_vmruntime_assets._build_kube_api_client", return_value=object())

--- a/shifter/shifter_platform/documentation/docs/technical/dev/adr-enforcement.md
+++ b/shifter/shifter_platform/documentation/docs/technical/dev/adr-enforcement.md
@@ -206,10 +206,10 @@ The first slice intentionally stays small:
   matches high-entropy random strings; this catches low-entropy
   committed credentials gitleaks ignores. Implementation note: the
   check is decomposed into focused helpers (`_collect_tfvars_candidates`,
-  `_scan_tfvars_file`, `_flagged_secret_var`, `_wrapped_rhs_has_literal`,
-  `_lines_have_string_literal`, `_find_balanced_close_index`,
-  `_find_block_close_index`, `_balance_scan`, `_block_depth_scan`,
-  `_scrub_line`) so each piece stays under SonarCloud's
+  `_scan_tfvars_file`, `_flagged_secret_var`, `_block_assignment_has_literal`,
+  `_wrapped_rhs_has_literal`, `_lines_have_string_literal`,
+  `_find_balanced_close_index`, `_find_block_close_index`, `_balance_scan`,
+  `_block_depth_scan`, `_scrub_line`) so each piece stays under SonarCloud's
   cognitive-complexity threshold and tests can target each clause
   independently.
 

--- a/shifter/shifter_platform/documentation/docs/technical/dev/adr-enforcement.md
+++ b/shifter/shifter_platform/documentation/docs/technical/dev/adr-enforcement.md
@@ -204,7 +204,14 @@ The first slice intentionally stays small:
   block comments are stripped before matching, matching Terraform's
   HCL grammar. Enforces ADR-004-R7. Complements gitleaks, which
   matches high-entropy random strings; this catches low-entropy
-  committed credentials gitleaks ignores.
+  committed credentials gitleaks ignores. Implementation note: the
+  check is decomposed into focused helpers (`_collect_tfvars_candidates`,
+  `_scan_tfvars_file`, `_flagged_secret_var`, `_wrapped_rhs_has_literal`,
+  `_lines_have_string_literal`, `_find_balanced_close_index`,
+  `_find_block_close_index`, `_balance_scan`, `_block_depth_scan`,
+  `_scrub_line`) so each piece stays under SonarCloud's
+  cognitive-complexity threshold and tests can target each clause
+  independently.
 
 - `rds-pending-modifications`
   Post-`terraform apply` gate in `_shifter-platform.yml`. Reads the portal

--- a/shifter/shifter_platform/documentation/docs/technical/dev/adr-enforcement.md
+++ b/shifter/shifter_platform/documentation/docs/technical/dev/adr-enforcement.md
@@ -176,6 +176,36 @@ The first slice intentionally stays small:
   stays under SonarCloud's cognitive-complexity threshold and tests
   can target each clause independently.
 
+- `no-plaintext-secrets-in-tfvars`
+  Architecture check that scans `*.tfvars` files committed under
+  `platform/terraform/environments/` and flags any line that assigns a
+  quoted string literal to a variable whose name ends in `_password`,
+  `_passwords`, `_secret`, `_secrets`, `_token`, `_tokens`, `_key`,
+  `_keys`, `_credential`, or `_credentials`. Heredoc string literals
+  (`name = <<EOF` / `<<-EOF`) are flagged equivalently. Object/array
+  assignments to a secret-bearing variable are walked forward to the
+  matching brace/bracket and flagged when any string literal appears
+  inside (so `db_credentials = { password = "..." }` is caught while
+  `db_credentials = { password = var.x }` is allowed). Function-wrapped
+  string literals (`db_password = trimspace("...")`,
+  `api_token = sensitive("...")`,
+  `db_credentials = jsonencode({ password = "..." })`) are caught via
+  a same-line RHS scan; multi-line wrapper expressions (jsonencode
+  spanning lines, nested function calls across lines) are walked via
+  balanced-delimiter matching of `()`/`[]`/`{}` until the expression
+  closes, and any inner string literal flags the assignment.
+  Var/local/data references and empty strings
+  are allowed. Variables whose name ENDS WITH a public-material suffix
+  (`public_key`, `public_keys`, `public_cert`, `pub_key`, `pubkey`,
+  `authorized_keys`, etc.) are exempted because that material is
+  share-only by design; the match is suffix-based so a name like
+  `public_key_password` (which has the public-key fragment AND a
+  secret suffix) stays flagged. `*.tfvars.example` files are skipped. Both `#` and `//` line comments and `/* ... */`
+  block comments are stripped before matching, matching Terraform's
+  HCL grammar. Enforces ADR-004-R7. Complements gitleaks, which
+  matches high-entropy random strings; this catches low-entropy
+  committed credentials gitleaks ignores.
+
 - `rds-pending-modifications`
   Post-`terraform apply` gate in `_shifter-platform.yml`. Reads the portal
   Terraform outputs, then calls `aws rds describe-db-instances` for each

--- a/shifter/shifter_platform/documentation/docs/technical/dev/secrets.md
+++ b/shifter/shifter_platform/documentation/docs/technical/dev/secrets.md
@@ -41,6 +41,45 @@ Runtime secrets accessed by the portal at startup.
 | `shifter-{env}-portal-db-credentials` | RDS connection (host, port, user, password, dbname) |
 | `shifter-{env}-portal-app` | Django SECRET_KEY, other app secrets |
 | `shifter-{env}-portal-cognito` | OIDC client ID, client secret, domain |
+| `shifter-{env}-portal-dc-domain` | Prebaked domain-controller Administrator password for Windows domain join |
+
+The domain-controller password is a live credential. Terraform may reference
+the secret identifier needed for runtime injection, but the password value must
+not live in committed tfvars, workflow YAML, Terraform plan comments, or command
+logs.
+
+#### Bootstrap (fresh environment)
+
+The DC domain password secret is **created out-of-band before
+`terraform apply`**, not by Terraform. The engine-provisioner module
+references the secret via a `data "aws_secretsmanager_secret"` block,
+so the secret (and its `AWSCURRENT` value) must exist before any
+plan/apply that touches the engine-provisioner or portal stacks. This
+avoids the chicken-and-egg case where the same apply would create the
+empty secret AND stand up an ASG whose launch hook needs the value.
+
+The bootstrap order on a fresh environment is:
+
+1. Create and populate the secret via AWS CLI:
+   ```bash
+   aws secretsmanager create-secret \
+     --name "shifter-${ENV}-portal-dc-domain" \
+     --description "Prebaked DC Administrator password" \
+     --secret-string "$DC_DOMAIN_PASSWORD"
+   ```
+   The value must match the prebaked DC AMI's Administrator password (see
+   `platform_infrastructure/ami-management.md`).
+2. Run `terraform apply` for the portal stack. The data source resolves the
+   existing secret ARN and wires it into the engine ECS task definition
+   (`secrets = [...]`) and the portal SSM parameter
+   (`${ps_prefix}/dc-domain-password-secret-arn`). The engine task and
+   portal container read it at runtime.
+3. Subsequent rotations or value changes use
+   `aws secretsmanager put-secret-value` (Terraform never touches the
+   value, so it never lands in state). Restart the portal containers to
+   pick up the new value (see "Domain Controller Administrator Password"
+   in the rotation runbook below); future engine ECS task launches read
+   the rotated value automatically.
 
 ### Dev Box
 
@@ -132,6 +171,27 @@ aws secretsmanager create-secret \
 1. Rotate in Cognito console
 2. Update in Secrets Manager
 3. Restart portal
+
+### Domain Controller Administrator Password
+
+The portal Django container reads `DC_DOMAIN_PASSWORD` once at startup
+(`entrypoint.sh`) and caches it in the process environment, so a Secrets
+Manager update does not refresh a running portal. The engine provisioner ECS
+task, by contrast, has the value injected by ECS at each task launch via the
+task definition's `secrets = [...]` block, so future range joins pick up the
+rotated value without a task-definition redeploy.
+
+1. Rotate the domain credential and rebuild any prebaked DC AMI that embeds
+   it; both must agree on the new value
+2. Update `shifter-{env}-portal-dc-domain` in Secrets Manager
+   (`aws secretsmanager put-secret-value`)
+3. Restart the portal containers so the new value is loaded:
+   ```bash
+   docker restart portal worker-engine worker-cms worker-mc ctf-scheduler
+   ```
+   (or terminate the portal EC2 and let the ASG relaunch)
+4. No engine provisioner task-definition redeploy is required; the next ECS
+   task launch reads the rotated value
 
 ### GitHub OIDC Role
 Role ARN doesn't change. Trust policy updates are in `platform/terraform/global/iam/`.

--- a/shifter/shifter_platform/documentation/docs/technical/platform_infrastructure/ami-management.md
+++ b/shifter/shifter_platform/documentation/docs/technical/platform_infrastructure/ami-management.md
@@ -40,12 +40,14 @@ Domain Controller uses a manually-created AMI with AD DS already promoted.
 | Hostname | Fixed from AMI (typically `DC01`) |
 | AMI IDs | `shifter/packer/dc-amis.json` |
 
-**Critical:** The prebaked DC's Administrator password must match `dc_domain_password` in `terraform.tfvars`. Victims use this password for domain join.
+**Critical:** The prebaked DC's Administrator password must match the
+environment's domain password in AWS Secrets Manager. Victims use this password
+for domain join, but the value must never be committed to `terraform.tfvars`.
 
 DC AMI is prebaked because runtime promotion adds 15-20 minutes to provisioning. Tradeoffs:
 - Fixed domain name across all ranges
 - Fixed hostname (no per-range DC naming)
-- Password must be coordinated between AMI and Terraform config
+- Password rotation must be coordinated between the AMI and the runtime secret
 
 ## Workflows
 
@@ -88,11 +90,14 @@ To create a new DC AMI:
 1. Launch Windows Server 2022 base AMI
 2. Install AD DS feature
 3. Promote to DC with domain `internal.shifter`, NetBIOS `INTSHIFTER`
-4. Set Administrator password to match `dc_domain_password` in terraform.tfvars
+4. Set Administrator password to match the environment's Secrets Manager domain password
 5. Sysprep and create AMI
 6. Update `dc-amis.json`
 
-**Important:** The Administrator password set during promotion must match the `dc_domain_password` value in `platform/terraform/environments/{env}/portal/terraform.tfvars` for domain join to work.
+**Important:** The Administrator password set during promotion must match the
+runtime secret referenced by the portal/engine Terraform stack for domain join
+to work. Keep only non-secret identifiers in Terraform configuration; do not
+store the password value in environment tfvars.
 
 ## Related Files (AWS)
 

--- a/shifter/shifter_platform/engine/services.py
+++ b/shifter/shifter_platform/engine/services.py
@@ -789,6 +789,51 @@ def resume_range(request_id: UUID) -> bool:
         return False
 
 
+def _require_dc_rdp_password(instance: dict[str, Any], os_type: str, rdp_password: str | None) -> None:
+    """Fail loud when a Windows Domain Controller has no RDP password.
+
+    Minting a passwordless Guacamole RDP URL would produce an unusable
+    session and obscure the misconfiguration; the mission_control RDP view
+    maps ``ValueError`` -> HTTP 400 so the operator sees the specific reason
+    instead of a silent broken connection. ``DC_DOMAIN_PASSWORD`` is scoped
+    to the portal's own deployment provider, so a request for a DC on a
+    different provider is rejected rather than handed the wrong credential.
+    """
+    role = _first_connection_value(instance.get("role"), "instance").lower()
+    if not (os_type == "windows" and role == "dc" and not rdp_password):
+        return
+    provider_label = _first_connection_value(instance.get("cloud_provider")).lower() or "aws"
+    portal_provider = os.environ.get("CLOUD_PROVIDER", "aws").lower()
+    if provider_label != portal_provider:
+        raise ValueError(
+            f"DC password unavailable: instance provider {provider_label!r} "
+            f"does not match portal deployment provider {portal_provider!r}; "
+            f"DC_DOMAIN_PASSWORD is scoped to the portal's own provider"
+        )
+    raise ValueError("DC_DOMAIN_PASSWORD is not configured; seed the DC domain password secret and restart the portal")
+
+
+def _fetch_sftp_ssh_key(instance: dict[str, Any], os_type: str) -> str | None:
+    """SSH key used for SFTP file transfers to a Windows instance.
+
+    Windows uses key-based auth; Linux instances use password auth, so this
+    returns ``None`` for them. A lookup failure is logged and swallowed —
+    SFTP is best-effort and must not block the RDP session.
+    """
+    if os_type != "windows":
+        return None
+    ssh_key_ref = _resolve_instance_ssh_key_secret_ref(instance)
+    if not ssh_key_ref:
+        return None
+    from engine.secrets import get_ssh_key
+
+    try:
+        return get_ssh_key(ssh_key_ref)
+    except Exception as e:
+        logger.warning("Failed to get SSH key for SFTP: %s", e)
+        return None
+
+
 def get_rdp_connection_info(user: User, instance_uuid: str) -> dict[str, Any]:
     """Get connection info for RDP access to a range instance.
 
@@ -801,7 +846,7 @@ def get_rdp_connection_info(user: User, instance_uuid: str) -> dict[str, Any]:
 
     Raises:
         ValueError: If no active range, range not READY, instance not found,
-            or instance has no GUI (ubuntu)
+            instance has no GUI, or a Windows DC has no RDP password
         PermissionError: If user doesn't own the range
     """
     from engine.models import Range
@@ -813,63 +858,27 @@ def get_rdp_connection_info(user: User, instance_uuid: str) -> dict[str, Any]:
 
     logger.debug("get_rdp_connection_info: user=%s instance_uuid=%s", user.id, instance_uuid)
 
-    # Get user's active range
     range_obj = Range.get_active_for_user(user)
     if not range_obj:
         raise ValueError("No active range found")
-
-    # Verify range is ready
     if range_obj.status != Range.Status.READY:
         raise ValueError(f"Range is not ready (status: {range_obj.status})")
 
-    # Find instance by UUID
     instance = range_obj.get_instance_by_uuid(instance_uuid)
     if not instance:
         raise ValueError(f"Instance {instance_uuid} not found in range")
-    # Check if instance has GUI
+
     os_type = _first_connection_value(instance.get("os_type"), instance.get("os")).lower()
     if os_type not in ("kali", "ubuntu", "windows"):
         raise ValueError(f"RDP not available for {os_type} instances (no GUI)")
 
-    # Get IP
     host = _resolve_instance_host(instance)
     if not host:
         raise ValueError(f"Instance {instance_uuid} has no IP address")
 
     connection_name = _resolve_instance_connection_name(instance)
     rdp_username, rdp_password = _resolve_rdp_credentials(instance)
-
-    # Fail-loud when a Windows DC has no password — minting a
-    # passwordless Guacamole RDP URL would produce an unusable session
-    # and obscure the misconfiguration. The mission_control RDP view
-    # already maps ValueError → HTTP 400, so the operator sees the
-    # specific reason instead of a silent broken connection.
-    role = _first_connection_value(instance.get("role"), "instance").lower()
-    if os_type == "windows" and role == "dc" and not rdp_password:
-        provider_label = _first_connection_value(instance.get("cloud_provider")).lower() or "aws"
-        portal_provider = os.environ.get("CLOUD_PROVIDER", "aws").lower()
-        if provider_label != portal_provider:
-            raise ValueError(
-                f"DC password unavailable: instance provider {provider_label!r} "
-                f"does not match portal deployment provider {portal_provider!r}; "
-                f"DC_DOMAIN_PASSWORD is scoped to the portal's own provider"
-            )
-        raise ValueError(
-            "DC_DOMAIN_PASSWORD is not configured; seed the DC domain password secret and restart the portal"
-        )
-
-    # Get SSH key for SFTP file transfers
-    # Windows uses key-based auth; Linux uses password auth for simplicity
-    from engine.secrets import get_ssh_key
-
-    ssh_key = None
-    if os_type == "windows":
-        ssh_key_ref = _resolve_instance_ssh_key_secret_ref(instance)
-        if ssh_key_ref:
-            try:
-                ssh_key = get_ssh_key(ssh_key_ref)
-            except Exception as e:
-                logger.warning("Failed to get SSH key for SFTP: %s", e)
+    _require_dc_rdp_password(instance, os_type, rdp_password)
 
     return {
         "private_ip": host,
@@ -878,7 +887,7 @@ def get_rdp_connection_info(user: User, instance_uuid: str) -> dict[str, Any]:
         "connection_name": connection_name,
         "rdp_username": rdp_username,
         "rdp_password": rdp_password,
-        "ssh_key": ssh_key,
+        "ssh_key": _fetch_sftp_ssh_key(instance, os_type),
     }
 
 

--- a/shifter/shifter_platform/engine/services.py
+++ b/shifter/shifter_platform/engine/services.py
@@ -135,8 +135,39 @@ def _resolve_instance_ssh_username(instance: dict[str, Any]) -> str:
     return "ubuntu"
 
 
-def _get_windows_rdp_fallback(role: str) -> str:
-    return "Sh1fterDC2026" if role == "dc" else "CortexSavesTheDay!"
+def _get_windows_rdp_fallback(role: str) -> str | None:
+    # The DC role's password is a real domain credential and must come from
+    # the runtime environment (DC_DOMAIN_PASSWORD, sourced from Secrets
+    # Manager via entrypoint.sh). No literal fallback — fail-closed when
+    # unset rather than leaking a credential through committed source.
+    if role == "dc":
+        return None
+    return "CortexSavesTheDay!"  # nosec B105 - non-DC Windows victim fallback (separate follow-up)
+
+
+def _resolve_dc_password(instance_provider: str) -> str | None:
+    """Return the DC Administrator password for a Windows DC instance.
+
+    DC_DOMAIN_PASSWORD is the env var contract shared with the engine
+    provisioner (`shifter/engine/provisioner/main.py` for AWS,
+    `shifter/engine/provisioner/gdc_vmruntime_assets.py` for GCP), so
+    the portal display side reads the same env var. The credential is
+    deployment-scoped: the portal's own CLOUD_PROVIDER env identifies
+    which provider's DC password lives in DC_DOMAIN_PASSWORD. Returning
+    that value for an instance from a different provider would leak the
+    portal-deployment provider's credential to the requesting provider's
+    user — refuse with None instead. A multi-provider portal would need
+    provider-specific secrets (separate workstream, see secrets.md).
+
+    An empty `instance_provider` (older payloads with no `cloud_provider`
+    field) is treated as `"aws"`, matching the default elsewhere in the
+    engine state handling.
+    """
+    instance_provider = instance_provider or "aws"
+    portal_provider = os.environ.get("CLOUD_PROVIDER", "aws").lower()
+    if instance_provider != portal_provider:
+        return None
+    return os.environ.get("DC_DOMAIN_PASSWORD")
 
 
 def _resolve_rdp_credentials(instance: dict[str, Any]) -> tuple[str | None, str | None]:
@@ -146,13 +177,17 @@ def _resolve_rdp_credentials(instance: dict[str, Any]) -> tuple[str | None, str 
     provider = _first_connection_value(instance.get("cloud_provider")).lower()
 
     if os_type == "windows":
+        # DC role: read DC_DOMAIN_PASSWORD only when the requested
+        # instance's provider matches the portal deployment's
+        # CLOUD_PROVIDER. Same env var as the engine provisioner so the
+        # DC password used for promote/domain-join matches what the
+        # portal hands Guacamole. Cross-provider DC requests return
+        # None and are turned into an explicit ValueError below
+        # (`get_rdp_connection_info`) rather than a silent
+        # passwordless RDP URL.
+        if role == "dc":
+            return ("Administrator", _resolve_dc_password(provider))
         if provider == "gcp":
-            if role == "dc":
-                return (
-                    "Administrator",
-                    os.environ.get("DC_DOMAIN_PASSWORD")
-                    or os.environ.get("GDC_WINDOWS_ADMIN_PASSWORD", _get_windows_rdp_fallback(role)),
-                )
             return (
                 "Administrator",
                 os.environ.get("GDC_WINDOWS_ADMIN_PASSWORD", _get_windows_rdp_fallback(role)),
@@ -803,6 +838,25 @@ def get_rdp_connection_info(user: User, instance_uuid: str) -> dict[str, Any]:
 
     connection_name = _resolve_instance_connection_name(instance)
     rdp_username, rdp_password = _resolve_rdp_credentials(instance)
+
+    # Fail-loud when a Windows DC has no password — minting a
+    # passwordless Guacamole RDP URL would produce an unusable session
+    # and obscure the misconfiguration. The mission_control RDP view
+    # already maps ValueError → HTTP 400, so the operator sees the
+    # specific reason instead of a silent broken connection.
+    role = _first_connection_value(instance.get("role"), "instance").lower()
+    if os_type == "windows" and role == "dc" and not rdp_password:
+        provider_label = _first_connection_value(instance.get("cloud_provider")).lower() or "aws"
+        portal_provider = os.environ.get("CLOUD_PROVIDER", "aws").lower()
+        if provider_label != portal_provider:
+            raise ValueError(
+                f"DC password unavailable: instance provider {provider_label!r} "
+                f"does not match portal deployment provider {portal_provider!r}; "
+                f"DC_DOMAIN_PASSWORD is scoped to the portal's own provider"
+            )
+        raise ValueError(
+            "DC_DOMAIN_PASSWORD is not configured; seed the DC domain password secret and restart the portal"
+        )
 
     # Get SSH key for SFTP file transfers
     # Windows uses key-based auth; Linux uses password auth for simplicity

--- a/shifter/shifter_platform/entrypoint.sh
+++ b/shifter/shifter_platform/entrypoint.sh
@@ -45,6 +45,7 @@ DB_SECRET_ID="${DB_SECRET_ID:-${DB_SECRET_ARN:-}}"
 APP_SECRET_ID="${APP_SECRET_ID:-${APP_SECRET_ARN:-}}"
 OIDC_SECRET_ID="${OIDC_SECRET_ID:-${OIDC_SECRET_ARN:-${COGNITO_SECRET_ARN:-}}}"
 GUACAMOLE_SECRET_ID="${GUACAMOLE_SECRET_ID:-${GUACAMOLE_SECRET_ARN:-}}"
+DC_DOMAIN_PASSWORD_SECRET_ID="${DC_DOMAIN_PASSWORD_SECRET_ID:-${DC_DOMAIN_PASSWORD_SECRET_ARN:-}}"
 
 if [[ -n "${DB_SECRET_ID:-}" ]] && [[ -n "${APP_SECRET_ID:-}" ]]; then
     echo "Fetching runtime secrets from ${CLOUD_PROVIDER:-aws} secret manager..."
@@ -92,6 +93,16 @@ print(key + '=' * padding)
     fi
 
     echo "Secrets loaded successfully"
+fi
+
+# Fetch the prebaked DC Administrator password if provided. Guarded
+# independently of the DB/app outer block so deployments that supply
+# DC_DOMAIN_PASSWORD_SECRET_ARN without DB_SECRET_ID / APP_SECRET_ID
+# (direct env-var configurations, non-portal entrypoint commands)
+# still hydrate the value. The Windows-DC RDP credential lookup in
+# engine.services depends on this env var being exported.
+if [[ -n "${DC_DOMAIN_PASSWORD_SECRET_ID:-}" ]]; then
+    export DC_DOMAIN_PASSWORD=$(fetch_runtime_secret "$DC_DOMAIN_PASSWORD_SECRET_ID")
 fi
 
 # ------------------------------------------------------------------------------

--- a/shifter/shifter_platform/tests/engine/services/test_get_rdp_connection_info.py
+++ b/shifter/shifter_platform/tests/engine/services/test_get_rdp_connection_info.py
@@ -3,6 +3,8 @@
 import os
 from unittest.mock import Mock, patch
 
+import pytest
+
 
 class TestGetRdpConnectionInfo:
     """Tests provider-aware RDP connection detail resolution."""
@@ -63,7 +65,11 @@ class TestGetRdpConnectionInfo:
         assert result["rdp_username"] == "ubuntu"
         assert result["rdp_password"] == "LabUbuntu123!"
 
-    def test_gcp_dc_rdp_uses_domain_password_env(self):
+    def test_gcp_dc_rdp_uses_dc_password_env_on_gcp_portal(self):
+        # Same provider as portal deployment: the DC display reads
+        # DC_DOMAIN_PASSWORD (which is the same env var the engine
+        # provisioner uses to set the DC admin password, so display
+        # matches actual).
         from engine.models import Range
         from engine.services import get_rdp_connection_info
 
@@ -86,9 +92,104 @@ class TestGetRdpConnectionInfo:
         with (
             patch.object(Range, "get_active_for_user", return_value=mock_range),
             patch("engine.secrets.get_ssh_key", return_value="fake-ssh-key-for-testing"),
-            patch.dict(os.environ, {"DC_DOMAIN_PASSWORD": "DomainPass123!"}, clear=False),
+            patch.dict(
+                os.environ,
+                {"CLOUD_PROVIDER": "gcp", "DC_DOMAIN_PASSWORD": "GcpDcPass123!"},
+                clear=False,
+            ),
         ):
             result = get_rdp_connection_info(mock_user, "gdc-dc-uuid-123")
 
         assert result["rdp_username"] == "Administrator"
-        assert result["rdp_password"] == "DomainPass123!"
+        assert result["rdp_password"] == "GcpDcPass123!"
+
+    def test_gcp_dc_rdp_does_not_leak_aws_portal_dc_password(self):
+        # Cross-provider credential isolation: an AWS-deployed portal
+        # (CLOUD_PROVIDER=aws) holds the AWS DC password in
+        # DC_DOMAIN_PASSWORD. A GCP DC RDP request to that portal must
+        # NOT return that value; the cross-provider path raises a
+        # typed ValueError that mission_control surfaces as HTTP 400.
+        from engine.models import Range
+        from engine.services import get_rdp_connection_info
+
+        mock_user = Mock(id=1)
+        instance_data = {
+            "uuid": "gdc-dc-uuid-789",
+            "role": "dc",
+            "os_type": "windows",
+            "cloud_provider": "gcp",
+            "private_ip": "10.200.0.132",
+            "provider_metadata": {
+                "gdc": {
+                    "ssh_secret_ref": "projects/test/secrets/vmrt-ssh-key",
+                }
+            },
+        }
+        mock_range = Mock(spec=Range, id=42, user=mock_user, status=Range.Status.READY)
+        mock_range.get_instance_by_uuid = Mock(return_value=instance_data)
+
+        env_aws_portal = {
+            "CLOUD_PROVIDER": "aws",
+            "DC_DOMAIN_PASSWORD": "AwsLeakProbe123!",
+        }
+        with (
+            patch.object(Range, "get_active_for_user", return_value=mock_range),
+            patch("engine.secrets.get_ssh_key", return_value="fake-ssh-key-for-testing"),
+            patch.dict(os.environ, env_aws_portal, clear=True),
+            pytest.raises(ValueError, match="does not match portal deployment provider"),
+        ):
+            get_rdp_connection_info(mock_user, "gdc-dc-uuid-789")
+
+    def test_dc_rdp_raises_when_password_env_unset(self):
+        # Same-provider request but the secret isn't seeded — the call
+        # raises a typed ValueError with a runbook pointer instead of
+        # silently returning a passwordless connection payload.
+        from engine.models import Range
+        from engine.services import get_rdp_connection_info
+
+        mock_user = Mock(id=1)
+        instance_data = {
+            "uuid": "aws-dc-uuid-456",
+            "role": "dc",
+            "os_type": "windows",
+            "cloud_provider": "aws",
+            "private_ip": "10.100.0.131",
+        }
+        mock_range = Mock(spec=Range, id=42, user=mock_user, status=Range.Status.READY)
+        mock_range.get_instance_by_uuid = Mock(return_value=instance_data)
+
+        env_aws_no_secret = {"CLOUD_PROVIDER": "aws"}
+        with (
+            patch.object(Range, "get_active_for_user", return_value=mock_range),
+            patch.dict(os.environ, env_aws_no_secret, clear=True),
+            pytest.raises(ValueError, match="DC_DOMAIN_PASSWORD is not configured"),
+        ):
+            get_rdp_connection_info(mock_user, "aws-dc-uuid-456")
+
+    def test_aws_dc_rdp_uses_dc_password_env_on_aws_portal(self):
+        from engine.models import Range
+        from engine.services import get_rdp_connection_info
+
+        mock_user = Mock(id=1)
+        instance_data = {
+            "uuid": "aws-dc-uuid-123",
+            "role": "dc",
+            "os_type": "windows",
+            "cloud_provider": "aws",
+            "private_ip": "10.100.0.130",
+        }
+        mock_range = Mock(spec=Range, id=42, user=mock_user, status=Range.Status.READY)
+        mock_range.get_instance_by_uuid = Mock(return_value=instance_data)
+
+        with (
+            patch.object(Range, "get_active_for_user", return_value=mock_range),
+            patch.dict(
+                os.environ,
+                {"CLOUD_PROVIDER": "aws", "DC_DOMAIN_PASSWORD": "AwsDcPass123!"},
+                clear=False,
+            ),
+        ):
+            result = get_rdp_connection_info(mock_user, "aws-dc-uuid-123")
+
+        assert result["rdp_username"] == "Administrator"
+        assert result["rdp_password"] == "AwsDcPass123!"


### PR DESCRIPTION
## Summary

- Removes the literal `dc_domain_password` value from prod + dev portal `terraform.tfvars`, the matching Python fallback in `engine.services._get_windows_rdp_fallback`, and the GDC VM Runtime DC fallback in `gdc_vmruntime_assets._get_windows_admin_password`.
- Engine-provisioner Terraform module references an out-of-band-managed `aws_secretsmanager_secret` (`shifter-{env}-portal-dc-domain`) via a `data` source; operators create AND populate the secret with `aws secretsmanager create-secret` before the first `terraform apply` (see secrets.md "Bootstrap (fresh environment)"). Engine ECS task injects the value via `secrets = [...]`; portal Django container reads it through `entrypoint.sh` + `DC_DOMAIN_PASSWORD_SECRET_ARN` plumbed through portal/ssm + portal/ec2.
- Windows-DC RDP credential lookup is provider-scoped via the portal's `CLOUD_PROVIDER` env and fail-loud (raises `ValueError` mapped to HTTP 400 by mission_control) when unset or when an instance's provider doesn't match the portal's deployment provider.
- Adds `adr_guard` check `no-plaintext-secrets-in-tfvars` (ADR-004-R7) — scans tfvars for string-literal assignments to secret-bearing variables, with multi-line wrapper / HCL comment / object-array detection. Registered in pre-commit, fast, and CI levels.

## Test plan

- [x] `python3 scripts/adr_guard/adr_guard.py --all --level all`
- [x] `python3 -m unittest scripts.adr_guard.tests.test_adr_guard` (57 tests)
- [x] `cd shifter/shifter_platform && uv run pytest tests/engine/ tests/integration/engine/ -q` (373 tests)
- [x] `cd shifter/engine/provisioner && uv run pytest tests/ -q` (617 tests)
- [x] `uv run ruff check . && uv run ruff format --check .`
- [x] `tflint --recursive --config .tflint.hcl --chdir platform/terraform`
- [x] `pre-commit run` (staged scope)
- [ ] Operational: rotate the previously exposed value via `aws secretsmanager put-secret-value`; the prebaked DC AMI Administrator password and the Secrets Manager value must match.
- [ ] Operational: review whether the secret needs purging from repository history and build logs.

Closes #760