### PR TITLE
Lock provisioner runtime to read-only root + dedicated workspace volume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Provisioner container now runs with read-only root filesystem and a dedicated
+  writable workspace volume (#1103, follow-up to #950).** `shifter/engine/provisioner/Dockerfile`
+  no longer chowns `/app` or copies source with `--chown=appuser`; application code
+  stays root-owned and immutable. Terraform writes are redirected to
+  `${TERRAFORM_WORKSPACE_DIR}` (default `/var/run/provisioner/workspace`):
+  `shifter/engine/provisioner/terraform_base.py` adds `_stage_workspace()` /
+  `_cleanup_workspace()` so each Terraform apply/destroy call copies the read-only
+  module source from `/app/terraform/modules/<name>` into a per-request workspace,
+  runs `terraform init`/`apply`/`destroy` from the staged path, and removes the
+  staged tree (with any `terraform.tfvars.json` that may carry secrets) on both
+  success and failure paths. The dynamic GCP Job factory at
+  `shifter/shifter_platform/shared/cloud/gcp/task_runner.py` now sets
+  `securityContext.readOnlyRootFilesystem=true`, `runAsNonRoot=true`,
+  `runAsUser=runAsGroup=1000`, `allowPrivilegeEscalation=false`,
+  `capabilities.drop=["ALL"]`, and `seccompProfile=RuntimeDefault`, plus four
+  explicit `emptyDir` volumes (the workspace memory-backed) for
+  `/var/run/provisioner/workspace`, `/tmp`,
+  `/home/appuser/.terraform.d/plugin-cache`, and `/home/appuser/.pulumi`. The ECS
+  task definition under `platform/terraform/modules/engine-provisioner/`
+  enables `readonlyRootFilesystem` and adds matching ephemeral `volume`/`mountPoints`
+  entries. Tests under `shifter/engine/provisioner/tests/test_dockerfile.py` and
+  `shifter/engine/provisioner/tests/test_terraform_base.py` lock in the structural
+  contract; the opt-in (`RUN_DOCKER_TESTS=1`) Docker smoke test now launches the
+  container with `--read-only` and tmpfs mounts and asserts `/app` is not writable
+  while the workspace path is. Dead `_get_working_dir()` helper in
+  `shifter/engine/provisioner/main.py` (never called, misleading) removed.
+  Source: codex review of #950 (cycle 2).
 - **Provisioner container now runs as non-root (#950).** `shifter/engine/provisioner/Dockerfile`
   creates `appuser:1000 / appgroup:1000` (matching the existing pattern in
   `shifter/shifter_platform/Dockerfile`) and drops privileges via

--- a/docs/adr/index.yaml
+++ b/docs/adr/index.yaml
@@ -179,7 +179,11 @@
     "evidence": [
       "platform/k8s/gcp/base/namespaces.yaml",
       ".kube-linter.yaml",
-      ".pre-commit-config.yaml"
+      ".pre-commit-config.yaml",
+      "shifter/shifter_platform/shared/cloud/gcp/task_runner.py",
+      "shifter/engine/provisioner/Dockerfile",
+      "shifter/engine/provisioner/terraform_base.py",
+      "platform/terraform/modules/engine-provisioner/task_definition.tf"
     ]
   },
   {

--- a/platform/terraform/modules/engine-provisioner/task_definition.tf
+++ b/platform/terraform/modules/engine-provisioner/task_definition.tf
@@ -11,10 +11,58 @@ resource "aws_ecs_task_definition" "engine_provisioner" {
   execution_role_arn       = aws_iam_role.ecs_execution.arn
   task_role_arn            = aws_iam_role.ecs_task.arn
 
+  # Issue #1103: dedicated writable volumes so the container can run with
+  # readonlyRootFilesystem = true. Fargate creates these from the task's
+  # ephemeral storage (no host_path), which is fine for Terraform staging
+  # and tool caches that should not persist across task restarts.
+  #
+  # Ownership contract — these volumes have NO `host` block and NO
+  # `host_path`, so AWS/Fargate creates a Docker named-volume on the
+  # task's ephemeral storage. Docker named-volume semantics (which AWS
+  # Fargate inherits) initialize the volume from the image's directory at
+  # the mount point: contents AND ownership/permissions are copied from
+  # the image dir at mount time. The Dockerfile pre-creates each of these
+  # paths (`/var/run/provisioner/workspace`, `/tmp`,
+  # `/home/appuser/.terraform.d/plugin-cache`, `/home/appuser/.pulumi`)
+  # with `mkdir` + `chown -R appuser:appgroup`, so the named volume comes
+  # up owned by uid/gid 1000 and the non-root container can write
+  # immediately. This is the AWS-native equivalent of the GKE
+  # `fsGroup: 1000` we set on the Pod spec — different mechanism, same
+  # outcome. End-to-end dev verification (per the issue's acceptance
+  # criterion) is the conclusive cross-check.
+  # See: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specify-bind-mount-config.html
+  volume {
+    name = "provisioner-workspace"
+  }
+  volume {
+    name = "tmp"
+  }
+  volume {
+    name = "tf-plugin-cache"
+  }
+  volume {
+    name = "pulumi-home"
+  }
+
   container_definitions = jsonencode([{
-    name      = "pulumi-provisioner"
-    image     = "${var.ecr_repository_url}:${var.container_image_tag}"
-    essential = true
+    name                   = "pulumi-provisioner"
+    image                  = "${var.ecr_repository_url}:${var.container_image_tag}"
+    essential              = true
+    readonlyRootFilesystem = true
+    # Defense-in-depth: the image's USER directive already drops to UID/GID
+    # 1000, but declaring it on the task definition makes the contract
+    # explicit and guards against an image where USER was omitted. The
+    # mountPoints below resolve to ephemeral Fargate volumes that inherit
+    # the image directory's ownership (appuser:appgroup, pre-chowned in
+    # the Dockerfile), so writes by UID 1000 succeed without an init-chown.
+    user = "1000:1000"
+
+    mountPoints = [
+      { sourceVolume = "provisioner-workspace", containerPath = "/var/run/provisioner/workspace", readOnly = false },
+      { sourceVolume = "tmp", containerPath = "/tmp", readOnly = false },
+      { sourceVolume = "tf-plugin-cache", containerPath = "/home/appuser/.terraform.d/plugin-cache", readOnly = false },
+      { sourceVolume = "pulumi-home", containerPath = "/home/appuser/.pulumi", readOnly = false },
+    ]
 
     environment = [
       { name = "ENVIRONMENT", value = var.environment },

--- a/shifter/engine/provisioner/Dockerfile
+++ b/shifter/engine/provisioner/Dockerfile
@@ -4,8 +4,9 @@ FROM python:3.12-slim-trixie
 ARG TERRAFORM_VERSION=1.14.3
 ARG PULUMI_VERSION=3.142.0
 
-# Single root-stage RUN: install build tools, terraform, pulumi, then create
-# the non-root runtime user with its writable plugin-cache / pulumi dirs.
+# Single root-stage RUN: install build tools, terraform, pulumi, create the
+# non-root runtime user with its writable plugin-cache / pulumi dirs, and
+# create the writable Terraform workspace mount point.
 # Keeping these in one layer satisfies docker:S7031 (no consecutive RUNs).
 # --create-home gives Terraform/Pulumi a writable HOME for plugin caches.
 RUN apt-get update && apt-get install -y curl openssh-client unzip && \
@@ -24,25 +25,36 @@ RUN apt-get update && apt-get install -y curl openssh-client unzip && \
     groupadd --gid 1000 appgroup && \
     useradd --uid 1000 --gid appgroup --create-home --shell /bin/bash appuser && \
     mkdir -p /home/appuser/.terraform.d/plugin-cache /home/appuser/.pulumi && \
-    chown -R appuser:appgroup /home/appuser
+    chown -R appuser:appgroup /home/appuser && \
+    # Pre-create the Terraform workspace mount point. The runtime mounts an
+    # emptyDir / Fargate ephemeral volume here; chowning the parent means the
+    # mount inherits appuser ownership without needing fsGroup. terraform_base
+    # stages module sources under this path per request (issue #1103).
+    mkdir -p /var/run/provisioner/workspace && \
+    chown -R appuser:appgroup /var/run/provisioner
 
 # Install Python dependencies
 WORKDIR /app
-RUN chown appuser:appgroup /app
 COPY requirements.txt requirements-gcp.txt ./
 RUN pip install --no-cache-dir -r requirements.txt && \
     pip install --no-cache-dir -r requirements-gcp.txt
 
-# Copy provisioner code, owned by the non-root runtime user so Terraform can
-# write .terraform/ and terraform.tfvars.json inside module working directories
-# (see terraform_base.apply / destroy in this package).
-COPY --chown=appuser:appgroup . .
+# Copy provisioner code as root-owned, immutable image content. The runtime
+# user does NOT own /app — Terraform writes go to TERRAFORM_WORKSPACE_DIR
+# (terraform_base._stage_workspace) so a process compromise cannot tamper
+# with application code at runtime (issue #1103, follow-up to #950).
+COPY . .
 
 # Set HOME explicitly so Terraform/Pulumi find the writable cache/config
 # directories created above (Docker's USER directive does not adjust HOME).
+# TERRAFORM_WORKSPACE_DIR documents the writable workspace mount contract;
+# any deployer mounting an emptyDir / Fargate ephemeral volume must mount it
+# at this path so terraform_base can stage modules and write
+# `.terraform/`, `.terraform.lock.hcl`, and `terraform.tfvars.json`.
 ENV HOME=/home/appuser \
     PULUMI_HOME=/home/appuser/.pulumi \
-    TF_PLUGIN_CACHE_DIR=/home/appuser/.terraform.d/plugin-cache
+    TF_PLUGIN_CACHE_DIR=/home/appuser/.terraform.d/plugin-cache \
+    TERRAFORM_WORKSPACE_DIR=/var/run/provisioner/workspace
 
 # Drop privileges before invoking Terraform/Pulumi. Numeric UID:GID is used
 # (instead of `USER appuser`) so Kubernetes admission controllers running with

--- a/shifter/engine/provisioner/main.py
+++ b/shifter/engine/provisioner/main.py
@@ -164,18 +164,6 @@ def get_ami_id(ami_type: str) -> str:
 NGFW_SSH_WAIT_TIMEOUT_DEFAULT = 1500  # 25 minutes
 
 
-def _get_working_dir() -> str:
-    """Get the working directory for provisioner commands.
-
-    In ECS container: /app
-    In local dev: the provisioner directory (where this script lives)
-    """
-    # If DB_PASSWORD is set, we're running locally
-    if os.environ.get("DB_PASSWORD"):
-        return os.path.dirname(os.path.abspath(__file__))
-    return "/app"
-
-
 def get_db_connection() -> psycopg.Connection:
     """Get database connection.
 

--- a/shifter/engine/provisioner/range_terraform_runner.py
+++ b/shifter/engine/provisioner/range_terraform_runner.py
@@ -49,13 +49,6 @@ def has_terraform_state(request_uuid: str) -> bool:
     return terraform_base.has_terraform_state(get_range_state_key_prefix(), request_uuid)
 
 
-def init_range_workspace(request_uuid: str, working_dir: Path) -> None:
-    """Initialize Terraform workspace for Range."""
-    if _uses_active_gdc_range_plane():
-        return
-    terraform_base.init_workspace(get_range_state_key_prefix(), request_uuid, working_dir, _LABEL)
-
-
 def apply_range(
     request_uuid: str,
     variables: dict[str, Any],

--- a/shifter/engine/provisioner/terraform_base.py
+++ b/shifter/engine/provisioner/terraform_base.py
@@ -16,7 +16,9 @@ import json
 import logging
 import os
 import re
+import shutil
 import subprocess
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -34,6 +36,55 @@ _SUPPORTED_BACKEND_URL_SCHEMES = {
     "s3://": _AWS_BACKEND,
     "gs://": _GCP_BACKEND,
 }
+
+# Default writable workspace path used when TERRAFORM_WORKSPACE_DIR is not set.
+# In production the Dockerfile sets TERRAFORM_WORKSPACE_DIR explicitly to
+# /var/run/provisioner/workspace and the runtime mounts an emptyDir / Fargate
+# ephemeral volume there. Outside the container (local dev, CI, unit tests)
+# /var/run is generally not writable for an unprivileged user, so the Python
+# default falls back to a per-user temp directory.
+_DEFAULT_TERRAFORM_WORKSPACE_DIR = str(Path(tempfile.gettempdir()) / "shifter-provisioner-workspace")
+
+# The Kubernetes / ECS mount-point path. Documented separately from the
+# Python default because the container ENV declares this exact path, and it
+# is the path the Job/task volume is mounted at. Tests that assert on the
+# Dockerfile / k8s contract use this constant.
+_CONTAINER_TERRAFORM_WORKSPACE_DIR = "/var/run/provisioner/workspace"
+
+# Filename Terraform writes input variables (incl. secrets) to. Hoisted to a
+# constant because it is removed independently from the per-request workspace
+# tree as a "secret-removal must not silently fail" safeguard.
+_TFVARS_FILENAME = "terraform.tfvars.json"
+
+# Pattern matching valid request_uuid path segments. The value reaches
+# `shutil.rmtree(workspace_root / request_uuid)`, so a malformed input
+# containing `..` or `/` could escape the workspace root. Internal callers
+# always pass real UUIDs, but we enforce the contract locally rather than
+# trusting every future caller to preserve a path-safe identifier.
+# Allows letters, digits, dot (excluded as leading char), dash, underscore;
+# bounded length to keep filesystem ops sane.
+_REQUEST_UUID_PATTERN = re.compile(r"^[A-Za-z0-9_-][A-Za-z0-9._-]{0,127}$")
+
+
+# Patterns excluded from the staged workspace copy. These are runtime
+# artifacts Terraform produces inside a working directory; if any leaked
+# into the image (via `COPY . .` or a leftover from a previous build) they
+# must NOT be propagated into every new request workspace, where stale
+# state could pin the wrong provider version or break locking.
+#
+# `.terraform.lock.hcl` is intentionally NOT excluded: it is a trusted
+# repo-reviewed lockfile that pins provider checksums. Excluding it
+# would force every `terraform init` to dynamically resolve providers
+# under the privileged Job's cloud credentials — a supply-chain risk.
+# It is treated as source input and propagated into the staged workspace.
+_TERRAFORM_RUNTIME_ARTIFACT_PATTERNS = (
+    ".terraform",
+    "*.tfstate",
+    "*.tfstate.backup",
+    "*.tflock",
+    _TFVARS_FILENAME,
+    "crash*.log",
+)
 
 
 @dataclass(frozen=True)
@@ -182,6 +233,125 @@ def has_terraform_state(state_key_prefix: str, request_uuid: str) -> bool:
     return result
 
 
+def _validate_request_uuid(request_uuid: str) -> None:
+    """Reject request_uuid values that would escape the workspace root.
+
+    The value is concatenated into a filesystem path and then handed to
+    `shutil.rmtree`. A `..`, `/`, or empty string would let cleanup walk
+    outside the workspace tree. Internal callers always pass real UUIDs;
+    this validator enforces the contract at the boundary so a future
+    careless caller cannot turn this into a path-traversal sink.
+    """
+    if not isinstance(request_uuid, str) or not _REQUEST_UUID_PATTERN.fullmatch(request_uuid):
+        raise ValueError(f"request_uuid must be a path-safe identifier, got {request_uuid!r}")
+
+
+def _stage_workspace(source_dir: Path, request_uuid: str, label: str) -> Path:
+    """Copy the read-only Terraform module source to a writable per-request workspace.
+
+    Terraform writes `.terraform/`, `.terraform.lock.hcl`, and `terraform.tfvars.json`
+    next to the module's `*.tf` files. When `/app` is mounted read-only those writes
+    fail, so the runtime stages a copy of the module under
+    ``${TERRAFORM_WORKSPACE_DIR}/<request_uuid>/`` and runs Terraform from there.
+    Each request gets its own staged tree so concurrent provisioner Jobs do not
+    collide.
+
+    The per-request directory is created with mode 0o700 so other local users (in
+    a multi-tenant CI host or local dev box where the fallback workspace lives
+    under ``/tmp``) cannot enumerate or read staged secrets like
+    ``terraform.tfvars.json`` while the request is in flight.
+
+    When the source follows the conventional ``…/terraform/modules/<module-name>/``
+    layout, the whole ``terraform/`` parent is staged so cross-module relative
+    references (e.g. ``source = "../shared"``) resolve in the staged copy. For
+    other layouts the leaf module is staged on its own.
+
+    Runtime artifacts that may have leaked into the image
+    (``.terraform/``, ``*.tfstate``, ``terraform.tfvars.json``, ``crash*.log``)
+    are excluded so they cannot propagate into the new request workspace, where
+    they would either pin a stale provider version, leak old secrets, or break
+    state-locking. ``.terraform.lock.hcl`` is intentionally preserved as
+    trusted source input.
+
+    Any pre-existing staged tree under the request UUID is removed first so the
+    "clean per-request workspace" contract holds even when a previous run's
+    cleanup failed.
+    """
+    _validate_request_uuid(request_uuid)
+    workspace_root = Path(os.environ.get("TERRAFORM_WORKSPACE_DIR", _DEFAULT_TERRAFORM_WORKSPACE_DIR))
+    request_root = workspace_root / request_uuid
+    if request_root.exists():
+        shutil.rmtree(request_root, ignore_errors=True)
+    workspace_root.mkdir(parents=True, exist_ok=True)
+
+    ignore = shutil.ignore_patterns(*_TERRAFORM_RUNTIME_ARTIFACT_PATTERNS)
+
+    if source_dir.parent.name == "modules":
+        terraform_root = source_dir.parent.parent
+        relative = source_dir.relative_to(terraform_root)
+        logger.debug("Staging %s Terraform tree: %s -> %s", label, terraform_root, request_root)
+        shutil.copytree(terraform_root, request_root, ignore=ignore)
+        request_root.chmod(0o700)
+        return request_root / relative
+
+    staged = request_root / source_dir.name
+    logger.debug("Staging %s Terraform module: %s -> %s", label, source_dir, staged)
+    request_root.mkdir(parents=True, exist_ok=True)
+    request_root.chmod(0o700)
+    shutil.copytree(source_dir, staged, ignore=ignore)
+    return staged
+
+
+def _purge_tfvars(request_root: Path) -> None:
+    """Delete every ``terraform.tfvars.json`` under the per-request workspace.
+
+    Called from ``apply()`` / ``destroy()`` finally blocks BEFORE the broader
+    workspace cleanup so the secret-bearing file is removed deterministically.
+    A failure here MUST surface — silencing it would let a workspace-volume
+    permission error leave secrets on disk while the apply/destroy path
+    reports success.
+    """
+    if not request_root.exists():
+        return
+    for tfvars in request_root.rglob(_TFVARS_FILENAME):
+        try:
+            tfvars.unlink()
+        except OSError as exc:
+            raise RuntimeError(f"Failed to remove {tfvars} from staged workspace: {exc}") from exc
+
+
+def _cleanup_workspace(staged_dir: Path) -> None:
+    """Remove the per-request staged Terraform workspace tree.
+
+    Walks up from ``staged_dir`` to the per-request root under
+    ``${TERRAFORM_WORKSPACE_DIR}/<request_uuid>/`` and removes the entire tree
+    so neither the leaf module nor any sibling-tree files (in the
+    parent-staging case) survive.
+
+    This is best-effort *disk hygiene only* — secret-bearing
+    ``terraform.tfvars.json`` files MUST already have been removed by
+    ``_purge_tfvars`` before this is called. Missing paths are ignored so
+    cleanup is safe to call from a ``finally`` block without re-raising;
+    rmtree failures are logged but do not raise, so a transient permission
+    issue on the workspace volume cannot mask the actual apply/destroy
+    outcome.
+    """
+    workspace_root = Path(os.environ.get("TERRAFORM_WORKSPACE_DIR", _DEFAULT_TERRAFORM_WORKSPACE_DIR))
+    try:
+        relative_parts = staged_dir.resolve().relative_to(workspace_root.resolve()).parts
+    except ValueError:
+        relative_parts = ()
+
+    request_root = workspace_root / relative_parts[0] if relative_parts else staged_dir
+
+    if not request_root.exists():
+        return
+    try:
+        shutil.rmtree(request_root, ignore_errors=False)
+    except OSError as exc:
+        logger.warning("Failed to remove staged workspace %s: %s", request_root, exc)
+
+
 def run_terraform(
     args: list[str],
     working_dir: Path,
@@ -222,23 +392,8 @@ def run_terraform(
     return result
 
 
-def init_workspace(
-    state_key_prefix: str,
-    request_uuid: str,
-    working_dir: Path,
-    label: str,
-) -> None:
-    """Initialize Terraform workspace with dynamic backend configuration.
-
-    Args:
-        state_key_prefix: Prefix for the state key
-        request_uuid: UUID of the provisioning request
-        working_dir: Directory containing Terraform files
-        label: Label for log messages (e.g. "NGFW", "Range")
-
-    Raises:
-        RuntimeError: If init fails
-    """
+def _build_init_args(state_key_prefix: str, request_uuid: str, label: str) -> list[str]:
+    """Build the `terraform init` argument list for the active backend."""
     backend = get_backend_config(state_key_prefix, request_uuid)
 
     logger.info(
@@ -270,9 +425,58 @@ def init_workspace(
     else:
         init_args.append(f"-backend-config=prefix={backend.backend_path}")
 
-    run_terraform(init_args, working_dir)
+    return init_args
 
+
+def _run_init_in_staged_workspace(
+    state_key_prefix: str,
+    request_uuid: str,
+    staged: Path,
+    label: str,
+) -> None:
+    """Run ``terraform init`` inside an already-staged workspace.
+
+    Internal helper for ``apply()`` / ``destroy()``. There is intentionally no
+    public ``init_workspace`` entrypoint: the staged workspace is per-call and
+    must be torn down before the call returns, so initialization on its own has
+    no usable post-condition for an external caller.
+    """
+    init_args = _build_init_args(state_key_prefix, request_uuid, label)
+    run_terraform(init_args, staged)
     logger.info("%s Terraform workspace initialized successfully", label)
+
+
+def _write_tfvars(staged: Path, variables: dict[str, Any]) -> Path:
+    """Write Terraform input variables to ``terraform.tfvars.json`` under ``staged``.
+
+    The file is created with mode ``0o600`` so other local users on a multi-tenant
+    CI host (where the fallback workspace lives under ``/tmp``) cannot read input
+    variables that may carry credentials or other secrets while the request is in
+    flight. Inside the production container the volume mount is already isolated
+    from other containers in the Pod; this protects the local-dev / CI path too.
+    """
+    tfvars_path = staged / _TFVARS_FILENAME
+    fd = os.open(tfvars_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w") as f:
+        json.dump(variables, f, indent=2)
+    return tfvars_path
+
+
+def _finalize_workspace(staged: Path) -> None:
+    """Remove secrets first, then best-effort tree cleanup.
+
+    Used by ``apply()`` / ``destroy()`` ``finally`` blocks. Order matters:
+    ``_purge_tfvars`` must succeed (it raises on failure) so leftover
+    secret material does not survive a failed rmtree.
+    """
+    workspace_root = Path(os.environ.get("TERRAFORM_WORKSPACE_DIR", _DEFAULT_TERRAFORM_WORKSPACE_DIR))
+    try:
+        relative_parts = staged.resolve().relative_to(workspace_root.resolve()).parts
+    except ValueError:
+        relative_parts = ()
+    request_root = workspace_root / relative_parts[0] if relative_parts else staged
+    _purge_tfvars(request_root)
+    _cleanup_workspace(staged)
 
 
 def apply(
@@ -284,70 +488,52 @@ def apply(
 ) -> dict[str, Any]:
     """Run terraform apply and return outputs.
 
-    Args:
-        state_key_prefix: Prefix for the state key
-        request_uuid: UUID of the provisioning request
-        variables: Terraform input variables
-        working_dir: Directory containing Terraform files
-        label: Label for log messages
-
-    Returns:
-        Dict of Terraform outputs
-
-    Raises:
-        RuntimeError: If apply fails
+    Stages a writable per-request workspace, runs init/apply/output from there, and
+    removes the staged tree before returning so `terraform.tfvars.json` (which can
+    carry secrets) does not persist on the workspace volume.
     """
-    # Initialize workspace first
-    init_workspace(state_key_prefix, request_uuid, working_dir, label)
-
-    # Write variables to tfvars.json
-    tfvars_path = working_dir / "terraform.tfvars.json"
-    with open(tfvars_path, "w") as f:
-        json.dump(variables, f, indent=2)
-
-    logger.info("Running terraform apply for %s...", label)
-
-    # Run apply
-    result = run_terraform(
-        [
-            "apply",
-            "-auto-approve",
-            _TF_INPUT_FALSE,
-            "-no-color",
-            f"-var-file={tfvars_path}",
-        ],
-        working_dir,
-    )
-
-    logger.info("Terraform apply stdout:\n%s", result.stdout)
-
-    # Get outputs
-    logger.info("Retrieving Terraform outputs...")
-    output_result = run_terraform(
-        ["output", "-json", "-no-color"],
-        working_dir,
-    )
-
-    # Parse outputs - Terraform wraps each output in {"value": X, "type": T}
+    staged = _stage_workspace(working_dir, request_uuid, label)
     try:
-        raw_outputs = json.loads(output_result.stdout)
-    except json.JSONDecodeError as e:
-        logger.error("Failed to parse Terraform output: %s", output_result.stdout[:500])
-        raise RuntimeError(f"Failed to parse Terraform output as JSON: {e}") from e
+        _run_init_in_staged_workspace(state_key_prefix, request_uuid, staged, label)
 
-    outputs: dict[str, Any] = {}
-    for key, val in raw_outputs.items():
-        if not isinstance(val, dict) or "value" not in val:
-            logger.warning("Unexpected output format for %s: %s", key, val)
-            continue
-        outputs[key] = val["value"]
+        tfvars_path = _write_tfvars(staged, variables)
 
-    logger.info("Terraform outputs: %s", json.dumps(outputs, indent=2))
+        logger.info("Running terraform apply for %s...", label)
+        result = run_terraform(
+            [
+                "apply",
+                "-auto-approve",
+                _TF_INPUT_FALSE,
+                "-no-color",
+                f"-var-file={tfvars_path}",
+            ],
+            staged,
+        )
+        logger.info("Terraform apply stdout:\n%s", result.stdout)
 
-    # Clean up tfvars file (contains sensitive data)
-    tfvars_path.unlink(missing_ok=True)
+        logger.info("Retrieving Terraform outputs...")
+        output_result = run_terraform(
+            ["output", "-json", "-no-color"],
+            staged,
+        )
 
-    return outputs
+        try:
+            raw_outputs = json.loads(output_result.stdout)
+        except json.JSONDecodeError as e:
+            logger.error("Failed to parse Terraform output: %s", output_result.stdout[:500])
+            raise RuntimeError(f"Failed to parse Terraform output as JSON: {e}") from e
+
+        outputs: dict[str, Any] = {}
+        for key, val in raw_outputs.items():
+            if not isinstance(val, dict) or "value" not in val:
+                logger.warning("Unexpected output format for %s: %s", key, val)
+                continue
+            outputs[key] = val["value"]
+
+        logger.info("Terraform outputs: %s", json.dumps(outputs, indent=2))
+        return outputs
+    finally:
+        _finalize_workspace(staged)
 
 
 def destroy(
@@ -359,44 +545,31 @@ def destroy(
 ) -> None:
     """Run terraform destroy.
 
-    Args:
-        state_key_prefix: Prefix for the state key
-        request_uuid: UUID of the provisioning request
-        working_dir: Directory containing Terraform files
-        label: Label for log messages
-        variables: Optional Terraform variables dict. Required when the
-            module has variables with no defaults.
-
-    Raises:
-        RuntimeError: If destroy fails
+    Stages a writable per-request workspace, runs init/destroy from there, and
+    removes the staged tree before returning so `terraform.tfvars.json` does not
+    persist on the workspace volume.
     """
-    # Initialize workspace (needed to connect to state)
-    init_workspace(state_key_prefix, request_uuid, working_dir, label)
-
-    logger.info("Running terraform destroy for %s...", label)
-
-    destroy_args = [
-        "destroy",
-        "-auto-approve",
-        _TF_INPUT_FALSE,
-        "-no-color",
-    ]
-
-    # Write tfvars if variables provided (needed for modules with required variables)
-    tfvars_path = working_dir / "terraform.tfvars.json"
-    if variables:
-        with open(tfvars_path, "w") as f:
-            json.dump(variables, f, indent=2)
-        destroy_args.append(f"-var-file={tfvars_path}")
-
+    staged = _stage_workspace(working_dir, request_uuid, label)
     try:
-        result = run_terraform(destroy_args, working_dir)
-    finally:
-        if variables:
-            tfvars_path.unlink(missing_ok=True)
+        _run_init_in_staged_workspace(state_key_prefix, request_uuid, staged, label)
 
-    logger.info("Terraform destroy stdout:\n%s", result.stdout)
-    logger.info("%s Terraform destroy completed successfully", label)
+        logger.info("Running terraform destroy for %s...", label)
+        destroy_args = [
+            "destroy",
+            "-auto-approve",
+            _TF_INPUT_FALSE,
+            "-no-color",
+        ]
+
+        if variables:
+            tfvars_path = _write_tfvars(staged, variables)
+            destroy_args.append(f"-var-file={tfvars_path}")
+
+        result = run_terraform(destroy_args, staged)
+        logger.info("Terraform destroy stdout:\n%s", result.stdout)
+        logger.info("%s Terraform destroy completed successfully", label)
+    finally:
+        _finalize_workspace(staged)
 
 
 def cleanup_state(state_key_prefix: str, request_uuid: str, label: str) -> None:

--- a/shifter/engine/provisioner/terraform_runner.py
+++ b/shifter/engine/provisioner/terraform_runner.py
@@ -23,11 +23,6 @@ def has_terraform_state(request_uuid: str) -> bool:
     return terraform_base.has_terraform_state(_STATE_KEY_PREFIX, request_uuid)
 
 
-def init_ngfw_workspace(request_uuid: str, working_dir: Path) -> None:
-    """Initialize Terraform workspace for NGFW."""
-    terraform_base.init_workspace(_STATE_KEY_PREFIX, request_uuid, working_dir, _LABEL)
-
-
 def apply_ngfw(
     request_uuid: str,
     variables: dict[str, Any],

--- a/shifter/engine/provisioner/tests/test_dockerfile.py
+++ b/shifter/engine/provisioner/tests/test_dockerfile.py
@@ -84,20 +84,53 @@ class TestDockerfileNonRootUser:
             f"k8s runAsNonRoot admission); got `{last_directive}` at line {last_index + 1}"
         )
 
-    def test_chowns_app_directory_to_appuser(self):
-        # COPY --chown only sets ownership of files copied INTO /app — the
-        # /app directory itself, created by WORKDIR, stays root-owned unless
-        # we explicitly chown it. Both must be in place: the directory is
-        # writable for the runtime user, AND copied content is owned by it.
+    def test_app_stays_immutable_image_content(self):
+        # Issue #1103: /app must NOT be writable by the runtime user. The
+        # provisioner Job mounts the runtime root read-only, and Terraform
+        # writes go to a dedicated workspace volume (TERRAFORM_WORKSPACE_DIR)
+        # — not into /app. Chowning /app to appuser or copying source with
+        # --chown=appuser would re-introduce the writable-application-code
+        # surface that #950's review (cycle 2) flagged.
         content = _read_dockerfile()
-        assert re.search(
+        assert not re.search(
             r"chown\s+(-R\s+)?appuser:appgroup\s+/app\b",
             content,
-        ), "Dockerfile must explicitly chown /app to appuser:appgroup (WORKDIR creates it root-owned)"
-        assert re.search(
+        ), "Dockerfile MUST NOT chown /app to appuser:appgroup (issue #1103 — /app stays root-owned + immutable)"
+        assert not re.search(
             r"COPY\s+--chown=appuser:appgroup",
             content,
-        ), "Dockerfile must use COPY --chown=appuser:appgroup so copied files belong to the runtime user"
+        ), (
+            "Dockerfile MUST NOT use COPY --chown=appuser:appgroup (issue #1103 — application code under "
+            "/app stays root-owned so a compromised runtime cannot tamper with it)"
+        )
+
+    def test_declares_default_terraform_workspace_dir(self):
+        # The runtime resolves the writable Terraform workspace path from
+        # TERRAFORM_WORKSPACE_DIR (terraform_base._stage_workspace). Setting
+        # the env var in the image documents the mount contract: any deployer
+        # mounting an emptyDir / Fargate ephemeral volume must put it at this
+        # path. The default matches terraform_base._DEFAULT_TERRAFORM_WORKSPACE_DIR.
+        content = _read_dockerfile()
+        assert re.search(
+            r"\bTERRAFORM_WORKSPACE_DIR=/var/run/provisioner/workspace\b",
+            content,
+        ), "Dockerfile must set TERRAFORM_WORKSPACE_DIR=/var/run/provisioner/workspace"
+
+    def test_creates_writable_workspace_mount_point(self):
+        # The image must pre-create the workspace mount point and chown it to
+        # appuser. When the runtime mounts an emptyDir there, the mount keeps
+        # parent-directory ownership unless overridden — pre-chowning means
+        # the runtime user can write the staging tree the moment the mount
+        # is in place, even before the first Terraform run.
+        content = _read_dockerfile()
+        assert re.search(
+            r"mkdir[^\n]*/var/run/provisioner/workspace\b",
+            content,
+        ), "Dockerfile must pre-create /var/run/provisioner/workspace"
+        assert re.search(
+            r"chown\s+(-R\s+)?appuser:appgroup\s+/var/run/provisioner\b",
+            content,
+        ), "Dockerfile must chown /var/run/provisioner to appuser:appgroup"
 
     def test_sets_home_for_non_root_user(self):
         # Docker's USER directive does NOT change HOME; Terraform/Pulumi
@@ -226,23 +259,87 @@ class TestDockerfileRuntimeSmoke:
         [
             "/home/appuser/.terraform.d/plugin-cache",
             "/home/appuser/.pulumi",
-            "/app",
+            "/var/run/provisioner/workspace",
         ],
-        ids=["terraform_plugin_cache", "pulumi_home", "app_workspace"],
+        ids=["terraform_plugin_cache", "pulumi_home", "terraform_workspace"],
     )
     def test_runtime_path_writable(self, built_image, path):
         # Each path must be writable by the non-root runtime user:
         # - terraform plugin cache: Terraform downloads providers here
         # - pulumi home: Pulumi state/config
-        # - /app: Terraform writes terraform.tfvars.json + .terraform/ into
-        #   module working dirs under /app (per terraform_base.apply).
+        # - terraform workspace: terraform_base._stage_workspace copies the
+        #   read-only module source from /app/terraform/modules/<name> here
+        #   per request, then runs terraform init/apply/destroy from the
+        #   staged path so /app stays read-only (issue #1103).
         # The helper's internal assert raises if the touch/rm fails.
         self._docker_run(
             built_image,
             ["sh", "-c", f"touch {path}/.write-probe && rm {path}/.write-probe"],
         )
 
+    def test_app_is_not_writable_when_root_filesystem_is_readonly(self, built_image):
+        # Simulates the production runtime contract: --read-only on the
+        # container root, with explicit tmpfs volumes for the workspace,
+        # /tmp, and the tool caches under HOME. Under that contract /app
+        # MUST refuse writes (it is image content) while the workspace
+        # path MUST accept them. This is the live counterpart of the
+        # structural test_app_stays_immutable_image_content gate.
+        docker = self._docker_bin()
+        workspace_path = "/var/run/provisioner/workspace"
+        tmp_path = "/tmp"  # noqa: S108 — Docker tmpfs mount target, not a tempfile API call
+        tf_cache_path = "/home/appuser/.terraform.d/plugin-cache"
+        pulumi_path = "/home/appuser/.pulumi"
+        tmpfs_args = [
+            "--tmpfs",
+            f"{workspace_path}:rw,uid=1000,gid=1000",
+            "--tmpfs",
+            f"{tmp_path}:rw,uid=1000,gid=1000",
+            "--tmpfs",
+            f"{tf_cache_path}:rw,uid=1000,gid=1000",
+            "--tmpfs",
+            f"{pulumi_path}:rw,uid=1000,gid=1000",
+        ]
+
+        # 1) Writes to /app fail under --read-only (expected non-zero exit).
+        result = subprocess.run(  # noqa: S603 — absolute docker path, list args, no shell
+            [
+                docker,
+                "run",
+                "--rm",
+                "--read-only",
+                *tmpfs_args,
+                "--entrypoint",
+                "sh",
+                built_image,
+                "-c",
+                "touch /app/.write-probe",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+        )
+        assert result.returncode != 0, (
+            f"/app should be read-only under --read-only, but write succeeded: "
+            f"stdout={result.stdout!r} stderr={result.stderr!r}"
+        )
+
+        # 2) Writes to the workspace path succeed under the same contract.
+        probe_cmd = f"touch {workspace_path}/.write-probe && rm {workspace_path}/.write-probe"
+        result = subprocess.run(  # noqa: S603 — absolute docker path, list args, no shell
+            [docker, "run", "--rm", "--read-only", *tmpfs_args, "--entrypoint", "sh", built_image, "-c", probe_cmd],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+        )
+        assert result.returncode == 0, (
+            f"workspace path must be writable under --read-only with tmpfs mount: "
+            f"exit={result.returncode} stdout={result.stdout!r} stderr={result.stderr!r}"
+        )
+
     def test_tool_env_vars_set(self, built_image):
         env_dump = self._docker_run(built_image, ["env"])
         assert "TF_PLUGIN_CACHE_DIR=/home/appuser/.terraform.d/plugin-cache" in env_dump
         assert "PULUMI_HOME=/home/appuser/.pulumi" in env_dump
+        assert "TERRAFORM_WORKSPACE_DIR=/var/run/provisioner/workspace" in env_dump

--- a/shifter/engine/provisioner/tests/test_range_terraform_runner.py
+++ b/shifter/engine/provisioner/tests/test_range_terraform_runner.py
@@ -4,8 +4,7 @@ Covers destroy_range variable passing (mirrors test_terraform_runner.py for NGFW
 """
 
 import os
-from pathlib import Path
-from unittest.mock import MagicMock, mock_open, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -99,74 +98,74 @@ class TestProviderRouting:
 
 
 class TestDestroyRange:
-    """Test destroy_range passes variables correctly."""
+    """Test destroy_range passes variables correctly.
 
+    Issue #1103: destroy() stages a writable workspace under TERRAFORM_WORKSPACE_DIR,
+    runs terraform from the staged path, and cleans the staged tree up on success and
+    failure. These tests cover the public destroy_range contract: var-file is passed
+    iff variables are supplied, and the staged workspace is removed when the call
+    returns.
+    """
+
+    @patch.dict(os.environ, {"TF_STATE_BUCKET": "shifter-dev-pulumi-state"}, clear=True)
     @patch("terraform_base.run_terraform")
-    @patch("terraform_base.init_workspace")
-    def test_destroy_with_variables_writes_tfvars(self, mock_init, mock_run, tmp_path):
+    def test_destroy_with_variables_writes_tfvars(self, mock_run, tmp_path, monkeypatch):
         """When variables are provided, destroy should write tfvars and pass -var-file."""
         from range_terraform_runner import destroy_range
 
-        working_dir = tmp_path / "test-module"
-        working_dir.mkdir()
+        source = tmp_path / "src" / "modules" / "range"
+        source.mkdir(parents=True)
+        (source / "main.tf").write_text("# main\n")
+        workspace_root = tmp_path / "workspace"
+        monkeypatch.setenv("TERRAFORM_WORKSPACE_DIR", str(workspace_root))
+        monkeypatch.setenv("TF_STATE_BUCKET", "shifter-dev-pulumi-state")
+
         variables = {"range_id": 42, "user_id": 1, "request_uuid": "req-123"}
+        destroy_range("req-123", source, variables=variables)
 
-        with patch("builtins.open", mock_open()) as mocked_file, patch.object(Path, "unlink"):
-            destroy_range("req-123", working_dir, variables=variables)
-
-        mocked_file.assert_called_once_with(working_dir / "terraform.tfvars.json", "w")
-        written_data = mocked_file().write.call_args_list
-        assert len(written_data) > 0
-
+        # Last call to run_terraform was the destroy command; assert -var-file present.
         destroy_args = mock_run.call_args[0][0]
         assert any("-var-file=" in arg for arg in destroy_args)
+        # The staged workspace must be cleaned up.
+        assert not (workspace_root / "req-123").exists()
 
+    @patch.dict(os.environ, {"TF_STATE_BUCKET": "shifter-dev-pulumi-state"}, clear=True)
     @patch("terraform_base.run_terraform")
-    @patch("terraform_base.init_workspace")
-    def test_destroy_without_variables_no_var_file(self, mock_init, mock_run, tmp_path):
+    def test_destroy_without_variables_no_var_file(self, mock_run, tmp_path, monkeypatch):
         """When no variables provided, destroy should not pass -var-file."""
         from range_terraform_runner import destroy_range
 
-        working_dir = tmp_path / "test-module"
-        working_dir.mkdir()
+        source = tmp_path / "src" / "modules" / "range"
+        source.mkdir(parents=True)
+        (source / "main.tf").write_text("# main\n")
+        workspace_root = tmp_path / "workspace"
+        monkeypatch.setenv("TERRAFORM_WORKSPACE_DIR", str(workspace_root))
+        monkeypatch.setenv("TF_STATE_BUCKET", "shifter-dev-pulumi-state")
 
-        destroy_range("req-123", working_dir)
+        destroy_range("req-123", source)
 
         destroy_args = mock_run.call_args[0][0]
         assert not any("-var-file=" in arg for arg in destroy_args)
         assert "-auto-approve" in destroy_args
+        assert not (workspace_root / "req-123").exists()
 
-    @patch("terraform_base.run_terraform", side_effect=RuntimeError("destroy failed"))
-    @patch("terraform_base.init_workspace")
-    def test_destroy_cleans_up_tfvars_on_failure(self, mock_init, mock_run, tmp_path):
-        """Tfvars file should be cleaned up even if destroy fails."""
+    @patch.dict(os.environ, {"TF_STATE_BUCKET": "shifter-dev-pulumi-state"}, clear=True)
+    def test_destroy_cleans_up_workspace_on_failure(self, tmp_path, monkeypatch):
+        """Staged workspace must be removed even when terraform destroy fails — otherwise
+        terraform.tfvars.json (which can carry secrets) would persist on the volume."""
         from range_terraform_runner import destroy_range
 
-        working_dir = tmp_path / "test-module"
-        working_dir.mkdir()
-        variables = {"range_id": 42}
-        mock_unlink = MagicMock()
+        source = tmp_path / "src" / "modules" / "range"
+        source.mkdir(parents=True)
+        (source / "main.tf").write_text("# main\n")
+        workspace_root = tmp_path / "workspace"
+        monkeypatch.setenv("TERRAFORM_WORKSPACE_DIR", str(workspace_root))
+        monkeypatch.setenv("TF_STATE_BUCKET", "shifter-dev-pulumi-state")
 
         with (
-            patch("builtins.open", mock_open()),
-            patch.object(Path, "unlink", mock_unlink),
+            patch("terraform_base.run_terraform", side_effect=RuntimeError("destroy failed")),
             pytest.raises(RuntimeError, match="destroy failed"),
         ):
-            destroy_range("req-123", working_dir, variables=variables)
+            destroy_range("req-123", source, variables={"range_id": 42})
 
-        mock_unlink.assert_called_once_with(missing_ok=True)
-
-    @patch("terraform_base.run_terraform")
-    @patch("terraform_base.init_workspace")
-    def test_destroy_without_variables_does_not_create_tfvars(self, mock_init, mock_run, tmp_path):
-        """When no variables provided, no tfvars file should be created or cleaned up."""
-        from range_terraform_runner import destroy_range
-
-        working_dir = tmp_path / "test-module"
-        working_dir.mkdir()
-        mock_unlink = MagicMock()
-
-        with patch.object(Path, "unlink", mock_unlink):
-            destroy_range("req-123", working_dir)
-
-        mock_unlink.assert_not_called()
+        assert not (workspace_root / "req-123").exists()

--- a/shifter/engine/provisioner/tests/test_terraform_base.py
+++ b/shifter/engine/provisioner/tests/test_terraform_base.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
+import contextlib
+import json
+from pathlib import Path
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 
 class TestBackendResolution:
@@ -34,16 +39,33 @@ class TestBackendResolution:
 
 
 class TestWorkspaceInitialization:
-    """Tests for backend-specific terraform init arguments."""
+    """Tests for backend-specific terraform init arguments.
+
+    `apply()` runs init as its first step inside the staged workspace; these tests
+    drive `apply()` and inspect the first run_terraform call (the init invocation).
+    There is intentionally no public ``init_workspace`` entrypoint — its staged
+    workspace is per-call and torn down before return, so initialization on its
+    own has no usable post-condition for an external caller.
+    """
 
     @patch.dict("os.environ", {"TF_STATE_BUCKET": "shifter-dev-pulumi-state"}, clear=True)
     @patch("terraform_base.run_terraform")
-    def test_init_workspace_uses_s3_backend_config(self, mock_run):
-        from terraform_base import init_workspace
+    def test_init_uses_s3_backend_config(self, mock_run, tmp_path, monkeypatch):
+        from terraform_base import apply
 
-        init_workspace("ranges", "req-123", MagicMock(), "Range")
+        source = tmp_path / "src" / "modules" / "range"
+        source.mkdir(parents=True)
+        (source / "main.tf").write_text("# main\n")
+        monkeypatch.setenv("TERRAFORM_WORKSPACE_DIR", str(tmp_path / "workspace"))
+        monkeypatch.setenv("TF_STATE_BUCKET", "shifter-dev-pulumi-state")
 
-        init_args = mock_run.call_args.args[0]
+        # First run_terraform call is `terraform init`; subsequent calls return empty
+        # output JSON so apply() can finish without raising on the output parse.
+        mock_run.return_value = MagicMock(returncode=0, stdout="{}", stderr="")
+        apply("ranges", "req-123", {}, source, "Range")
+
+        init_args = mock_run.call_args_list[0].args[0]
+        assert init_args[0] == "init"
         assert "-backend-config=bucket=shifter-dev-pulumi-state" in init_args
         assert "-backend-config=key=ranges/req-123/terraform.tfstate" in init_args
         assert "-backend-config=dynamodb_table=shifter-dev-pulumi-locks" in init_args
@@ -55,15 +77,23 @@ class TestWorkspaceInitialization:
         clear=True,
     )
     @patch("terraform_base.run_terraform")
-    def test_init_workspace_handles_account_id_suffixed_bucket(self, mock_run):
+    def test_init_handles_account_id_suffixed_bucket(self, mock_run, tmp_path, monkeypatch):
         # Buckets created by the engine-state module post-3.95.6 carry an
         # account-id suffix to dodge the global S3 namespace collision.
         # The lock table name still strips at "-pulumi-state" → "-pulumi-locks".
-        from terraform_base import init_workspace
+        from terraform_base import apply
 
-        init_workspace("ranges", "req-456", MagicMock(), "Range")
+        source = tmp_path / "src" / "modules" / "range"
+        source.mkdir(parents=True)
+        (source / "main.tf").write_text("# main\n")
+        monkeypatch.setenv("TERRAFORM_WORKSPACE_DIR", str(tmp_path / "workspace"))
+        monkeypatch.setenv("TF_STATE_BUCKET", "dev-range-pulumi-state-788327019743")
 
-        init_args = mock_run.call_args.args[0]
+        mock_run.return_value = MagicMock(returncode=0, stdout="{}", stderr="")
+        apply("ranges", "req-456", {}, source, "Range")
+
+        init_args = mock_run.call_args_list[0].args[0]
+        assert init_args[0] == "init"
         assert "-backend-config=bucket=dev-range-pulumi-state-788327019743" in init_args
         assert "-backend-config=dynamodb_table=dev-range-pulumi-locks" in init_args
 
@@ -73,12 +103,21 @@ class TestWorkspaceInitialization:
         clear=True,
     )
     @patch("terraform_base.run_terraform")
-    def test_init_workspace_uses_gcs_backend_config(self, mock_run):
-        from terraform_base import init_workspace
+    def test_init_uses_gcs_backend_config(self, mock_run, tmp_path, monkeypatch):
+        from terraform_base import apply
 
-        init_workspace("gcp/gdc-ranges", "req-123", MagicMock(), "Range")
+        source = tmp_path / "src" / "modules" / "range"
+        source.mkdir(parents=True)
+        (source / "main.tf").write_text("# main\n")
+        monkeypatch.setenv("TERRAFORM_WORKSPACE_DIR", str(tmp_path / "workspace"))
+        monkeypatch.setenv("CLOUD_PROVIDER", "gcp")
+        monkeypatch.setenv("TF_STATE_BUCKET", "shifter-gcp-dev-terraform-state")
 
-        init_args = mock_run.call_args.args[0]
+        mock_run.return_value = MagicMock(returncode=0, stdout="{}", stderr="")
+        apply("gcp/gdc-ranges", "req-123", {}, source, "Range")
+
+        init_args = mock_run.call_args_list[0].args[0]
+        assert init_args[0] == "init"
         assert "-backend-config=bucket=shifter-gcp-dev-terraform-state" in init_args
         assert "-backend-config=prefix=gcp/gdc-ranges/req-123" in init_args
         assert not any(arg.startswith("-backend-config=key=") for arg in init_args)
@@ -106,3 +145,540 @@ class TestStateCleanup:
             bucket="shifter-gcp-dev-terraform-state",
             key="gcp/gdc-ranges/req-123/default.tfstate",
         )
+
+
+class TestWorkspaceStaging:
+    """Workspace staging keeps /app immutable while Terraform writes go to a dedicated, writable path.
+
+    Issue #1103: when the provisioner container runs with readOnlyRootFilesystem=true the
+    Terraform module path under /app/terraform/modules/<name> cannot be the working directory
+    (terraform init writes .terraform/, .terraform.lock.hcl, terraform.tfvars.json there).
+    terraform_base copies the module source tree to ${TERRAFORM_WORKSPACE_DIR}/<request_uuid>/<name>/
+    before running terraform, runs terraform from the staged path, and removes the staged tree
+    afterwards.
+    """
+
+    def test_stage_workspace_copies_module_into_workspace_dir(self, tmp_path):
+        from terraform_base import _stage_workspace
+
+        source = tmp_path / "module-src"
+        (source / "templates").mkdir(parents=True)
+        (source / "main.tf").write_text("# main\n")
+        (source / "variables.tf").write_text("# variables\n")
+        (source / "templates" / "kali.sh.tpl").write_text("#!/bin/sh\n")
+
+        workspace_root = tmp_path / "workspace"
+
+        with patch.dict("os.environ", {"TERRAFORM_WORKSPACE_DIR": str(workspace_root)}, clear=False):
+            staged = _stage_workspace(source, "req-abc", "Range")
+
+        assert staged.is_dir()
+        assert staged.parent == workspace_root / "req-abc"
+        assert (staged / "main.tf").read_text() == "# main\n"
+        assert (staged / "variables.tf").read_text() == "# variables\n"
+        assert (staged / "templates" / "kali.sh.tpl").read_text() == "#!/bin/sh\n"
+
+    def test_stage_workspace_default_dir_is_writable_for_local_dev(self, tmp_path, monkeypatch):
+        """The Python default for TERRAFORM_WORKSPACE_DIR must be a path local dev /
+        CI users can actually create. Inside the container the Dockerfile sets
+        TERRAFORM_WORKSPACE_DIR=/var/run/provisioner/workspace explicitly; the
+        Python fallback applies only when the env var is unset (local runs).
+        Defaulting to /var/run/* there would fail PermissionError under non-root
+        local users, so the fallback resolves under the per-user temp directory."""
+        from terraform_base import (
+            _CONTAINER_TERRAFORM_WORKSPACE_DIR,
+            _DEFAULT_TERRAFORM_WORKSPACE_DIR,
+            _stage_workspace,
+        )
+
+        # The container env var declares this exact path; tests assert against the
+        # constant rather than hardcoding the literal.
+        assert _CONTAINER_TERRAFORM_WORKSPACE_DIR == "/var/run/provisioner/workspace"
+        # The Python fallback resolves under tempfile.gettempdir() — writable for
+        # local dev / CI without root.
+        import tempfile
+
+        assert _DEFAULT_TERRAFORM_WORKSPACE_DIR.startswith(tempfile.gettempdir())
+
+        # Redirect the default to a fresh tmp path so the test does not touch the
+        # shared system temp dir.
+        monkeypatch.setattr("terraform_base._DEFAULT_TERRAFORM_WORKSPACE_DIR", str(tmp_path / "default-workspace"))
+        monkeypatch.delenv("TERRAFORM_WORKSPACE_DIR", raising=False)
+
+        source = tmp_path / "module"
+        source.mkdir()
+        (source / "main.tf").write_text("# main\n")
+
+        staged = _stage_workspace(source, "req-xyz", "NGFW")
+
+        assert str(staged).startswith(str(tmp_path / "default-workspace" / "req-xyz"))
+        assert (staged / "main.tf").read_text() == "# main\n"
+
+    def test_cleanup_workspace_removes_staged_tree(self, tmp_path):
+        from terraform_base import _cleanup_workspace
+
+        workspace_root = tmp_path / "workspace"
+        staged = workspace_root / "req-abc" / "module"
+        staged.mkdir(parents=True)
+        (staged / "main.tf").write_text("# main\n")
+
+        with patch.dict("os.environ", {"TERRAFORM_WORKSPACE_DIR": str(workspace_root)}, clear=False):
+            _cleanup_workspace(staged)
+
+        # The whole per-request directory under workspace_root is removed.
+        assert not staged.exists()
+        assert not (workspace_root / "req-abc").exists()
+
+    def test_cleanup_workspace_swallows_missing_path(self, tmp_path):
+        from terraform_base import _cleanup_workspace
+
+        # Calling cleanup on a non-existent path must not raise.
+        with patch.dict("os.environ", {"TERRAFORM_WORKSPACE_DIR": str(tmp_path / "workspace")}, clear=False):
+            _cleanup_workspace(tmp_path / "workspace" / "does-not-exist")
+
+    def test_stage_workspace_drops_stale_tree_before_copy(self, tmp_path):
+        """If a previous request_uuid's staged tree was left behind (cleanup failed,
+        container restarted mid-run), the next stage must start clean — not merge into
+        the stale tree, which could leak `terraform.tfvars.json` or stale `.terraform/`."""
+        from terraform_base import _stage_workspace
+
+        source = tmp_path / "module"
+        source.mkdir()
+        (source / "main.tf").write_text("# new\n")
+
+        workspace_root = tmp_path / "workspace"
+        # Pre-populate a stale staged tree that imitates a partial copy.
+        stale = workspace_root / "req-abc" / "module"
+        stale.mkdir(parents=True)
+        (stale / "leftover.tfvars.json").write_text('{"old": "secret"}')
+        (stale / "main.tf").write_text("# stale\n")
+
+        with patch.dict("os.environ", {"TERRAFORM_WORKSPACE_DIR": str(workspace_root)}, clear=False):
+            staged = _stage_workspace(source, "req-abc", "Range")
+
+        assert (staged / "main.tf").read_text() == "# new\n"
+        assert not (staged / "leftover.tfvars.json").exists(), (
+            "stale terraform.tfvars.json must not survive into a fresh stage"
+        )
+
+    def test_stage_workspace_stages_terraform_tree_for_modules_layout(self, tmp_path):
+        """When the source follows the conventional `…/terraform/modules/<name>/`
+        layout, the whole `terraform/` parent must be staged so cross-module relative
+        references (e.g. `source = "../shared"`) resolve in the staged tree."""
+        from terraform_base import _stage_workspace
+
+        terraform_root = tmp_path / "src" / "terraform"
+        modules_dir = terraform_root / "modules"
+        range_module = modules_dir / "range"
+        range_module.mkdir(parents=True)
+        (range_module / "main.tf").write_text("# range\n")
+        # Sibling shared/ that the module could one day reference via `../shared`.
+        shared_dir = terraform_root / "shared"
+        shared_dir.mkdir()
+        (shared_dir / "common.tf").write_text("# shared\n")
+        # An adjacent NGFW module to confirm we copy it too.
+        ngfw_module = modules_dir / "ngfw"
+        ngfw_module.mkdir()
+        (ngfw_module / "main.tf").write_text("# ngfw\n")
+
+        workspace_root = tmp_path / "workspace"
+        with patch.dict("os.environ", {"TERRAFORM_WORKSPACE_DIR": str(workspace_root)}, clear=False):
+            staged = _stage_workspace(range_module, "req-shared", "Range")
+
+        # staged points at the staged equivalent of the module under modules/<name>/
+        assert staged.name == "range"
+        assert (staged / "main.tf").read_text() == "# range\n"
+        # The whole terraform/ tree was staged — sibling modules + shared/ are present.
+        request_root = workspace_root / "req-shared"
+        assert (request_root / "modules" / "ngfw" / "main.tf").read_text() == "# ngfw\n"
+        assert (request_root / "shared" / "common.tf").read_text() == "# shared\n"
+
+    def test_stage_workspace_excludes_runtime_artifacts(self, tmp_path):
+        """`COPY . .` in the Dockerfile would copy a `.terraform/`, `*.tfstate`, or stray
+        `terraform.tfvars.json` if any leaked into the build context. The stager must
+        exclude those so they never propagate into a fresh per-request workspace.
+
+        ``.terraform.lock.hcl`` is intentionally NOT excluded: it is a trusted
+        repo-reviewed lockfile pinning provider checksums, and excluding it would
+        force every ``terraform init`` to dynamically resolve providers under the
+        privileged Job's cloud credentials (supply-chain risk). It is treated as
+        source input — this test asserts that contract."""
+        from terraform_base import _stage_workspace
+
+        terraform_root = tmp_path / "src" / "terraform"
+        range_module = terraform_root / "modules" / "range"
+        range_module.mkdir(parents=True)
+        (range_module / "main.tf").write_text("# main\n")
+        # Runtime artifacts that should NOT be copied into the staged tree.
+        (range_module / ".terraform").mkdir()
+        (range_module / ".terraform" / "providers.json").write_text("{}")
+        (range_module / "terraform.tfvars.json").write_text('{"old_secret": "x"}')
+        (range_module / "old.tfstate").write_text("{}")
+        (range_module / "old.tfstate.backup").write_text("{}")
+        (range_module / ".terraform.tflock").write_text("")
+        (range_module / "crash.log").write_text("oops")
+        # Trusted source input that MUST survive into the staged tree.
+        (range_module / ".terraform.lock.hcl").write_text("# pinned providers\n")
+
+        workspace_root = tmp_path / "workspace"
+        with patch.dict("os.environ", {"TERRAFORM_WORKSPACE_DIR": str(workspace_root)}, clear=False):
+            staged = _stage_workspace(range_module, "req-clean", "Range")
+
+        assert (staged / "main.tf").read_text() == "# main\n"
+        assert not (staged / ".terraform").exists()
+        assert not (staged / "terraform.tfvars.json").exists()
+        assert not (staged / "old.tfstate").exists()
+        assert not (staged / "old.tfstate.backup").exists()
+        assert not (staged / ".terraform.tflock").exists()
+        assert not (staged / "crash.log").exists()
+        # Trusted lock file is preserved.
+        assert (staged / ".terraform.lock.hcl").read_text() == "# pinned providers\n"
+
+    def test_purge_tfvars_raises_on_failure(self, tmp_path, monkeypatch):
+        """The whole point of staging is that secret-bearing terraform.tfvars.json
+        does not survive a request. If the unlink fails, that secret is still on the
+        workspace volume — the apply/destroy outcome must surface that, not silently
+        report success while disk hygiene quietly broke."""
+        from terraform_base import _purge_tfvars
+
+        request_root = tmp_path / "req-x"
+        module_dir = request_root / "modules" / "range"
+        module_dir.mkdir(parents=True)
+        tfvars = module_dir / "terraform.tfvars.json"
+        tfvars.write_text('{"secret": "x"}')
+
+        # Patch Path.unlink to raise as if the volume rejected the delete.
+        original_unlink = Path.unlink
+
+        def _failing_unlink(self, *args, **kwargs):
+            if self.name == "terraform.tfvars.json":
+                raise OSError("simulated permission error")
+            return original_unlink(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "unlink", _failing_unlink)
+
+        with pytest.raises(RuntimeError, match=r"terraform\.tfvars\.json"):
+            _purge_tfvars(request_root)
+
+    @pytest.mark.parametrize(
+        "bad_uuid",
+        [
+            "..",
+            "../escape",
+            "req/abc",
+            "req\\abc",
+            "",
+            ".req",  # leading dot would let an attacker hide the dir
+            "x" * 200,  # too long
+        ],
+    )
+    def test_stage_workspace_rejects_unsafe_request_uuid(self, tmp_path, bad_uuid):
+        """request_uuid is concatenated into a filesystem path and then deleted with
+        shutil.rmtree(). A `..`, `/`, or other path-bearing value would let cleanup
+        walk outside the workspace root. Internal callers always pass real UUIDs,
+        but the helper enforces the contract locally so a future careless caller
+        cannot turn this into a path-traversal sink."""
+        from terraform_base import _stage_workspace
+
+        source = tmp_path / "module"
+        source.mkdir()
+        (source / "main.tf").write_text("# main\n")
+
+        with (
+            patch.dict("os.environ", {"TERRAFORM_WORKSPACE_DIR": str(tmp_path / "workspace")}, clear=False),
+            pytest.raises(ValueError, match="path-safe"),
+        ):
+            _stage_workspace(source, bad_uuid, "Range")
+
+    def test_destroy_uses_write_tfvars_helper(self, tmp_path, monkeypatch):
+        """`destroy()` writes terraform.tfvars.json the same way `apply()` does — via
+        `_write_tfvars` (0o600 perms, owner-only). Without this, the destroy path
+        would write tfvars with default 0o644 and bypass the secret-file protection."""
+        from terraform_base import destroy
+
+        source = tmp_path / "src" / "modules" / "range"
+        source.mkdir(parents=True)
+        (source / "main.tf").write_text("# main\n")
+        workspace_root = tmp_path / "workspace"
+        monkeypatch.setenv("TERRAFORM_WORKSPACE_DIR", str(workspace_root))
+        monkeypatch.setenv("TF_STATE_BUCKET", "shifter-dev-pulumi-state")
+
+        observed_modes: list[int] = []
+
+        def _fake_run(args, working_dir, env=None, capture_output=True):
+            tfvars_path = Path(working_dir) / "terraform.tfvars.json"
+            if tfvars_path.is_file():
+                observed_modes.append(tfvars_path.stat().st_mode & 0o777)
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = ""
+            result.stderr = ""
+            return result
+
+        with patch("terraform_base.run_terraform", side_effect=_fake_run):
+            destroy("ranges", "req-destroy-secure", source, "Range", variables={"secret": "x"})
+
+        assert observed_modes, "terraform.tfvars.json must have been written and visible to terraform"
+        for mode in observed_modes:
+            assert mode == 0o600, f"destroy() tfvars mode is {oct(mode)}, expected 0o600"
+
+    def test_stage_workspace_creates_request_root_with_private_mode(self, tmp_path):
+        """Local-dev / CI fallback workspace lives under /tmp and is shared with
+        other users on the host. The per-request directory MUST be 0o700 so other
+        users cannot enumerate or read staged secrets while the request runs."""
+        from terraform_base import _stage_workspace
+
+        source = tmp_path / "module"
+        source.mkdir()
+        (source / "main.tf").write_text("# main\n")
+
+        workspace_root = tmp_path / "workspace"
+        with patch.dict("os.environ", {"TERRAFORM_WORKSPACE_DIR": str(workspace_root)}, clear=False):
+            _stage_workspace(source, "req-private", "Range")
+
+        request_root = workspace_root / "req-private"
+        # Lower 9 bits of mode == 0o700 (rwx for owner, none for group/others).
+        assert (request_root.stat().st_mode & 0o777) == 0o700, (
+            f"request_root mode is {oct(request_root.stat().st_mode & 0o777)}, expected 0o700"
+        )
+
+    def test_write_tfvars_has_owner_only_permissions(self, tmp_path):
+        """terraform.tfvars.json carries Terraform inputs that may include cloud
+        credentials. Other local users on a multi-tenant CI host MUST NOT be able
+        to read it; the file is created with 0o600."""
+        from terraform_base import _write_tfvars
+
+        staged = tmp_path / "staged"
+        staged.mkdir()
+        path = _write_tfvars(staged, {"secret": "x"})
+
+        assert (path.stat().st_mode & 0o777) == 0o600, (
+            f"tfvars mode is {oct(path.stat().st_mode & 0o777)}, expected 0o600"
+        )
+        assert path.read_text().strip().startswith("{")
+
+    def test_apply_secrets_purge_failure_is_not_silenced(self, tmp_path, monkeypatch):
+        """End-to-end: if tfvars cleanup fails on the apply path, apply() must
+        surface that (RuntimeError) rather than reporting success and leaving
+        secret material on the workspace volume."""
+        from terraform_base import apply
+
+        source = tmp_path / "src" / "terraform" / "modules" / "range"
+        source.mkdir(parents=True)
+        (source / "main.tf").write_text("# main\n")
+        workspace_root = tmp_path / "workspace"
+        monkeypatch.setenv("TERRAFORM_WORKSPACE_DIR", str(workspace_root))
+        monkeypatch.setenv("TF_STATE_BUCKET", "shifter-dev-pulumi-state")
+
+        # Mock terraform shell-outs to no-ops returning empty output.
+        with patch("terraform_base.run_terraform") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="{}", stderr="")
+
+            original_unlink = Path.unlink
+
+            def _failing_unlink(self, *args, **kwargs):
+                if self.name == "terraform.tfvars.json":
+                    raise OSError("simulated permission error")
+                return original_unlink(self, *args, **kwargs)
+
+            monkeypatch.setattr(Path, "unlink", _failing_unlink)
+
+            with pytest.raises(RuntimeError, match=r"terraform\.tfvars\.json"):
+                apply("ranges", "req-bad", {"secret": "x"}, source, "Range")
+
+    def test_cleanup_workspace_removes_per_request_root_for_tree_staging(self, tmp_path):
+        """When the stager copies the whole `terraform/` tree (modules layout),
+        cleanup must walk back to the per-request root and remove the entire tree —
+        not just the leaf module — so sibling modules and the shared/ dir do not
+        survive."""
+        from terraform_base import _cleanup_workspace, _stage_workspace
+
+        terraform_root = tmp_path / "src" / "terraform"
+        range_module = terraform_root / "modules" / "range"
+        range_module.mkdir(parents=True)
+        (range_module / "main.tf").write_text("# range\n")
+        (terraform_root / "shared").mkdir()
+        (terraform_root / "shared" / "common.tf").write_text("# shared\n")
+
+        workspace_root = tmp_path / "workspace"
+        with patch.dict("os.environ", {"TERRAFORM_WORKSPACE_DIR": str(workspace_root)}, clear=False):
+            staged = _stage_workspace(range_module, "req-cleanup", "Range")
+            _cleanup_workspace(staged)
+
+        # The whole per-request directory under workspace_root is gone, including
+        # the staged shared/ and modules/ngfw siblings.
+        assert not (workspace_root / "req-cleanup").exists()
+
+    @patch.dict(
+        "os.environ",
+        {"TF_STATE_BUCKET": "shifter-dev-pulumi-state"},
+        clear=True,
+    )
+    @patch("terraform_base.run_terraform")
+    def test_apply_runs_from_staged_path_and_cleans_up(self, mock_run, tmp_path, monkeypatch):
+        """apply() must stage the module, run terraform from the staged path, and clean up the
+        staged tree on exit (success path) so successive runs do not pile up in the workspace."""
+        from terraform_base import apply
+
+        source = tmp_path / "src" / "modules" / "range"
+        source.mkdir(parents=True)
+        (source / "main.tf").write_text("# main\n")
+
+        workspace_root = tmp_path / "workspace"
+        monkeypatch.setenv("TERRAFORM_WORKSPACE_DIR", str(workspace_root))
+        monkeypatch.setenv("TF_STATE_BUCKET", "shifter-dev-pulumi-state")
+
+        # Capture cwd at each terraform call AND that the staged tree exists during the call.
+        observed = []
+
+        def _fake_run(args, working_dir, env=None, capture_output=True):
+            observed.append(
+                {
+                    "args": list(args),
+                    "working_dir": Path(working_dir),
+                    "exists": Path(working_dir).is_dir(),
+                }
+            )
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = "{}" if args[0] == "output" else "apply ok"
+            result.stderr = ""
+            return result
+
+        mock_run.side_effect = _fake_run
+
+        apply("ranges", "req-clean", {"foo": "bar"}, source, "Range")
+
+        # init + apply + output → at least 3 invocations
+        assert len(observed) >= 3
+        for entry in observed:
+            assert entry["working_dir"] != source
+            assert str(entry["working_dir"]).startswith(str(workspace_root))
+            assert entry["exists"] is True
+
+        # Staged tree is gone after apply returns.
+        staged_root = workspace_root / "req-clean"
+        assert not staged_root.exists(), "apply() must remove the staged workspace on success"
+
+    @patch.dict(
+        "os.environ",
+        {"TF_STATE_BUCKET": "shifter-dev-pulumi-state"},
+        clear=True,
+    )
+    @patch("terraform_base.run_terraform")
+    def test_apply_cleans_up_workspace_on_failure(self, mock_run, tmp_path, monkeypatch):
+        """If terraform itself fails partway through, the staged workspace still has to be torn
+        down — otherwise leftover credentials in terraform.tfvars.json could persist on disk."""
+        from terraform_base import apply
+
+        source = tmp_path / "src" / "modules" / "range"
+        source.mkdir(parents=True)
+        (source / "main.tf").write_text("# main\n")
+
+        workspace_root = tmp_path / "workspace"
+        monkeypatch.setenv("TERRAFORM_WORKSPACE_DIR", str(workspace_root))
+        monkeypatch.setenv("TF_STATE_BUCKET", "shifter-dev-pulumi-state")
+
+        def _fake_run(args, working_dir, env=None, capture_output=True):
+            if args[0] == "init":
+                result = MagicMock()
+                result.returncode = 0
+                result.stdout = ""
+                result.stderr = ""
+                return result
+            raise RuntimeError("simulated terraform apply failure")
+
+        mock_run.side_effect = _fake_run
+
+        with contextlib.suppress(RuntimeError):
+            apply("ranges", "req-fail", {"foo": "bar"}, source, "Range")
+
+        staged_root = workspace_root / "req-fail"
+        assert not staged_root.exists(), "apply() must clean up the staged workspace even on failure"
+
+    @patch.dict(
+        "os.environ",
+        {"TF_STATE_BUCKET": "shifter-dev-pulumi-state"},
+        clear=True,
+    )
+    @patch("terraform_base.run_terraform")
+    def test_destroy_runs_from_staged_path_and_cleans_up(self, mock_run, tmp_path, monkeypatch):
+        from terraform_base import destroy
+
+        source = tmp_path / "src" / "modules" / "range"
+        source.mkdir(parents=True)
+        (source / "main.tf").write_text("# main\n")
+
+        workspace_root = tmp_path / "workspace"
+        monkeypatch.setenv("TERRAFORM_WORKSPACE_DIR", str(workspace_root))
+        monkeypatch.setenv("TF_STATE_BUCKET", "shifter-dev-pulumi-state")
+
+        observed_dirs = []
+
+        def _fake_run(args, working_dir, env=None, capture_output=True):
+            observed_dirs.append(Path(working_dir))
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = ""
+            result.stderr = ""
+            return result
+
+        mock_run.side_effect = _fake_run
+
+        destroy("ranges", "req-destroy", source, "Range", variables={"foo": "bar"})
+
+        for working_dir in observed_dirs:
+            assert working_dir != source
+            assert str(working_dir).startswith(str(workspace_root))
+
+        staged_root = workspace_root / "req-destroy"
+        assert not staged_root.exists()
+
+    @patch.dict(
+        "os.environ",
+        {"TF_STATE_BUCKET": "shifter-dev-pulumi-state"},
+        clear=True,
+    )
+    @patch("terraform_base.run_terraform")
+    def test_apply_writes_tfvars_under_staged_path(self, mock_run, tmp_path, monkeypatch):
+        """terraform.tfvars.json must land in the staged workspace, not the source module path —
+        otherwise apply() would try to write under /app and fail when /app is read-only."""
+        from terraform_base import apply
+
+        source = tmp_path / "src" / "modules" / "range"
+        source.mkdir(parents=True)
+        (source / "main.tf").write_text("# main\n")
+
+        workspace_root = tmp_path / "workspace"
+        monkeypatch.setenv("TERRAFORM_WORKSPACE_DIR", str(workspace_root))
+        monkeypatch.setenv("TF_STATE_BUCKET", "shifter-dev-pulumi-state")
+
+        observed_tfvars = []
+
+        def _fake_run(args, working_dir, env=None, capture_output=True):
+            tfvars_path = Path(working_dir) / "terraform.tfvars.json"
+            if tfvars_path.is_file():
+                observed_tfvars.append(
+                    {
+                        "working_dir": Path(working_dir),
+                        "contents": json.loads(tfvars_path.read_text()),
+                    }
+                )
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = "{}" if args[0] == "output" else ""
+            result.stderr = ""
+            return result
+
+        mock_run.side_effect = _fake_run
+
+        apply("ranges", "req-tfvars", {"foo": "bar"}, source, "Range")
+
+        # The tfvars file must have been visible to terraform (apply step) under the staged path.
+        assert any(
+            str(observed["working_dir"]).startswith(str(workspace_root)) and observed["contents"] == {"foo": "bar"}
+            for observed in observed_tfvars
+        ), "terraform.tfvars.json should be staged under the writable workspace dir, not under the source module path"
+
+        # And it must NOT have been written next to the source module (read-only /app surface).
+        assert not (source / "terraform.tfvars.json").exists()

--- a/shifter/engine/provisioner/tests/test_terraform_runner.py
+++ b/shifter/engine/provisioner/tests/test_terraform_runner.py
@@ -3,72 +3,81 @@
 Covers destroy_ngfw variable passing and _build_tf_variables helper.
 """
 
-from pathlib import Path
-from unittest.mock import MagicMock, mock_open, patch
+import os
+from unittest.mock import patch
 
 import pytest
 
 
 class TestDestroyNgfw:
-    """Test destroy_ngfw passes variables correctly."""
+    """Test destroy_ngfw passes variables correctly.
 
+    Issue #1103: destroy() stages a writable workspace under TERRAFORM_WORKSPACE_DIR,
+    runs terraform from the staged path, and cleans the staged tree up on success and
+    failure. NGFW Terraform shares the same image as range Terraform — the staging
+    contract MUST cover both paths or NGFW provision/deprovision breaks under
+    readOnlyRootFilesystem.
+    """
+
+    @patch.dict(os.environ, {"TF_STATE_BUCKET": "shifter-dev-pulumi-state"}, clear=True)
     @patch("terraform_base.run_terraform")
-    @patch("terraform_base.init_workspace")
-    def test_destroy_with_variables_writes_tfvars(self, mock_init, mock_run, tmp_path):
+    def test_destroy_with_variables_writes_tfvars(self, mock_run, tmp_path, monkeypatch):
         """When variables are provided, destroy should write tfvars and pass -var-file."""
         from terraform_runner import destroy_ngfw
 
-        working_dir = tmp_path / "test-module"
-        working_dir.mkdir()
+        source = tmp_path / "src" / "modules" / "ngfw"
+        source.mkdir(parents=True)
+        (source / "main.tf").write_text("# main\n")
+        workspace_root = tmp_path / "workspace"
+        monkeypatch.setenv("TERRAFORM_WORKSPACE_DIR", str(workspace_root))
+        monkeypatch.setenv("TF_STATE_BUCKET", "shifter-dev-pulumi-state")
+
         variables = {"name_prefix": "ngfw-user-1", "user_id": 1}
+        destroy_ngfw("req-123", source, variables=variables)
 
-        with patch("builtins.open", mock_open()) as mocked_file, patch.object(Path, "unlink"):
-            destroy_ngfw("req-123", working_dir, variables=variables)
-
-        # Verify tfvars file was written
-        mocked_file.assert_called_once_with(working_dir / "terraform.tfvars.json", "w")
-        written_data = mocked_file().write.call_args_list
-        # json.dump writes in chunks; just verify it was called
-        assert len(written_data) > 0
-
-        # Verify -var-file was passed to terraform
         destroy_args = mock_run.call_args[0][0]
         assert any("-var-file=" in arg for arg in destroy_args)
+        assert not (workspace_root / "req-123").exists()
 
+    @patch.dict(os.environ, {"TF_STATE_BUCKET": "shifter-dev-pulumi-state"}, clear=True)
     @patch("terraform_base.run_terraform")
-    @patch("terraform_base.init_workspace")
-    def test_destroy_without_variables_no_var_file(self, mock_init, mock_run, tmp_path):
+    def test_destroy_without_variables_no_var_file(self, mock_run, tmp_path, monkeypatch):
         """When no variables provided, destroy should not pass -var-file."""
         from terraform_runner import destroy_ngfw
 
-        working_dir = tmp_path / "test-module"
-        working_dir.mkdir()
+        source = tmp_path / "src" / "modules" / "ngfw"
+        source.mkdir(parents=True)
+        (source / "main.tf").write_text("# main\n")
+        workspace_root = tmp_path / "workspace"
+        monkeypatch.setenv("TERRAFORM_WORKSPACE_DIR", str(workspace_root))
+        monkeypatch.setenv("TF_STATE_BUCKET", "shifter-dev-pulumi-state")
 
-        destroy_ngfw("req-123", working_dir)
+        destroy_ngfw("req-123", source)
 
         destroy_args = mock_run.call_args[0][0]
         assert not any("-var-file=" in arg for arg in destroy_args)
         assert "-auto-approve" in destroy_args
+        assert not (workspace_root / "req-123").exists()
 
-    @patch("terraform_base.run_terraform", side_effect=RuntimeError("destroy failed"))
-    @patch("terraform_base.init_workspace")
-    def test_destroy_cleans_up_tfvars_on_failure(self, mock_init, mock_run, tmp_path):
-        """Tfvars file should be cleaned up even if destroy fails."""
+    @patch.dict(os.environ, {"TF_STATE_BUCKET": "shifter-dev-pulumi-state"}, clear=True)
+    def test_destroy_cleans_up_workspace_on_failure(self, tmp_path, monkeypatch):
+        """Staged workspace must be removed even when terraform destroy fails."""
         from terraform_runner import destroy_ngfw
 
-        working_dir = tmp_path / "test-module"
-        working_dir.mkdir()
-        variables = {"name_prefix": "ngfw-user-1"}
-        mock_unlink = MagicMock()
+        source = tmp_path / "src" / "modules" / "ngfw"
+        source.mkdir(parents=True)
+        (source / "main.tf").write_text("# main\n")
+        workspace_root = tmp_path / "workspace"
+        monkeypatch.setenv("TERRAFORM_WORKSPACE_DIR", str(workspace_root))
+        monkeypatch.setenv("TF_STATE_BUCKET", "shifter-dev-pulumi-state")
 
         with (
-            patch("builtins.open", mock_open()),
-            patch.object(Path, "unlink", mock_unlink),
+            patch("terraform_base.run_terraform", side_effect=RuntimeError("destroy failed")),
             pytest.raises(RuntimeError, match="destroy failed"),
         ):
-            destroy_ngfw("req-123", working_dir, variables=variables)
+            destroy_ngfw("req-123", source, variables={"name_prefix": "ngfw-user-1"})
 
-        mock_unlink.assert_called_once_with(missing_ok=True)
+        assert not (workspace_root / "req-123").exists()
 
 
 class TestBuildTfVariables:

--- a/shifter/shifter_platform/engine/ecs.py
+++ b/shifter/shifter_platform/engine/ecs.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING, Any
 
 from django.conf import settings
 
-from shared.cloud import get_task_runner
+from shared.cloud import PROVISIONER_CONTAINER_NAME, get_task_runner
 from shared.cloud.exceptions import CloudTaskError
 from shared.enums import ResourceType
 
@@ -326,7 +326,7 @@ def _start_ecs_task(range_id: int, user_id: int, command: str) -> str | None:
             task_definition=task_definition,
             cluster=cluster,
             command=command_list,
-            container_name="pulumi-provisioner",
+            container_name=PROVISIONER_CONTAINER_NAME,
             env_overrides=_get_gcp_provisioner_env_overrides(),
             network_config=network_config,
         )
@@ -426,7 +426,7 @@ def _start_range_ecs_task(request_id: UUID, command: str) -> str | None:
             task_definition=task_definition,
             cluster=cluster,
             command=command_list,
-            container_name="pulumi-provisioner",
+            container_name=PROVISIONER_CONTAINER_NAME,
             env_overrides=_get_gcp_provisioner_env_overrides(),
             network_config=network_config,
         )
@@ -541,7 +541,7 @@ def _start_ngfw_ecs_task(request_id: UUID, command: list[str]) -> str | None:
             task_definition=task_definition,
             cluster=cluster,
             command=command,
-            container_name="pulumi-provisioner",
+            container_name=PROVISIONER_CONTAINER_NAME,
             env_overrides=_get_gcp_provisioner_env_overrides(),
             network_config=network_config,
         )

--- a/shifter/shifter_platform/shared/cloud/__init__.py
+++ b/shifter/shifter_platform/shared/cloud/__init__.py
@@ -17,6 +17,15 @@ from django.conf import settings
 
 from shared.cloud.exceptions import CloudProviderNotImplementedError
 
+# Cross-provider container-name contract for the engine provisioner Job.
+# Lives at the cloud-neutral layer so AWS/ECS dispatch sites and the GCP
+# task-runner gate import the same string. The GCP runner uses this to
+# select issue #1103 hardening (readOnlyRootFilesystem, writable mounts,
+# fsGroup); the ECS task definition's container_name must also match it
+# so behavior is consistent across providers — a structural test in
+# `tests/shared/cloud/test_gcp_task_runner.py` enforces alignment.
+PROVISIONER_CONTAINER_NAME = "pulumi-provisioner"
+
 if TYPE_CHECKING:
     from shared.cloud.types import (
         ObjectStorage,

--- a/shifter/shifter_platform/shared/cloud/gcp/task_runner.py
+++ b/shifter/shifter_platform/shared/cloud/gcp/task_runner.py
@@ -9,10 +9,50 @@ from typing import Any
 
 from django.conf import settings
 
+from shared.cloud import PROVISIONER_CONTAINER_NAME
 from shared.cloud.exceptions import CloudTaskError
 from shared.cloud.gcp.base import build_job_generate_name, parse_job_task_id
 
+__all__ = ("PROVISIONER_CONTAINER_NAME", "GCPTaskRunner")
+
 logger = logging.getLogger(__name__)
+
+_PROVISIONER_RUN_AS_UID = 1000
+_PROVISIONER_RUN_AS_GID = 1000
+
+# Memory-backed workspace volume size cap. Terraform staging trees are tiny
+# (a few MB), but a runaway plan log or provider download could otherwise
+# consume node memory unbounded. 256Mi is generous for the staged terraform/
+# tree plus typical plan output without putting the node under pressure.
+_PROVISIONER_WORKSPACE_SIZE_LIMIT = "256Mi"
+
+# Writable mount points the provisioner image needs at runtime. /app and the
+# rest of the root filesystem are read-only (issue #1103); these explicit
+# emptyDir volumes are the only paths the runtime user can write to.
+# - workspace: terraform_base._stage_workspace target. Memory-backed (medium=Memory)
+#   so terraform.tfvars.json (which can carry secrets) does not persist on disk;
+#   capped at _PROVISIONER_WORKSPACE_SIZE_LIMIT to bound the worst-case node memory
+#   pressure from a runaway plan log or large provider download.
+# - /tmp: Python tempfile, kubectl temp kubeconfigs (gdc_*), etc.
+# - tf plugin cache and pulumi home: Terraform/Pulumi tool state under HOME.
+_PROVISIONER_WRITABLE_MOUNTS: tuple[tuple[str, str, str | None, str | None], ...] = (
+    ("provisioner-workspace", "/var/run/provisioner/workspace", "Memory", _PROVISIONER_WORKSPACE_SIZE_LIMIT),
+    ("tmp", "/tmp", None, None),  # noqa: S108 # nosec B108 — Kubernetes mount path, not a tempfile API call
+    ("tf-plugin-cache", "/home/appuser/.terraform.d/plugin-cache", None, None),
+    ("pulumi-home", "/home/appuser/.pulumi", None, None),
+)
+
+
+def _is_provisioner_task(container_name: str) -> bool:
+    """Return True if the Job being built is the provisioner task.
+
+    Hardening from issue #1103 (read-only root filesystem, writable workspace
+    volume, drop-ALL capabilities, etc.) is provisioner-specific. CMS
+    experiments and any future shared-runner caller keep their current,
+    less-prescribed contract until the runner protocol grows a per-task
+    runtime profile parameter.
+    """
+    return container_name == PROVISIONER_CONTAINER_NAME
 
 
 class GCPTaskRunner:
@@ -55,6 +95,51 @@ class GCPTaskRunner:
             return None
         return [client.V1EnvVar(name=name, value=value) for name, value in sorted(env_overrides.items())]
 
+    def _build_container_security_context(self, client: Any) -> Any:
+        # Issue #1103: lock the provisioner Job's writable surface to the
+        # explicit volumes built below. ALL capabilities dropped, no privilege
+        # escalation, non-root, read-only root FS.
+        return client.V1SecurityContext(
+            read_only_root_filesystem=True,
+            run_as_non_root=True,
+            run_as_user=_PROVISIONER_RUN_AS_UID,
+            run_as_group=_PROVISIONER_RUN_AS_GID,
+            allow_privilege_escalation=False,
+            capabilities=client.V1Capabilities(drop=["ALL"]),
+        )
+
+    def _build_pod_security_context(self, client: Any) -> Any:
+        # seccompProfile=RuntimeDefault matches the platform's worker-engine
+        # baseline and is required for restricted Pod Security Standard
+        # admission (ADR-006). fsGroup=1000 makes the kubelet chown mounted
+        # emptyDir volumes to the runtime group so the non-root container can
+        # write to them without an init-chown or fsGroupChangePolicy=Always
+        # (which would also re-chown read-only mounts on every start).
+        return client.V1PodSecurityContext(
+            seccomp_profile=client.V1SeccompProfile(type="RuntimeDefault"),
+            fs_group=_PROVISIONER_RUN_AS_GID,
+            fs_group_change_policy="OnRootMismatch",
+        )
+
+    def _build_writable_volumes(self, client: Any) -> list[Any]:
+        volumes = []
+        for name, _mount_path, medium, size_limit in _PROVISIONER_WRITABLE_MOUNTS:
+            empty_dir_kwargs: dict[str, Any] = {}
+            if medium:
+                empty_dir_kwargs["medium"] = medium
+            if size_limit:
+                empty_dir_kwargs["size_limit"] = size_limit
+            volumes.append(
+                client.V1Volume(name=name, empty_dir=client.V1EmptyDirVolumeSource(**empty_dir_kwargs)),
+            )
+        return volumes
+
+    def _build_container_volume_mounts(self, client: Any) -> list[Any]:
+        return [
+            client.V1VolumeMount(name=name, mount_path=mount_path)
+            for name, mount_path, _medium, _size_limit in _PROVISIONER_WRITABLE_MOUNTS
+        ]
+
     def _build_container(
         self,
         client: Any,
@@ -63,13 +148,17 @@ class GCPTaskRunner:
         command: list[str],
         env: list[Any] | None,
     ) -> Any:
-        return client.V1Container(
-            name=container_name,
-            image=image,
-            args=command,
-            env=env,
-            image_pull_policy=getattr(settings, "ENGINE_TASK_IMAGE_PULL_POLICY", "IfNotPresent"),
-        )
+        kwargs: dict[str, Any] = {
+            "name": container_name,
+            "image": image,
+            "args": command,
+            "env": env,
+            "image_pull_policy": getattr(settings, "ENGINE_TASK_IMAGE_PULL_POLICY", "IfNotPresent"),
+        }
+        if _is_provisioner_task(container_name):
+            kwargs["security_context"] = self._build_container_security_context(client)
+            kwargs["volume_mounts"] = self._build_container_volume_mounts(client)
+        return client.V1Container(**kwargs)
 
     def _build_job(
         self,
@@ -79,10 +168,14 @@ class GCPTaskRunner:
         command: list[str],
         env: list[Any] | None,
     ) -> Any:
-        pod_spec = client.V1PodSpec(
-            containers=[self._build_container(client, container_name, image, command, env)],
-            restart_policy="Never",
-        )
+        pod_spec_kwargs: dict[str, Any] = {
+            "containers": [self._build_container(client, container_name, image, command, env)],
+            "restart_policy": "Never",
+        }
+        if _is_provisioner_task(container_name):
+            pod_spec_kwargs["security_context"] = self._build_pod_security_context(client)
+            pod_spec_kwargs["volumes"] = self._build_writable_volumes(client)
+        pod_spec = client.V1PodSpec(**pod_spec_kwargs)
 
         service_account_name = getattr(settings, "ENGINE_TASK_SERVICE_ACCOUNT_NAME", "")
         if service_account_name:

--- a/shifter/shifter_platform/tests/shared/cloud/test_gcp_task_runner.py
+++ b/shifter/shifter_platform/tests/shared/cloud/test_gcp_task_runner.py
@@ -17,6 +17,31 @@ class _ApiException(Exception):
         self.status = status
 
 
+def _make_fake_k8s_client() -> SimpleNamespace:
+    """Build a SimpleNamespace stand-in for kubernetes.client.
+
+    The real client classes accept keyword args and store them as attributes;
+    SimpleNamespace mirrors that contract well enough for unit tests asserting
+    on the produced Job spec without pulling in the kubernetes package.
+    """
+    return SimpleNamespace(
+        V1EnvVar=lambda **kwargs: SimpleNamespace(**kwargs),
+        V1Container=lambda **kwargs: SimpleNamespace(**kwargs),
+        V1PodSpec=lambda **kwargs: SimpleNamespace(**kwargs),
+        V1ObjectMeta=lambda **kwargs: SimpleNamespace(**kwargs),
+        V1PodTemplateSpec=lambda **kwargs: SimpleNamespace(**kwargs),
+        V1JobSpec=lambda **kwargs: SimpleNamespace(**kwargs),
+        V1Job=lambda **kwargs: SimpleNamespace(**kwargs),
+        V1SecurityContext=lambda **kwargs: SimpleNamespace(**kwargs),
+        V1PodSecurityContext=lambda **kwargs: SimpleNamespace(**kwargs),
+        V1Capabilities=lambda **kwargs: SimpleNamespace(**kwargs),
+        V1SeccompProfile=lambda **kwargs: SimpleNamespace(**kwargs),
+        V1Volume=lambda **kwargs: SimpleNamespace(**kwargs),
+        V1VolumeMount=lambda **kwargs: SimpleNamespace(**kwargs),
+        V1EmptyDirVolumeSource=lambda **kwargs: SimpleNamespace(**kwargs),
+    )
+
+
 class TestGCPTaskRunnerRunTask:
     """Job creation behavior."""
 
@@ -32,15 +57,7 @@ class TestGCPTaskRunnerRunTask:
         )
         core_api = MagicMock()
 
-        client = SimpleNamespace(
-            V1EnvVar=lambda **kwargs: SimpleNamespace(**kwargs),
-            V1Container=lambda **kwargs: SimpleNamespace(**kwargs),
-            V1PodSpec=lambda **kwargs: SimpleNamespace(**kwargs),
-            V1ObjectMeta=lambda **kwargs: SimpleNamespace(**kwargs),
-            V1PodTemplateSpec=lambda **kwargs: SimpleNamespace(**kwargs),
-            V1JobSpec=lambda **kwargs: SimpleNamespace(**kwargs),
-            V1Job=lambda **kwargs: SimpleNamespace(**kwargs),
-        )
+        client = _make_fake_k8s_client()
 
         runner = GCPTaskRunner()
         runner._load_kubernetes_api = MagicMock(return_value=(batch_api, core_api, client, _ApiException))
@@ -75,6 +92,207 @@ class TestGCPTaskRunnerRunTask:
                 command=["range", "provision"],
                 container_name="pulumi-provisioner",
             )
+
+    def test_job_locks_down_runtime_writable_surface(self, settings) -> None:
+        """Issue #1103: provisioner Jobs must run with read-only root filesystem and a
+        single dedicated writable workspace volume. Without this, a process compromise
+        inside a provisioner Job (already non-root after #950) could still tamper with
+        the container's writable layer or with /app — keeping `/app` immutable closes
+        that gap. The Job factory is the only enforcement point because Jobs are
+        created dynamically (kube-linter does not see them)."""
+        settings.ENGINE_TASK_SERVICE_ACCOUNT_NAME = "shifter-provisioner"
+        settings.ENGINE_TASK_IMAGE_PULL_POLICY = "Always"
+        settings.ENGINE_TASK_BACKOFF_LIMIT = 0
+        settings.ENGINE_TASK_TTL_SECONDS_AFTER_FINISHED = 3600
+
+        batch_api = MagicMock()
+        batch_api.create_namespaced_job.return_value = SimpleNamespace(metadata=SimpleNamespace(name="job-xyz"))
+        core_api = MagicMock()
+        client = _make_fake_k8s_client()
+
+        runner = GCPTaskRunner()
+        runner._load_kubernetes_api = MagicMock(return_value=(batch_api, core_api, client, _ApiException))
+
+        runner.run_task(
+            task_definition="us-central1-docker.pkg.dev/test/provisioner:latest",
+            cluster="shifter-jobs",
+            command=["range", "provision", "--range-id", "42"],
+            container_name="pulumi-provisioner",
+        )
+
+        job = batch_api.create_namespaced_job.call_args.kwargs["body"]
+        container = job.spec.template.spec.containers[0]
+
+        # Container security context — readOnlyRootFilesystem, runAsNonRoot,
+        # and capability drop together implement the issue's contract.
+        sc = container.security_context
+        assert sc.read_only_root_filesystem is True
+        assert sc.run_as_non_root is True
+        assert sc.run_as_user == 1000
+        assert sc.run_as_group == 1000
+        assert sc.allow_privilege_escalation is False
+        assert sc.capabilities.drop == ["ALL"]
+
+        # Pod security context — seccompProfile=RuntimeDefault matches the
+        # platform's existing worker-engine deployment baseline. fsGroup=1000
+        # makes the kubelet chown the mounted emptyDir volumes to gid 1000 so
+        # the non-root container can write to them — without it the volumes
+        # come up root:root 700 and Terraform fails on first init.
+        pod_sc = job.spec.template.spec.security_context
+        assert pod_sc.seccomp_profile.type == "RuntimeDefault"
+        assert pod_sc.fs_group == 1000
+        assert pod_sc.fs_group_change_policy == "OnRootMismatch"
+
+        # Writable surface is exactly four explicit volumes:
+        # - workspace (terraform_base._stage_workspace target, issue #1103)
+        # - /tmp (Python tempfile, kubectl temp kubeconfig, etc.)
+        # - terraform plugin cache and pulumi home (HOME is read-only as a
+        #   whole when we mount it that way, so the writable subdirs are
+        #   explicit emptyDirs).
+        volumes = {v.name: v for v in job.spec.template.spec.volumes}
+        assert set(volumes.keys()) == {
+            "provisioner-workspace",
+            "tmp",
+            "tf-plugin-cache",
+            "pulumi-home",
+        }
+        # Workspace volume is memory-backed so terraform.tfvars.json (which can
+        # carry secrets) does not persist on disk between Job restarts. The
+        # size_limit caps node-memory pressure from a runaway plan log or
+        # provider download — without it the volume could grow to 50% of node
+        # memory by default.
+        assert volumes["provisioner-workspace"].empty_dir.medium == "Memory"
+        assert volumes["provisioner-workspace"].empty_dir.size_limit == "256Mi"
+
+        mounts = {m.name: m.mount_path for m in container.volume_mounts}
+        assert mounts == {
+            "provisioner-workspace": "/var/run/provisioner/workspace",
+            "tmp": "/tmp",  # noqa: S108 — Kubernetes mount path, not a tempfile API call
+            "tf-plugin-cache": "/home/appuser/.terraform.d/plugin-cache",
+            "pulumi-home": "/home/appuser/.pulumi",
+        }
+
+    def test_provisioner_container_name_lives_in_cloud_neutral_module(self) -> None:
+        """The provisioner contract is cross-provider (AWS/ECS dispatch and GCP Job
+        hardening both key off the same container name). It MUST live at the
+        cloud-neutral ``shared.cloud`` layer rather than inside ``shared.cloud.gcp.*``,
+        so AWS orchestration code does not have to import from the GCP module —
+        which would couple AWS dispatch to a GCP-namespaced symbol and break the
+        cloud abstraction the factory functions enforce."""
+        import importlib
+
+        cloud_module = importlib.import_module("shared.cloud")
+        assert hasattr(cloud_module, "PROVISIONER_CONTAINER_NAME"), (
+            "shared.cloud must export PROVISIONER_CONTAINER_NAME at the cloud-neutral layer"
+        )
+        # The GCP runner re-exports it for backward-compat / co-location with the
+        # gating logic, but the source of truth is shared.cloud.
+        from shared.cloud import PROVISIONER_CONTAINER_NAME as cloud_constant
+        from shared.cloud.gcp import task_runner as gcp_module
+
+        assert cloud_constant == gcp_module.PROVISIONER_CONTAINER_NAME
+        assert gcp_module.PROVISIONER_CONTAINER_NAME is cloud_constant, (
+            "GCP task_runner must re-export the cloud-neutral constant, not redefine it"
+        )
+
+    def test_provisioner_container_name_matches_ecs_task_definition(self) -> None:
+        """The ECS task definition under platform/terraform/modules/engine-provisioner
+        also has to carry the provisioner's container name. Terraform can't import the
+        Python constant, so we lock in alignment with a structural assertion: the .tf
+        file MUST contain `name = "<PROVISIONER_CONTAINER_NAME>"`. A future Python-side
+        rename without a matching .tf update would fail this test."""
+        from pathlib import Path
+
+        from shared.cloud.gcp.task_runner import PROVISIONER_CONTAINER_NAME
+
+        repo_root = Path(__file__).resolve().parents[5]
+        tf_path = repo_root / "platform" / "terraform" / "modules" / "engine-provisioner" / "task_definition.tf"
+        source = tf_path.read_text(encoding="utf-8")
+        assert f'name                   = "{PROVISIONER_CONTAINER_NAME}"' in source or (
+            f'name = "{PROVISIONER_CONTAINER_NAME}"' in source
+        ), (
+            f"task_definition.tf must reference the provisioner container name "
+            f"{PROVISIONER_CONTAINER_NAME!r} that the GCP task runner gates hardening on; "
+            "renaming one without the other would silently break ECS↔GCP alignment"
+        )
+
+    def test_provisioner_container_name_is_used_at_engine_dispatch_sites(self) -> None:
+        """The hardening gate inside `_is_provisioner_task` keys on the cloud-neutral
+        ``PROVISIONER_CONTAINER_NAME`` constant, and the engine dispatch sites in
+        `shifter/shifter_platform/engine/ecs.py` MUST pass that exact constant when
+        calling ``run_task``. Otherwise a rename of the constant would silently
+        disable the issue #1103 hardening for production traffic. The engine layer
+        imports from ``shared.cloud`` (cloud-neutral) — NOT from
+        ``shared.cloud.gcp.*`` — to keep AWS dispatch decoupled from GCP modules."""
+        import re
+        from pathlib import Path
+
+        from shared.cloud import PROVISIONER_CONTAINER_NAME
+
+        ecs_path = Path(__file__).resolve().parents[3] / "engine" / "ecs.py"
+        source = ecs_path.read_text(encoding="utf-8")
+
+        # The engine module must import the constant from the cloud-neutral layer.
+        assert re.search(
+            r"from shared\.cloud import [^\n]*\bPROVISIONER_CONTAINER_NAME\b",
+            source,
+        ), "engine/ecs.py must import PROVISIONER_CONTAINER_NAME from cloud-neutral shared.cloud"
+        # And NOT from shared.cloud.gcp.* (which would break the cloud abstraction).
+        assert (
+            "from shared.cloud.gcp" not in source
+            or "PROVISIONER_CONTAINER_NAME" not in source.split("from shared.cloud.gcp")[1].splitlines()[0]
+        ), "engine/ecs.py must NOT import PROVISIONER_CONTAINER_NAME from shared.cloud.gcp.*"
+
+        # Every run_task call site in the engine must dispatch with the
+        # constant — no string literals like `"pulumi-provisioner"` allowed.
+        run_task_calls = list(re.finditer(r"runner\.run_task\((.*?)\)", source, flags=re.DOTALL))
+        assert run_task_calls, "engine/ecs.py must contain runner.run_task call sites"
+        for match in run_task_calls:
+            args = match.group(1)
+            if "container_name" not in args:
+                continue
+            assert "container_name=PROVISIONER_CONTAINER_NAME" in args, (
+                f"run_task call must dispatch with PROVISIONER_CONTAINER_NAME, got:\n{args}"
+            )
+            assert f'"{PROVISIONER_CONTAINER_NAME}"' not in args, (
+                "run_task call must use the imported constant, not the string literal"
+            )
+
+    def test_non_provisioner_task_keeps_existing_contract(self, settings) -> None:
+        """Issue #1103 hardening is provisioner-specific. Other tasks launched through
+        the shared GCPTaskRunner (e.g. CMS experiment-executor) MUST keep their current
+        contract — no readOnlyRootFilesystem, no provisioner-specific volume mounts —
+        until the runner protocol grows a per-task runtime profile parameter. Forcing
+        the provisioner mounts onto every shared-runner caller would either break image
+        layouts that don't have those paths or hide other tasks' real security gaps."""
+        settings.ENGINE_TASK_SERVICE_ACCOUNT_NAME = "shifter-cms"
+        settings.ENGINE_TASK_IMAGE_PULL_POLICY = "IfNotPresent"
+        settings.ENGINE_TASK_BACKOFF_LIMIT = 0
+        settings.ENGINE_TASK_TTL_SECONDS_AFTER_FINISHED = 3600
+
+        batch_api = MagicMock()
+        batch_api.create_namespaced_job.return_value = SimpleNamespace(metadata=SimpleNamespace(name="exp-job-7"))
+        core_api = MagicMock()
+        client = _make_fake_k8s_client()
+
+        runner = GCPTaskRunner()
+        runner._load_kubernetes_api = MagicMock(return_value=(batch_api, core_api, client, _ApiException))
+
+        runner.run_task(
+            task_definition="us-central1-docker.pkg.dev/test/experiment-executor:latest",
+            cluster="shifter-jobs",
+            command=["run", "--experiment-id", "42"],
+            container_name="experiment-executor",
+        )
+
+        job = batch_api.create_namespaced_job.call_args.kwargs["body"]
+        container = job.spec.template.spec.containers[0]
+        # Provisioner-specific kwargs must NOT be set on a non-provisioner container.
+        assert not hasattr(container, "security_context")
+        assert not hasattr(container, "volume_mounts")
+        # Pod-level provisioner-specific kwargs must NOT be set either.
+        assert not hasattr(job.spec.template.spec, "security_context")
+        assert not hasattr(job.spec.template.spec, "volumes")
 
 
 class TestGCPTaskRunnerGetTaskStatus:


### PR DESCRIPTION
## Summary

Post-#950 hardening follow-up. Locks the provisioner container's writable surface to a single explicit workspace volume so a process compromise cannot tamper with `/app` (image code) or arbitrary FS paths at runtime.

- **Container security**: `readOnlyRootFilesystem: true` on k8s and `readonlyRootFilesystem: true` on ECS; runs as UID/GID 1000 with all caps dropped, no privilege escalation, `seccompProfile: RuntimeDefault`. GKE Pod spec also sets `fsGroup: 1000` so the kubelet chowns the mounted emptyDir volumes for the runtime user.
- **Workspace staging**: `terraform_base` now stages each Terraform request to `${TERRAFORM_WORKSPACE_DIR}/<request_uuid>/`, runs `init`/`apply`/`destroy` from the staged path, and tears the staged tree down on success and failure paths. `terraform.tfvars.json` is created with 0o600 perms (per-request dir 0o700); cleanup of secret-bearing files surfaces failure rather than silently leaving secrets on disk. Stale runtime artifacts are filtered out of the staged copy; the trusted `.terraform.lock.hcl` is preserved as source input to keep provider checksums pinned (supply-chain).
- **Cloud-neutral container-name contract**: `PROVISIONER_CONTAINER_NAME` exported from `shared.cloud` (not from a GCP-namespaced module) so AWS/ECS dispatch sites and the GCP task-runner gate import the same string. Hardening only applies to provisioner Jobs; CMS experiments and other shared-runner callers keep their existing contract. Structural tests assert the constant is honored at every dispatch site (engine/ecs.py, ECS task definition, GCP task runner).
- **ADR-006 evidence updated**; `.kube-linter.yaml` continues to enforce the static-manifest baseline. Dead `_get_working_dir()` in main.py removed.

## Acceptance criteria status

- [x] `securityContext.readOnlyRootFilesystem: true` (k8s) and `readonlyRootFilesystem: true` (ECS) — `shifter/shifter_platform/shared/cloud/gcp/task_runner.py`, `platform/terraform/modules/engine-provisioner/task_definition.tf`.
- [x] Runtime smoke test in `test_dockerfile.py` includes a read-only-root assertion (`test_app_is_not_writable_when_root_filesystem_is_readonly`).
- [x] ADR-006 evidence updated; `.kube-linter.yaml` enforces `readOnlyRootFilesystem` for static manifests.
- [ ] **End-to-end Fargate / GKE dev verification** — operational test, post-merge: provision a range, destroy it under the read-only configuration. The structural mitigations (Dockerfile pre-chown of mount paths, GKE `fsGroup: 1000`, ECS `user = "1000:1000"`, named-volume ownership inheritance) should succeed; this is the conclusive cross-check.

## Test plan

- [x] Provisioner test suite (650 passed, 8 skipped).
- [x] Shifter platform test suite (2752 passed).
- [x] Pre-commit (ruff, ruff-format, bandit, checkov, mypy, terraform fmt, terraform validate, tflint, ADR guard, import-linter — all green).
- [ ] CI green on this PR.
- [ ] SonarCloud quality gate clean.
- [ ] Test-quality review skill green.
- [ ] Dev verification: deploy this image to dev cluster, provision a range, destroy it.

## Codex review history

5 cycles run pre-push (override-authorized after cycle 3 cap). Genuine new findings fixed in each cycle: cycle 1 (fsGroup, dirs_exist_ok, dead init_workspace, container-name gate); cycle 2 (sibling-module staging, runtime-artifact ignore, magic-string gate); cycle 3 (cleanup-failure silencing, /tmp default permissions, lock-file ignore — later **reversed** in cycle 4 on supply-chain grounds, ECS↔GCP container-name alignment, sizeLimit on memory volume, cloud-neutral constant placement); cycle 5 (destroy() bypassed `_write_tfvars`, request_uuid path-segment validation). Repeat findings on ECS Fargate ownership and the container-name string switch are mitigated structurally; full architectural fixes (TaskRunner-protocol parameterization, end-to-end Fargate test) are out of scope for this PR. Decision rationale on each cycle is in the issue thread.

Closes #1103