### PR TITLE
Add root installation config schema (#1112)

### DIFF
--- a/.github/workflows/_quality.yml
+++ b/.github/workflows/_quality.yml
@@ -228,6 +228,27 @@ jobs:
           uv run ruff check .
           uv run ruff format --check .
 
+  installation-lint:
+    permissions:
+      contents: read
+    name: Lint (installation)
+    # GitHub-hosted ephemeral runner: this job runs PR-controlled Python from a
+    # standalone package with no special infra needs, so keep it off the persistent
+    # self-hosted pool.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+
+      - name: Lint Python
+        working-directory: shifter/installation
+        run: |
+          uv sync --group dev
+          uv run ruff check .
+          uv run ruff format --check .
+
   k8s-lint:
     permissions:
       contents: read
@@ -446,6 +467,24 @@ jobs:
           uv tool install 'bandit[toml]'
           bandit -r . -c pyproject.toml
 
+  installation-sast:
+    permissions:
+      contents: read
+    name: SAST (installation)
+    # GitHub-hosted ephemeral runner (see installation-lint).
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+
+      - name: Run Bandit
+        run: |
+          uv tool install bandit
+          bandit -r shifter/installation/ --skip B101 --exclude shifter/installation/tests,shifter/installation/.venv
+
   # ===========================================================================
   # Python Tests
   # ===========================================================================
@@ -601,6 +640,28 @@ jobs:
 
       - name: Run tests
         working-directory: scripts/check_rds_pending_modifications
+        run: uv run pytest tests/
+
+  installation-tests:
+    permissions:
+      contents: read
+    name: Tests (installation)
+    if: ${{ !inputs.skip_tests }}
+    needs: [installation-lint]
+    # GitHub-hosted ephemeral runner (see installation-lint).
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+
+      - name: Install dependencies
+        working-directory: shifter/installation
+        run: uv sync --group dev
+
+      - name: Run tests
+        working-directory: shifter/installation
         run: uv run pytest tests/
 
   adr-guard-tests:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,6 +85,13 @@ repos:
       - id: ruff-format
         name: ruff-format (check_rds_pending_modifications)
         files: ^scripts/check_rds_pending_modifications/
+      - id: ruff
+        name: ruff (installation)
+        args: [--fix]
+        files: ^shifter/installation/
+      - id: ruff-format
+        name: ruff-format (installation)
+        files: ^shifter/installation/
 
   # JavaScript/CSS linting
   - repo: local
@@ -215,6 +222,11 @@ repos:
         args: [-r, --skip, "B101,B112"]
         files: ^scripts/check_layer_imports/
         exclude: ^scripts/check_layer_imports/(tests|\.venv)/
+      - id: bandit
+        name: bandit (installation)
+        args: [-r, --skip, B101]
+        files: ^shifter/installation/
+        exclude: ^shifter/installation/(tests|\.venv)/
 
   # IaC Security (Terraform, Dockerfile)
   - repo: https://github.com/bridgecrewio/checkov
@@ -398,6 +410,20 @@ repos:
           bash -c 'cd scripts/check_rds_pending_modifications && uv run pytest tests/ -q'
         language: system
         files: ^scripts/check_rds_pending_modifications/
+        pass_filenames: false
+
+  # Installation config tests
+  - repo: local
+    hooks:
+      - id: pytest-installation
+        name: pytest (installation)
+        entry: >-
+          bash -c 'cd shifter/installation && uv run pytest tests/ -q --cov=.
+          --cov-report=html:../../coverage/installation
+          --cov-report=xml:coverage.xml
+          --cov-report=term-missing:skip-covered'
+        language: system
+        files: ^shifter/installation/
         pass_filenames: false
 
   # Jest tests (JS)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,70 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.99.0] - 2026-05-10
+
+### Added
+
+- **Root installation config schema (#1112, PLAT-2001 / GEN-2001 /
+  GEN-2002).** New `installation` package (`shifter/installation/`)
+  defining `shifter.yaml` — the single authoritative root file an OSS
+  deployment edits to choose and configure a backend bundle. It ships:
+  - Typed Pydantic v2 models (`installation.schema.RootConfig`,
+    `DeploymentConfig`) for the root keys `version`, `backend`,
+    `deployment` (`name`, `domain`, `profile`), `secrets`, and
+    `settings`. The schema validates the *shape* of the root config:
+    unknown top-level keys, unknown `deployment` keys, missing required
+    keys, an unknown backend, an unsupported profile/backend
+    combination, a malformed deployment name or domain, duplicate YAML
+    mapping keys at any level (which PyYAML would otherwise silently
+    collapse), and `secrets` values that are clearly raw key material
+    (multi-line, PEM-headered, or implausibly long — capped at 1024
+    characters, well above the longest realistic provider reference) are
+    all rejected — and every problem is reported together — *before*
+    Terraform, Helm, Django startup, workers, or deployment scripts run.
+    `secrets` holds *references* (a provider secret name, a GitHub
+    Actions secret name, an env var, or `prompt`), never values; the
+    schema cannot tell a short secret value from a secret *name*, so the
+    precise per-provider reference grammar — and the contents of
+    `settings`, and which settings each backend requires — are validated
+    by the selected backend bundle's contract (#1113), not by the root
+    schema. The schema models exactly one standalone deployment (no
+    fleet / install registry / cross-install orchestration keys). The
+    known backends and the profiles each allows live in
+    `installation.backends` as a provisional registry that #1113
+    supersedes; the `local` backend is #1119.
+  - `installation.loader.load_root_config` /
+    `validate_root_config_file` — load and fail-fast validate a config
+    file, aggregating all problems on `InstallationConfigError.issues`.
+    The error model (`installation.errors.ConfigIssue` /
+    `InstallationConfigError`) never carries the rejected input, so a
+    mistyped secret cannot leak through an error message; YAML parse
+    errors are reported from the parser's own position/description only,
+    not from the file content.
+  - The `shifter-config validate [PATH]` CLI (also `python -m
+    installation validate`), run from the repo root via `uv run
+    --project shifter/installation`: exits `0` with `OK — root config
+    shape is valid (backend=…, profile=…)` for a valid config, or `1`
+    with each problem on stderr; defaults to `./shifter.yaml`.
+  - Worked, machine-validated example configs for the AWS and GCP
+    backends under `shifter/installation/examples/` (the test suite
+    loads every file there through the same parser, so an example cannot
+    drift from the schema).
+
+  Wired into the standard per-package CI jobs (`installation-lint`,
+  `installation-sast`, `installation-tests` in
+  `.github/workflows/_quality.yml` — on GitHub-hosted ephemeral runners,
+  since they execute PR-controlled Python), pre-commit (ruff /
+  ruff-format / bandit / pytest hooks scoped to `shifter/installation/`),
+  SonarCloud (`sonar.sources` / `sonar.tests` / coverage report path),
+  and recorded as ADR-011 evidence in `docs/adr/index.yaml`. The package
+  is built into the Shifter Platform Docker image alongside `cyberscript`
+  (so the Django app, workers, and provisioner can `import installation`
+  when #1114 derives runtime config from the root config). The
+  architecture note `docs/architecture/root-configured-backend-bundles.md`
+  records the resolved root-config filename. Django-free (pydantic v2 +
+  PyYAML only) so scripts, CI, and the Django app can all use it.
+
 ## [3.98.1] - 2026-05-10
 
 ### Fixed

--- a/docs/adr/index.yaml
+++ b/docs/adr/index.yaml
@@ -378,6 +378,9 @@
     "evidence": [
       "docs/architecture/root-configured-backend-bundles.md",
       "docs/adr/index.yaml",
+      "shifter/installation/__init__.py",
+      "shifter/installation/schema.py",
+      "shifter/installation/README.md",
       "shifter/shifter_platform/shared/cloud/__init__.py",
       "shifter/engine/provisioner/cloud/__init__.py",
       ".github/workflows/deploy.yml",

--- a/docs/architecture/root-configured-backend-bundles.md
+++ b/docs/architecture/root-configured-backend-bundles.md
@@ -61,6 +61,199 @@ configuration mode is deliberately introduced later.
 - Existing AWS and GCP behavior should migrate through compatibility paths that
   preserve current security controls.
 
+## Root Config Schema Preflight
+
+Scope for `GEN-2001`, `PLAT-2001`, `GEN-2002`, and #1112: define the root
+installation config contract and its validation boundary only. Do not implement
+backend migration, workflow replacement, runtime adapter rewiring, cross-install
+orchestration, or a public capability-composition model as part of the schema
+definition.
+
+The authoritative root file is **`shifter.yaml`** at the repository root, and the
+contract is implemented by the `installation` package
+([`shifter/installation/`](../../shifter/installation/README.md)): the typed schema,
+a fail-fast loader, worked examples, and the `shifter-config validate` CLI. The
+backend bundle contract and registry referenced below are #1113; the `local`
+backend is #1119.
+
+### Contract Boundary
+
+- The root config is user-authored installation intent. It selects one backend
+  bundle, deployment identity, public domain/hostname intent, and profile-level
+  settings. It is not a generated runtime env file, Terraform output file, Helm
+  values file, Kubernetes manifest, or CI branch selector.
+- The root config models exactly one standalone Shifter deployment. It must not
+  introduce fleet, install registry, tenant-to-install mapping, parent/child
+  deployment, remote cluster inventory, cross-install dependency, or centralized
+  rollout concepts in the OSS app model.
+- Secret material must stay out of the root config. The schema may accept secret
+  references, provider secret names, GitHub secret names, or bootstrap prompts,
+  but not raw secret values, access tokens, passwords, private keys, or service
+  account JSON.
+- Backend-specific settings must be namespaced behind the selected backend
+  bundle and validated by that bundle contract. The public root schema must not
+  expose low-level identity/storage/queue/task/secrets capability composition in
+  the default UX.
+- Unknown backends, unknown root keys, conflicting settings, unsupported
+  profile/backend combinations, missing required settings, and insecure public
+  posture must fail before Terraform, Helm, Django startup, worker startup, or
+  deployment scripts run.
+- Root config examples must be machine-validated by the same parser used by
+  setup, doctor, CI, and render commands. Documentation examples are not a
+  second schema.
+
+### Incumbents To Reuse
+
+| Concern | Canonical incumbent | Root config guardrail |
+| --- | --- | --- |
+| Shared contracts and layer boundaries | `shared/`, `.importlinter`, `scripts/check_layer_imports/layer_imports.yaml`, `ADR-001` | Put any cross-runtime contract behind `shared` or a repo-level script contract that does not import Django app layers directly. Do not create provider schemas separately inside each app. |
+| Schema validation | Existing Pydantic v2 schema style in `shared.schemas`, `cyberscript.schemas`, `cms.scenarios.schema`, and `cms.experiments.schemas`; script-local validators in `scripts/bootstrap/deploy.py` | Use one authoritative typed model/parser for the root config. If YAML is the UX format, use a structured parser and central validation instead of ad hoc regex/string parsing. |
+| Runtime env binding | `shifter/shifter_platform/config/settings.py`, `scripts/gcp/render_runtime_env.py`, `scripts/bootstrap/deploy.py::render_gcp_helm_values`, Helm `runtimeEnv` | Treat runtime env as derived output. Generate canonical keys first and keep AWS/Pulumi-era aliases as compatibility only while migration work requires them. |
+| Cloud capability seams | `shifter/shifter_platform/shared/cloud/__init__.py`, `shared/cloud/types.py`, `shifter/engine/provisioner/cloud/__init__.py`, `ADR-005-R1` | Backend selection may feed the existing factories, but domain code must continue to call cloud-neutral factories/protocols instead of provider-specific modules. |
+| Identity/auth | `ADR-009`, `config/settings.py`, `config/oidc.py`, `config/identity_platform.py`, `scripts/bootstrap/deploy.py::ensure_gcp_identity_platform_operator` | Backend config may choose the identity stack through backend metadata; it must not move provider credential collection into Django or bypass domain/email/MFA/bootstrap controls. |
+| Secrets | `shared.cloud.*.secrets`, `engine/provisioner/cloud/*/secrets.py`, `scripts/bootstrap/deploy.py` Secret Manager/GitHub secret helpers, `.gitleaks.toml` | Store and pass secret identifiers, not values. Keep generated secret-bearing Helm values in temporary/staged outputs or provider secret stores, and never echo secret values in diagnostics. |
+| Logging and error text | `config.logging.ECSFormatter`, `shared.log_sanitize.safe_log`, existing CLI `error()`/`warn()` fail-fast style | Validation errors should name paths/keys and remediation, but must not include secret values, token payloads, or unescaped user-controlled strings. Do not add a parallel exception hierarchy unless a caller boundary needs it. |
+| Infrastructure validators | `terraform validate`, `.tflint.hcl`, `kubeconform`, `.kube-linter.yaml`, `ADR-006`, `ADR-008` | Backend doctor checks must invoke or front-run these validators instead of replacing them. Security posture checks such as managed TLS, public hostname, and authorized admin CIDRs stay fail-closed. |
+| Workflow/architecture gates | `.ground-control.yaml`, `.gc/plan-rules.md`, `scripts/adr_guard/adr_guard.py`, `.github/workflows/_quality.yml`, `ADR-002`, `ADR-003`, `ADR-011` | Root config work must preserve ADR guard, import boundaries, secret scanning, branch-independent deploy intent, and documented guardrail changes. |
+
+### Security Layers The Design Must Pass
+
+- Auth surface: backend-derived config must satisfy the existing `AUTH_PROVIDER`
+  paths and `ADR-009` controls. AWS remains OIDC/Cognito-compatible; GCP remains
+  Identity Platform with provider-side credential collection, verified email,
+  MFA, and bootstrap-owned first-operator seeding.
+- Secret-handling surface: root config accepts references only. Provider secret
+  adapters and bootstrap helpers resolve values at runtime or deployment time.
+  Secret values must not be committed, logged, rendered into docs/examples, or
+  passed through command-line argv.
+- Env-binding shape: generated env must match `settings.py` canonical keys and
+  existing alias windows. Any new key must have one owner, one renderer, and one
+  validation source; generated ConfigMaps must not carry values that should be
+  Kubernetes Secrets or provider secrets.
+- Config validators: the root parser validates shape and cross-field conflicts;
+  backend bundles validate provider requirements; Terraform, Helm, Kubernetes,
+  actionlint, import-linter, and ADR guard keep their existing authority.
+- OS/process exposure: deployment and doctor commands should continue to use
+  argv-array subprocess calls, temporary credential files with cleanup, and
+  interactive secret prompts via `getpass` where values must be collected.
+- Error envelopes and logs: CLI failures should be deterministic nonzero exits
+  with sanitized messages. Django-facing validation should use existing
+  validation/error response patterns rather than a new global error envelope.
+
+### Extensibility Seam
+
+The schema needs an explicit version/profile/backend seam so the next backend
+or profile does not require redefining the root contract. The root parser owns
+root keys and dispatches selected-backend settings to backend bundle validation;
+backend bundles own provider-specific requirements, generated outputs,
+entrypoints, health checks, and docs. Future `local` or production variants
+should add backend/profile data behind that seam, not add another authoritative
+root file or branch convention.
+
+### Anti-Patterns
+
+- Treating branch names, Terraform environment directories, Helm values,
+  generated env files, or provider-local docs as additional authoritative config.
+- Duplicating root schema definitions across scripts, Django settings, Terraform
+  variables, Helm values, and examples.
+- Letting runtime code independently infer provider from `CLOUD_PROVIDER` while
+  setup/doctor uses a different root config interpretation.
+- Mixing public backend selection with low-level capability composition in the
+  default UX.
+- Recording secret values, bootstrap passwords, service-account JSON, access
+  tokens, or private keys in root config, argv, logs, examples, ConfigMaps, or
+  plan comments.
+- Weakening ADR, import, Terraform, Kubernetes, actionlint, gitleaks, or CI
+  enforcement to make the schema migration easier.
+
+### Non-Goals
+
+- Do not design a fleet manager, multi-install controller, hosted control plane,
+  marketplace, plugin runtime, or centralized upgrade service.
+- Do not move provider credential collection, secret value storage, identity
+  policy, deployment state, Terraform state, or Kubernetes runtime manifests
+  into the root config.
+- Do not rename legacy Pulumi-era or AWS/GCP compatibility surfaces as part of
+  schema definition unless a dedicated migration issue owns the state, workflow,
+  tests, and documentation impact.
+
+## Setup And Doctor UX Preflight
+
+Scope for `GEN-2002` and #1115: expose a backend-aware setup and validation
+experience that proves the selected backend is ready before Terraform, Helm,
+Django, workers, or provisioners mutate infrastructure or start runtime work.
+This is a UX and validation boundary, not a new deployment orchestrator.
+
+### Command Boundary
+
+- Setup may create or update the root config and guide secret/bootstrap
+  reference creation. It must not become a second source of backend truth.
+- Doctor is read-only by default. It may inspect local files, tool availability,
+  provider identity, secret existence, rendered outputs, Terraform/Helm/K8s
+  validity, and reachable health endpoints, but it must not run `apply`,
+  `upgrade --install`, `kubectl apply`, secret version writes, first-user
+  seeding, or destructive cleanup.
+- The public UX should reuse the existing CLI grammar, dry-run behavior,
+  non-interactive behavior, and `info`/`warn`/`error` fail-fast style from
+  `scripts/bootstrap/deploy.py`. If a new entrypoint is introduced, it should
+  call the same parser/check/render functions rather than fork bootstrap logic.
+- CI-facing validation should use the same root parser and backend doctor checks
+  as the local UX. Documentation examples and workflow examples must not carry a
+  parallel interpretation of valid config.
+
+### Checks To Reuse
+
+| Layer | Canonical incumbent | Doctor guardrail |
+| --- | --- | --- |
+| CLI dependency checks | `scripts/bootstrap/deploy.py::check_dependencies`, command-specific tool lists | Extend the command-specific dependency model for backends. Do not scatter `shutil.which` checks across backend scripts. |
+| Provider security preflight | `validate_gcp_control_plane_security_inputs`, GCP edge promotion checks, AWS Cognito/OIDC and Terraform input conventions | Preserve fail-closed checks for hostname, managed TLS, admin CIDRs, provider auth, and identity bootstrap prerequisites before deploy. |
+| Render validation | `scripts/gcp/render_runtime_env.py`, `scripts/gcp/render_edge_manifest.py`, `render_gcp_helm_values`, Helm `runtimeEnv` | Doctor should render to memory or temp paths and compare against the backend contract. Do not hand-build env files in a separate path. |
+| Infrastructure validation | `terraform init -backend=false`, `terraform validate`, `.tflint.hcl`, Helm template rendering, `kubeconform`, `.kube-linter.yaml`, `ADR-006`, `ADR-008` | Doctor may front-run these checks and summarize them, but it must not replace their authority or mask their exact failures. |
+| Runtime validation | `config/settings.py`, `/health/`, Django `check --deploy`, cloud factories in `shared.cloud` and `engine/provisioner/cloud` | Validate generated runtime keys against canonical settings and factories before startup. Runtime provider selection must still flow from validated backend config. |
+| Tests | `scripts/bootstrap/tests/test_deploy.py`, `scripts/gcp/tests/*`, shared cloud factory tests, `tests/config/*` | Add contract tests around setup/doctor parsing, read-only behavior, redaction, and backend dispatch rather than only snapshotting terminal output. |
+
+### Security Layers
+
+- Auth surface: setup/doctor may verify the selected backend's auth mode and
+  required references, but provider credential collection stays in existing
+  provider flows. GCP first-operator handling continues through
+  `ensure_gcp_identity_platform_operator`; AWS remains Cognito/OIDC-compatible.
+- Secret-handling surface: checks must verify secret references, names, access,
+  or freshness without printing or storing secret payloads. If a payload must be
+  read for an existing backend check, use existing provider secret helpers,
+  temporary files with cleanup, and redacted diagnostics.
+- Env-binding shape: generated runtime values must keep secret identifiers in
+  ConfigMaps and secret values in Kubernetes Secrets or provider stores.
+  Doctor should fail when a value crosses that boundary.
+- OS/process exposure: subprocess calls use argv arrays. Do not pass passwords,
+  service-account JSON, private keys, access tokens, or bootstrap secrets in
+  argv, dry-run output, plan comments, shell snippets, or log messages.
+- Error envelopes and logs: CLI output should identify the failing check,
+  config path, canonical owner, and remediation. User-provided paths, hostnames,
+  and provider messages should be sanitized before logging.
+
+### Extensibility Seam
+
+Backend bundles should contribute setup and doctor metadata behind the same
+version/profile/backend seam as the root config schema: required tools, required
+secret references, provider prerequisites, renderers, validators, health checks,
+and whether a check is read-only. Adding a `local` backend or a production
+profile should add backend/profile check data, not a new setup command family or
+branch-derived validation path.
+
+### Anti-Patterns
+
+- A doctor command that mutates infrastructure, writes provider secrets, applies
+  Kubernetes manifests, seeds users, or silently repairs state.
+- Separate root config parsers for setup, doctor, render, CI, Terraform docs, or
+  Django settings.
+- Treating `CLOUD_PROVIDER`, branch names, Terraform directories, Helm values,
+  or generated env files as the source of truth when the root config exists.
+- Printing provider credentials, secret payloads, env dumps, Terraform outputs
+  with sensitive values, or command lines containing tokens.
+- Marking doctor green when Terraform, Helm, Kubernetes, ADR guard, import
+  boundaries, or security posture checks failed downstream.
+
 ## Draft Requirements
 
 These requirements have been created in Ground Control as `DRAFT` requirements.
@@ -112,9 +305,14 @@ evidence only when corresponding files change.
 
 ## Open Questions
 
-- What is the first-class root config filename and location?
 - Should the local backend be Docker Compose first, Kubernetes first, or staged?
 - Which commands should form the public setup UX: `make`, a Python CLI, Django
-  management commands, or a small standalone tool?
+  management commands, or a small standalone tool? (#1112 ships `shifter-config
+  validate`; the broader setup/doctor UX is #1115.)
 - Which existing Pulumi-related names are harmless compatibility aliases, and
   which require migration to avoid confusing users?
+
+## Resolved
+
+- The first-class root config file is `shifter.yaml` at the repository root; the
+  contract is the `installation` package (`shifter/installation/`). (#1112)

--- a/shifter/installation/README.md
+++ b/shifter/installation/README.md
@@ -1,0 +1,98 @@
+# installation — root installation config contract
+
+A Shifter OSS deployment is configured by **one** root file, `shifter.yaml`, at the
+repository root. This package owns that contract: the typed schema, a loader that
+fails fast with aggregated errors, and the `shifter-config` CLI. It is the single
+authoritative parser — setup, doctor, CI, and (later) runtime derivation validate
+against it rather than re-parsing the YAML by hand. Constrained by
+[ADR-011](../../docs/adr/index.yaml) and the
+[Root-Configured Backend Bundles](../../docs/architecture/root-configured-backend-bundles.md)
+architecture note.
+
+This package is Django-free (pydantic v2 + PyYAML only) so scripts, CI, and the
+Django app can all use it.
+
+## `shifter.yaml`
+
+```yaml
+version: 1                       # optional, default 1; only schema version 1 is supported
+backend: aws                     # required; one of the known backends (currently: aws, gcp)
+deployment:                      # required
+  name: shifter                  # required; DNS-label-safe (lowercase letters, digits, internal hyphens, 1-40 chars)
+  domain: shifter.example.com    # required; a real public DNS hostname (>= 2 labels, not an IP, not bare localhost)
+  profile: prod                  # optional, default prod; one of {prod, dev}; must be allowed by the selected backend
+secrets:                         # optional; mapping of logical name -> reference identifier
+  django_secret_key: shifter/prod/django-secret-key
+settings:                        # optional; backend-specific settings, validated by the selected backend bundle
+  region: us-east-2
+```
+
+### Field reference
+
+| Key | Required | Type | Notes |
+| --- | --- | --- | --- |
+| `version` | no (default `1`) | int | Schema version. Only `1` is supported today. |
+| `backend` | yes | string | The backend bundle to use. Must be one of the known backends (`aws`, `gcp`). The backend bundle registry in #1113 supersedes this set; the `local` backend is #1119. |
+| `deployment.name` | yes | string | DNS-label-safe identifier for this installation: lowercase letters, digits, and internal hyphens; 1-40 characters. |
+| `deployment.domain` | yes | string | Public hostname users reach this deployment at. Must be a fully-qualified DNS name (at least two labels), lowercase, with no scheme, no IP literal, and no trailing dot. |
+| `deployment.profile` | no (default `prod`) | string | Deployment tier: `prod` or `dev`. Must also be a profile the selected backend supports. |
+| `secrets` | no (default `{}`) | mapping | Logical secret name → reference identifier. Keys match `^[a-z][a-z0-9_]*$`. Values are *references* — a provider secret name, a GitHub Actions secret name, an environment variable, or the literal `prompt` — never the secret value itself. |
+| `settings` | no (default `{}`) | mapping | Backend-specific settings. Opaque to the root parser; the selected backend bundle validates the contents (#1113). |
+
+`validate` checks the *shape* of the root config — the backend selector, deployment
+identity, secret references, and that `settings` is a mapping. Unknown top-level keys,
+unknown keys under `deployment`, missing required keys, an unknown backend, an
+unsupported profile/backend combination, a malformed name or domain, and a `secrets`
+value that is clearly raw key material (multi-line, PEM-headered, or implausibly long)
+are all rejected — and all problems are reported together — *before* Terraform, Helm,
+Django, workers, or deployment scripts run. The *contents* of `settings` (and which
+settings a backend requires) are validated by the selected backend bundle's
+contract (#1113), not by this command.
+
+> The root config holds references, not secret values. Storing a raw password,
+> token, private key, or service-account JSON in `shifter.yaml` is rejected by the
+> schema where it is recognizable and caught independently by `gitleaks`. The schema
+> cannot tell a short secret value from a secret *name*, so the precise per-provider
+> reference format is the backend bundle's responsibility (#1113).
+
+## Usage
+
+This package is its own [uv](https://docs.astral.sh/uv/) project, so run the CLI
+through `uv run --project shifter/installation` from the repo root (paths are
+relative to the directory you run from):
+
+```bash
+# After copying an example to ./shifter.yaml at the repo root:
+uv run --project shifter/installation shifter-config validate            # validates ./shifter.yaml
+uv run --project shifter/installation shifter-config validate path/to/shifter.yaml
+# equivalently:  uv run --project shifter/installation python -m installation validate [PATH]
+```
+
+`validate` prints `OK — root config shape is valid (backend=…, profile=…)` and exits
+`0` when the config is valid, or prints each problem to stderr and exits `1`.
+
+```python
+from installation import load_root_config, validate_root_config_file, InstallationConfigError
+
+config = load_root_config("shifter.yaml")   # raises InstallationConfigError with aggregated .issues
+issues = validate_root_config_file("shifter.yaml")  # returns a list of ConfigIssue; never raises
+```
+
+## Examples
+
+Worked, machine-validated configs for the supported backends live in
+[`examples/`](examples/) (`aws.yaml`, `gcp.yaml`). The package test suite loads
+every file in that directory through the same parser, so an example can never drift
+from the schema. Copy one to `./shifter.yaml` at the repo root and edit it for your
+deployment.
+
+## Layout
+
+| File | Purpose |
+| --- | --- |
+| `schema.py` | Pydantic v2 models for the root config (`RootConfig`, `DeploymentConfig`). |
+| `backends.py` | Provisional registry of known backends and the profiles each allows (superseded by the backend bundle registry in #1113). |
+| `loader.py` | `load_root_config` / `validate_root_config_file` — read YAML, validate, aggregate errors. |
+| `errors.py` | `ConfigIssue` and `InstallationConfigError` — the error model (never carries the rejected input, so it cannot leak a mistyped secret). |
+| `cli.py` / `__main__.py` | The `shifter-config` CLI. |
+| `examples/` | Worked example configs, validated by the test suite. |

--- a/shifter/installation/__init__.py
+++ b/shifter/installation/__init__.py
@@ -1,0 +1,27 @@
+"""Root installation configuration contract for Shifter OSS deployments.
+
+A Shifter OSS deployment is configured by one root file, ``shifter.yaml``, that
+selects a backend bundle and supplies deployment-level settings. This package owns
+that contract: the typed schema, a loader that fails fast with aggregated errors, and
+the ``shifter-config`` CLI. Constrained by ADR-011 (OSS deployments use
+root-configured backend bundles).
+"""
+
+from __future__ import annotations
+
+from .backends import ALLOWED_PROFILES, KNOWN_BACKENDS, KNOWN_PROFILES
+from .errors import ConfigIssue, InstallationConfigError
+from .loader import load_root_config, validate_root_config_file
+from .schema import DeploymentConfig, RootConfig
+
+__all__ = [
+    "ALLOWED_PROFILES",
+    "KNOWN_BACKENDS",
+    "KNOWN_PROFILES",
+    "ConfigIssue",
+    "DeploymentConfig",
+    "InstallationConfigError",
+    "RootConfig",
+    "load_root_config",
+    "validate_root_config_file",
+]

--- a/shifter/installation/__main__.py
+++ b/shifter/installation/__main__.py
@@ -1,0 +1,10 @@
+"""Entry point for ``python -m installation``."""
+
+from __future__ import annotations
+
+import sys
+
+from .cli import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/shifter/installation/backends.py
+++ b/shifter/installation/backends.py
@@ -1,0 +1,33 @@
+"""Provisional registry of known Shifter backends.
+
+The root installation config (:mod:`installation.schema`) validates the ``backend``
+selector and the ``deployment.profile``/``backend`` combination against the data
+here. This is intentionally a small, hard-coded set covering the backends that have
+real infrastructure in the repository today; the backend *bundle* contract and a
+proper registry land in issue #1113 and supersede this module. The ``local`` backend
+is defined by issue #1119.
+
+Keeping the contents minimal keeps the root schema decoupled from per-backend
+settings: the root parser only needs to know which backend names exist and which
+deployment profiles each one supports. Everything else (required settings, generated
+outputs, infrastructure entrypoints, health checks, docs) belongs to the backend
+bundle, not here.
+"""
+
+from __future__ import annotations
+
+#: The single source of truth: each known backend mapped to the deployment profiles
+#: it supports. Issue #1113 replaces this dict with the backend bundle registry; the
+#: schema validates ``backend``, ``deployment.profile``, and the profile/backend
+#: combination entirely against this data, so a future backend or profile only needs
+#: to be added here.
+ALLOWED_PROFILES: dict[str, frozenset[str]] = {
+    "aws": frozenset({"prod", "dev"}),
+    "gcp": frozenset({"prod", "dev"}),
+}
+
+#: Backend names the root installation config currently accepts (derived).
+KNOWN_BACKENDS: frozenset[str] = frozenset(ALLOWED_PROFILES)
+
+#: Deployment profiles the schema understands at all, independent of backend (derived).
+KNOWN_PROFILES: frozenset[str] = frozenset().union(*ALLOWED_PROFILES.values())

--- a/shifter/installation/cli.py
+++ b/shifter/installation/cli.py
@@ -1,0 +1,78 @@
+"""``shifter-config`` — inspect and validate the root Shifter installation config.
+
+Today it exposes one subcommand, ``validate``, which checks the *shape* of
+``shifter.yaml`` — the backend selector, deployment identity, secret references, and
+that backend-specific ``settings`` is a mapping — so CI, deploy scripts, and operators
+catch a malformed root config before Terraform, Helm, Django, workers, or deployment
+scripts run. The *contents* of ``settings`` (and which settings a backend requires) are
+validated by the selected backend bundle's contract (#1113); the backend-aware
+setup/doctor UX is #1115. This command deliberately stays small: parse a path, read a
+file, print sanitized results.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from .errors import InstallationConfigError
+from .loader import load_root_config
+
+DEFAULT_CONFIG_FILENAME = "shifter.yaml"
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="shifter-config",
+        description="Inspect and validate the root Shifter installation config.",
+    )
+    subcommands = parser.add_subparsers(dest="command", metavar="<command>")
+    validate = subcommands.add_parser(
+        "validate",
+        help=f"Validate the shape of a root installation config (default: ./{DEFAULT_CONFIG_FILENAME}).",
+        description=(
+            f"Validate the shape of a root installation config (default: ./{DEFAULT_CONFIG_FILENAME}): "
+            "the backend selector, deployment identity, secret references, and that backend-specific "
+            "settings is a mapping. The contents of settings are validated by the selected backend bundle."
+        ),
+    )
+    validate.add_argument(
+        "path",
+        nargs="?",
+        default=DEFAULT_CONFIG_FILENAME,
+        help=f"Path to the config file (default: ./{DEFAULT_CONFIG_FILENAME}).",
+    )
+    return parser
+
+
+def _cmd_validate(path_str: str) -> int:
+    config_path = Path(path_str)
+    try:
+        config = load_root_config(config_path)
+    except InstallationConfigError as exc:
+        print(f"{config_path}: invalid", file=sys.stderr)
+        for issue in exc.issues:
+            print(f"  - {issue.render()}", file=sys.stderr)
+        return 1
+    print(
+        f"{config_path}: OK — root config shape is valid "
+        f"(backend={config.backend}, profile={config.deployment.profile})"
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    if args.command is None:
+        parser.print_help(sys.stderr)
+        return 2
+    if args.command == "validate":
+        return _cmd_validate(args.path)
+    parser.print_help(sys.stderr)  # pragma: no cover - argparse rejects unknown subcommands first
+    return 2
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised via ``python -m installation``
+    sys.exit(main())

--- a/shifter/installation/errors.py
+++ b/shifter/installation/errors.py
@@ -1,0 +1,63 @@
+"""Error model for root installation config loading and validation.
+
+A single small exception type, :class:`InstallationConfigError`, carries a list of
+:class:`ConfigIssue` records. There is deliberately no broader error hierarchy here:
+callers (the ``shifter-config`` CLI, CI checks, and — later — deploy/doctor tooling)
+only need "valid" vs "here are the problems", and Django-facing callers should keep
+using their own validation/error response patterns rather than this type.
+
+Issue records never carry the *input* that failed validation, so rendering an
+``InstallationConfigError`` cannot leak a raw secret value that a user mistakenly
+placed in the config.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ConfigIssue:
+    """One problem found in a root installation config.
+
+    Attributes:
+        path: Dotted location of the problem (e.g. ``deployment.domain``), the file
+            path for file-level problems (missing file, unparseable YAML), or
+            ``"<root>"`` when the problem is not attributable to a specific key.
+        message: Human-readable description naming what is wrong and, where useful,
+            how to fix it. Never contains the rejected input value.
+        hint: Optional extra remediation guidance.
+    """
+
+    path: str
+    message: str
+    hint: str | None = None
+
+    def render(self) -> str:
+        text = f"{self.path}: {self.message}"
+        if self.hint:
+            text += f" ({self.hint})"
+        return text
+
+
+class InstallationConfigError(Exception):
+    """Raised when a root installation config is missing or invalid.
+
+    The aggregated problems are available on :attr:`issues`.
+    """
+
+    def __init__(self, issues: list[ConfigIssue]) -> None:
+        self.issues: list[ConfigIssue] = list(issues)
+        super().__init__(self._render())
+
+    def _render(self) -> str:
+        if not self.issues:
+            return "invalid root installation config"
+        count = len(self.issues)
+        noun = "problem" if count == 1 else "problems"
+        lines = [f"invalid root installation config ({count} {noun}):"]
+        lines.extend(f"  - {issue.render()}" for issue in self.issues)
+        return "\n".join(lines)
+
+    def __str__(self) -> str:
+        return self._render()

--- a/shifter/installation/examples/aws.yaml
+++ b/shifter/installation/examples/aws.yaml
@@ -1,0 +1,32 @@
+# Example root installation config for the AWS backend.
+#
+# Copy this file to ./shifter.yaml at the repository root and edit it for your
+# deployment, then validate it from the repo root with:
+#   uv run --project shifter/installation shifter-config validate shifter.yaml
+# See shifter/installation/README.md for the full field reference.
+#
+# This file is user-authored installation intent only. It holds *references* to
+# secrets, never secret values — store the values in AWS Secrets Manager / GitHub
+# Actions secrets and reference them by name here.
+version: 1
+backend: aws
+
+deployment:
+  # DNS-label-safe identifier for this installation (lowercase, digits, internal hyphens).
+  name: shifter
+  # Public hostname users reach this deployment at. Must be a real DNS name.
+  domain: shifter.example.com
+  # Deployment tier. One of: prod, dev.
+  profile: prod
+
+# References to the secrets this deployment needs. The names on the right are
+# resolved by the AWS backend bundle at deploy/runtime (a Secrets Manager name,
+# a GitHub Actions secret name, an environment variable, or the literal "prompt").
+secrets:
+  django_secret_key: shifter/prod/django-secret-key
+  db_password: shifter/prod/db-password
+
+# Backend-specific settings. Validated by the AWS backend bundle, not by the root
+# schema — see issue #1113 for the backend bundle contract.
+settings:
+  region: us-east-2

--- a/shifter/installation/examples/gcp.yaml
+++ b/shifter/installation/examples/gcp.yaml
@@ -1,0 +1,32 @@
+# Example root installation config for the GCP backend.
+#
+# Copy this file to ./shifter.yaml at the repository root and edit it for your
+# deployment, then validate it from the repo root with:
+#   uv run --project shifter/installation shifter-config validate shifter.yaml
+# See shifter/installation/README.md for the full field reference.
+#
+# This file is user-authored installation intent only. It holds *references* to
+# secrets, never secret values — store the values in Google Secret Manager / GitHub
+# Actions secrets and reference them by name here.
+version: 1
+backend: gcp
+
+deployment:
+  # DNS-label-safe identifier for this installation (lowercase, digits, internal hyphens).
+  name: shifter
+  # Public hostname users reach this deployment at. Must be a real DNS name.
+  domain: shifter.example.com
+  # Deployment tier. One of: prod, dev.
+  profile: prod
+
+# References to the secrets this deployment needs. The names on the right are
+# resolved by the GCP backend bundle at deploy/runtime (a Secret Manager resource
+# name, a GitHub Actions secret name, an environment variable, or the literal "prompt").
+secrets:
+  django_secret_key: projects/your-gcp-project/secrets/shifter-django-secret-key/versions/latest
+
+# Backend-specific settings. Validated by the GCP backend bundle, not by the root
+# schema — see issue #1113 for the backend bundle contract.
+settings:
+  region: us-central1
+  project_id: your-gcp-project

--- a/shifter/installation/loader.py
+++ b/shifter/installation/loader.py
@@ -1,0 +1,168 @@
+"""Load and fail-fast validate the root installation config (``shifter.yaml``).
+
+:func:`load_root_config` is the entry point for code paths that need the parsed config
+(setup, doctor, CI checks, runtime derivation): it returns a validated
+:class:`~installation.schema.RootConfig` or raises
+:class:`~installation.errors.InstallationConfigError` with *all* problems aggregated, so
+a malformed root config (unknown/missing/conflicting key, bad backend, bad
+deployment identity, duplicate YAML key, raw key material in ``secrets``) is rejected
+before Terraform, Helm, Django startup, workers, or deployment scripts run. This is
+root-config *shape* validation; the contents of ``settings`` and the per-backend
+required-settings set are validated by the selected backend bundle's contract (#1113).
+:func:`validate_root_config_file` is the non-raising variant for "check, then report"
+callers.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import ValidationError
+
+from .errors import ConfigIssue, InstallationConfigError
+from .schema import RootConfig
+
+_YAML_MERGE_TAG = "tag:yaml.org,2002:merge"
+
+
+def _reject_duplicate_keys(node: yaml.Node, _visited: set[int] | None = None) -> None:
+    """Walk a parsed YAML node graph and reject duplicated mapping keys and merge keys.
+
+    PyYAML's loader silently keeps the *last* value for a duplicated key, so
+    ``backend: aws`` followed by ``backend: gcp`` would validate as ``gcp`` without
+    complaint — a confident, wrong "OK" for the authoritative root config. YAML merge
+    keys (``<<``) are rejected outright: they too let a "merged" key and an explicit
+    key of the same name coexist (the explicit one silently wins after construction),
+    and they add nothing to a hand-authored installation config. Both checks run on the
+    parsed node graph before any value is constructed. ``_visited`` guards against
+    recursive alias graphs (``&a {b: *a}``) so a crafted config cannot cause unbounded
+    recursion.
+    """
+    if _visited is None:
+        _visited = set()
+    if id(node) in _visited:
+        return
+    _visited.add(id(node))
+    if isinstance(node, yaml.MappingNode):
+        seen: set[object] = set()
+        for key_node, value_node in node.value:
+            if getattr(key_node, "tag", "") == _YAML_MERGE_TAG or (
+                isinstance(key_node, yaml.ScalarNode) and key_node.value == "<<"
+            ):
+                raise yaml.constructor.ConstructorError(
+                    "while constructing a mapping",
+                    node.start_mark,
+                    "YAML merge keys ('<<') are not supported in the root installation config",
+                    key_node.start_mark,
+                )
+            key = key_node.value if isinstance(key_node, yaml.ScalarNode) else repr(key_node.value)
+            if key in seen:
+                raise yaml.constructor.ConstructorError(
+                    "while constructing a mapping",
+                    node.start_mark,
+                    f"found duplicate key {key!r}",
+                    key_node.start_mark,
+                )
+            seen.add(key)
+            _reject_duplicate_keys(value_node, _visited)
+    elif isinstance(node, yaml.SequenceNode):
+        for item in node.value:
+            _reject_duplicate_keys(item, _visited)
+
+
+def _read_yaml_mapping(path: Path) -> dict[str, Any]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise InstallationConfigError(
+            [
+                ConfigIssue(
+                    str(path),
+                    "root installation config not found",
+                    "create it from one of the examples in shifter/installation/examples/",
+                )
+            ]
+        ) from exc
+    except OSError as exc:
+        detail = getattr(exc, "strerror", None) or str(exc)
+        raise InstallationConfigError(
+            [ConfigIssue(str(path), f"could not read root installation config: {detail}")]
+        ) from exc
+
+    try:
+        # Parse to a node graph first (no Python objects constructed) so duplicate
+        # mapping keys can be rejected before SafeLoader silently collapses them.
+        node = yaml.compose(text, Loader=yaml.SafeLoader)
+        if node is not None:
+            _reject_duplicate_keys(node)
+        data = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise InstallationConfigError([_yaml_issue(path, exc)]) from exc
+
+    if data is None:
+        raise InstallationConfigError(
+            [ConfigIssue(str(path), "root installation config is empty; expected a YAML mapping at the top level")]
+        )
+    if not isinstance(data, dict):
+        raise InstallationConfigError(
+            [ConfigIssue(str(path), f"expected a YAML mapping at the top level, found {type(data).__name__}")]
+        )
+    return data
+
+
+def _yaml_issue(path: Path, exc: yaml.YAMLError) -> ConfigIssue:
+    # Build the message from the parser's own problem description and position only —
+    # never from the file content — so a parse error on a line that holds a value
+    # (for example a mistyped secret) cannot be echoed back through the error surface.
+    where = ""
+    mark = getattr(exc, "problem_mark", None) or getattr(exc, "context_mark", None)
+    if mark is not None:
+        where = f" at line {mark.line + 1}, column {mark.column + 1}"
+    problem = getattr(exc, "problem", None) or getattr(exc, "context", None) or "could not parse YAML"
+    return ConfigIssue(str(path), f"invalid YAML{where}: {problem}")
+
+
+def _issues_from_validation_error(exc: ValidationError) -> list[ConfigIssue]:
+    seen: set[tuple[str, str]] = set()
+    issues: list[ConfigIssue] = []
+    for err in exc.errors():
+        loc = err.get("loc", ())
+        path = ".".join(str(part) for part in loc) if loc else "<root>"
+        message = err.get("msg", "invalid value")
+        dedup_key = (path, message)
+        if dedup_key in seen:
+            continue
+        seen.add(dedup_key)
+        issues.append(ConfigIssue(path, message))
+    issues.sort(key=lambda issue: (issue.path, issue.message))
+    return issues
+
+
+def load_root_config(path: str | Path) -> RootConfig:
+    """Parse and validate a root installation config file.
+
+    Raises:
+        InstallationConfigError: if the file is missing, unparseable, or fails schema
+            validation. All problems are aggregated on the exception's ``issues``.
+    """
+    config_path = Path(path)
+    data = _read_yaml_mapping(config_path)
+    try:
+        return RootConfig.model_validate(data)
+    except ValidationError as exc:
+        raise InstallationConfigError(_issues_from_validation_error(exc)) from exc
+
+
+def validate_root_config_file(path: str | Path) -> list[ConfigIssue]:
+    """Validate a root installation config file, returning the problems found.
+
+    Returns an empty list when the config is valid. Never raises
+    :class:`InstallationConfigError`.
+    """
+    try:
+        load_root_config(path)
+    except InstallationConfigError as exc:
+        return list(exc.issues)
+    return []

--- a/shifter/installation/loader.py
+++ b/shifter/installation/loader.py
@@ -27,6 +27,33 @@ from .schema import RootConfig
 _YAML_MERGE_TAG = "tag:yaml.org,2002:merge"
 
 
+def _check_mapping_key(key_node: yaml.Node, value_node: yaml.Node, seen: set[object]) -> None:
+    """Reject a ``<<`` merge key or a key already present in ``seen``; otherwise record it.
+
+    Raises a :class:`yaml.constructor.ConstructorError` (a :class:`yaml.YAMLError`) with the
+    offending key's position so the loader can report it like any other parse error.
+    """
+    is_merge = getattr(key_node, "tag", "") == _YAML_MERGE_TAG or (
+        isinstance(key_node, yaml.ScalarNode) and key_node.value == "<<"
+    )
+    if is_merge:
+        raise yaml.constructor.ConstructorError(
+            "while constructing a mapping",
+            value_node.start_mark,
+            "YAML merge keys ('<<') are not supported in the root installation config",
+            key_node.start_mark,
+        )
+    key = key_node.value if isinstance(key_node, yaml.ScalarNode) else repr(key_node.value)
+    if key in seen:
+        raise yaml.constructor.ConstructorError(
+            "while constructing a mapping",
+            value_node.start_mark,
+            f"found duplicate key {key!r}",
+            key_node.start_mark,
+        )
+    seen.add(key)
+
+
 def _reject_duplicate_keys(node: yaml.Node, _visited: set[int] | None = None) -> None:
     """Walk a parsed YAML node graph and reject duplicated mapping keys and merge keys.
 
@@ -48,24 +75,7 @@ def _reject_duplicate_keys(node: yaml.Node, _visited: set[int] | None = None) ->
     if isinstance(node, yaml.MappingNode):
         seen: set[object] = set()
         for key_node, value_node in node.value:
-            if getattr(key_node, "tag", "") == _YAML_MERGE_TAG or (
-                isinstance(key_node, yaml.ScalarNode) and key_node.value == "<<"
-            ):
-                raise yaml.constructor.ConstructorError(
-                    "while constructing a mapping",
-                    node.start_mark,
-                    "YAML merge keys ('<<') are not supported in the root installation config",
-                    key_node.start_mark,
-                )
-            key = key_node.value if isinstance(key_node, yaml.ScalarNode) else repr(key_node.value)
-            if key in seen:
-                raise yaml.constructor.ConstructorError(
-                    "while constructing a mapping",
-                    node.start_mark,
-                    f"found duplicate key {key!r}",
-                    key_node.start_mark,
-                )
-            seen.add(key)
+            _check_mapping_key(key_node, value_node, seen)
             _reject_duplicate_keys(value_node, _visited)
     elif isinstance(node, yaml.SequenceNode):
         for item in node.value:

--- a/shifter/installation/pyproject.toml
+++ b/shifter/installation/pyproject.toml
@@ -1,0 +1,63 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "installation"
+version = "0.1.0"
+description = "Root installation configuration contract for Shifter OSS deployments"
+requires-python = ">=3.12"
+dependencies = [
+    "pydantic>=2.0",
+    "pyyaml>=6.0",
+]
+
+[project.scripts]
+shifter-config = "installation.cli:main"
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.2",
+    "pytest-cov>=7.0.0",
+    "ruff>=0.14.10",
+    "bandit>=1.9.2",
+    "types-pyyaml>=6.0",
+]
+
+[tool.setuptools]
+packages = ["installation"]
+package-dir = {"installation" = "."}
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-q"
+
+[tool.coverage.run]
+omit = [
+    "tests/conftest.py",
+    "tests/*/conftest.py",
+]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 120
+exclude = [".venv", "__pycache__"]
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "B", "C4", "UP", "S", "T20", "SIM", "RUF"]
+# T201: print is intentional in the CLI tool
+# S101: assert is fine in tests (covered by per-file ignores too)
+ignore = ["S101", "T201"]
+
+[tool.ruff.lint.per-file-ignores]
+# S603: tests spawn the test interpreter (`sys.executable`) with fully literal args
+#       to exercise the `python -m installation` entry point — no untrusted input.
+"tests/**/*.py" = ["S101", "S105", "S106", "S603"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+
+[tool.bandit]
+exclude_dirs = [".venv", "tests"]
+skips = ["B101"]

--- a/shifter/installation/pyproject.toml
+++ b/shifter/installation/pyproject.toml
@@ -31,6 +31,9 @@ package-dir = {"installation" = "."}
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-q"
+markers = [
+    "integration: spawns a subprocess to exercise the installed CLI (`python -m installation`) end to end",
+]
 
 [tool.coverage.run]
 omit = [

--- a/shifter/installation/schema.py
+++ b/shifter/installation/schema.py
@@ -1,0 +1,225 @@
+"""Typed schema for the root installation configuration (``shifter.yaml``).
+
+``shifter.yaml`` is the single user-authored contract that selects a Shifter backend
+bundle and supplies deployment-level settings. This module is the *one* authoritative
+model for that file — setup, doctor, CI, and (later) runtime derivation must validate
+against it rather than re-parsing the YAML by hand or maintaining a parallel schema.
+
+Scope: this module owns the *root* keys (``version``, ``backend``, ``deployment``,
+``secrets``, ``settings``). Backend-specific settings live under ``settings`` and are
+opaque here — the backend bundle contract (#1113) validates their contents. The set of
+known backends and the profiles each supports come from :mod:`installation.backends`,
+which a real backend registry supersedes in #1113.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import re
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from . import backends
+
+# A DNS-label-safe identifier: lowercase letters/digits with internal hyphens, 1-40 chars.
+_DEPLOYMENT_NAME_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,38}[a-z0-9])?$")
+# A single hostname label: lowercase letters/digits with internal hyphens, 1-63 chars.
+_DOMAIN_LABEL_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$")
+# A logical secret name (the key in the ``secrets`` mapping).
+_SECRET_NAME_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+# The root schema treats ``secrets`` values as opaque references and cannot fully
+# distinguish a short secret value from a secret *name* — the selected backend bundle
+# (#1113) owns the precise per-provider reference grammar, and gitleaks scans for raw
+# secrets independently. This package only rejects values that are *clearly* raw key
+# material: multi-line, PEM-headered, or implausibly long. The cap sits well above the
+# longest realistic reference (an AWS Secrets Manager name is up to 512 chars, plus
+# ARN/region/version text; a GCP Secret Manager resource path is well under that) while
+# still catching a pasted base64 blob or PEM body.
+_MAX_SECRET_REFERENCE_LEN = 1024
+_MAX_DOMAIN_LEN = 253
+
+#: Schema versions this module understands.
+SUPPORTED_VERSIONS: tuple[int, ...] = (1,)
+
+
+def _validate_deployment_name(value: str) -> str:
+    if not _DEPLOYMENT_NAME_RE.match(value):
+        raise ValueError(
+            "must be 1-40 characters of lowercase letters, digits, and internal hyphens (a DNS-label-safe identifier)"
+        )
+    return value
+
+
+def _validate_domain(value: str) -> str:
+    if not value or value != value.strip():
+        raise ValueError("must be a non-empty hostname with no surrounding whitespace")
+    if value != value.lower():
+        raise ValueError("must be lowercase")
+    if value.endswith("."):
+        raise ValueError("must not end with a trailing dot")
+    try:
+        ipaddress.ip_address(value)
+    except ValueError:
+        pass
+    else:
+        raise ValueError("must be a DNS hostname, not an IP address")
+    labels = value.split(".")
+    if len(labels) < 2:
+        raise ValueError("must be a fully qualified hostname with at least two labels (e.g. shifter.example.com)")
+    if len(value) > _MAX_DOMAIN_LEN:
+        raise ValueError(f"must be at most {_MAX_DOMAIN_LEN} characters")
+    for label in labels:
+        if not _DOMAIN_LABEL_RE.match(label):
+            raise ValueError(
+                f"label {label!r} is invalid: each label must be 1-63 characters of lowercase letters, "
+                "digits, and internal hyphens"
+            )
+    tld = labels[-1]
+    if tld.isdigit() or len(tld) < 2:
+        raise ValueError(
+            f"the rightmost label {tld!r} is not a valid public DNS suffix; the hostname must end in a "
+            "registry-style TLD (e.g. shifter.example.com)"
+        )
+    return value
+
+
+def _validate_secrets(value: Any) -> dict[str, str]:
+    # A *present* ``secrets:`` key must be a mapping. An explicit YAML null (a dangling
+    # ``secrets:``) is treated as a malformed block and rejected, not silently coerced
+    # to ``{}`` — omit the key entirely to get the empty default.
+    if not isinstance(value, dict):
+        raise ValueError("must be a mapping of logical secret name to a reference identifier")
+    problems: list[str] = []
+    cleaned: dict[str, str] = {}
+    for raw_key, raw_value in value.items():
+        key = str(raw_key)
+        if not _SECRET_NAME_RE.match(key):
+            problems.append(f"secret name {key!r} must match ^[a-z][a-z0-9_]*$")
+            continue
+        if not isinstance(raw_value, str):
+            problems.append(f"secret reference for {key!r} must be a string")
+            continue
+        ref = raw_value
+        if ref != ref.strip() or not ref.strip():
+            problems.append(f"secret reference for {key!r} must be a non-empty string with no surrounding whitespace")
+            continue
+        if any(ch in ref for ch in "\r\n\t"):
+            problems.append(
+                f"secret reference for {key!r} must be a single line; the root config holds a reference "
+                "(a provider secret name, a GitHub Actions secret name, an env var, or 'prompt'), not the "
+                "secret value itself"
+            )
+            continue
+        if ref.startswith("-----BEGIN"):
+            problems.append(
+                f"secret reference for {key!r} looks like raw PEM key/certificate material; store the value in "
+                "a secret store and reference it by name"
+            )
+            continue
+        if len(ref) > _MAX_SECRET_REFERENCE_LEN:
+            problems.append(
+                f"secret reference for {key!r} is implausibly long for a reference ({len(ref)} characters, "
+                f"limit {_MAX_SECRET_REFERENCE_LEN}); the root config holds a reference, not the secret value "
+                "itself"
+            )
+            continue
+        cleaned[key] = ref
+    if problems:
+        raise ValueError("; ".join(problems))
+    return cleaned
+
+
+def _validate_settings(value: Any) -> dict[str, Any]:
+    # The root schema only checks that ``settings`` is a mapping; its *contents* are
+    # backend-specific and are validated by the selected backend bundle's contract
+    # (#1113) — including which settings are required for that backend and which keys
+    # are even allowed. Do not add per-backend settings validation here; that dispatch
+    # belongs to the backend bundle, not the root schema. A present-but-null
+    # ``settings:`` is rejected as malformed (omit the key to get the empty default).
+    if not isinstance(value, dict):
+        raise ValueError(
+            "must be a mapping of backend-specific keys; the selected backend bundle validates its contents"
+        )
+    return value
+
+
+class DeploymentConfig(BaseModel):
+    """Deployment-level settings shared by every backend."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    domain: str
+    # Validated against the registry's known profiles; the profile/backend combination
+    # is checked by RootConfig once the backend is also known.
+    profile: str = "prod"
+
+    @field_validator("name")
+    @classmethod
+    def _check_name(cls, v: str) -> str:
+        return _validate_deployment_name(v)
+
+    @field_validator("domain")
+    @classmethod
+    def _check_domain(cls, v: str) -> str:
+        return _validate_domain(v)
+
+    @field_validator("profile")
+    @classmethod
+    def _check_profile(cls, v: str) -> str:
+        if v not in backends.KNOWN_PROFILES:
+            valid = ", ".join(sorted(backends.KNOWN_PROFILES))
+            raise ValueError(f"unknown deployment profile {v!r}; must be one of {valid}")
+        return v
+
+
+class RootConfig(BaseModel):
+    """The authoritative root installation configuration loaded from ``shifter.yaml``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    version: int = 1
+    backend: str
+    deployment: DeploymentConfig
+    secrets: dict[str, str] = Field(default_factory=dict)
+    settings: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("version", mode="before")
+    @classmethod
+    def _check_version(cls, v: Any) -> int:
+        if isinstance(v, bool) or not isinstance(v, int):
+            raise ValueError("must be the integer 1")
+        if v not in SUPPORTED_VERSIONS:
+            supported = ", ".join(str(s) for s in SUPPORTED_VERSIONS)
+            raise ValueError(f"unsupported schema version {v!r}; supported versions: {supported}")
+        return v
+
+    @field_validator("backend")
+    @classmethod
+    def _check_backend(cls, v: str) -> str:
+        if v not in backends.KNOWN_BACKENDS:
+            valid = ", ".join(sorted(backends.KNOWN_BACKENDS))
+            raise ValueError(f"unknown backend {v!r}; must be one of {valid}")
+        return v
+
+    @field_validator("secrets", mode="before")
+    @classmethod
+    def _check_secrets(cls, v: Any) -> dict[str, str]:
+        return _validate_secrets(v)
+
+    @field_validator("settings", mode="before")
+    @classmethod
+    def _check_settings(cls, v: Any) -> dict[str, Any]:
+        return _validate_settings(v)
+
+    @model_validator(mode="after")
+    def _check_profile_backend_combination(self) -> RootConfig:
+        allowed = backends.ALLOWED_PROFILES.get(self.backend, frozenset())
+        if self.deployment.profile not in allowed:
+            allowed_text = ", ".join(sorted(allowed)) or "(none)"
+            raise ValueError(
+                f"deployment profile {self.deployment.profile!r} is not supported by backend "
+                f"{self.backend!r}; allowed profiles for {self.backend!r}: {allowed_text}"
+            )
+        return self

--- a/shifter/installation/schema.py
+++ b/shifter/installation/schema.py
@@ -84,6 +84,39 @@ def _validate_domain(value: str) -> str:
     return value
 
 
+def _validate_secret_entry(key: str, raw_value: Any) -> tuple[str | None, str | None]:
+    """Validate one ``secrets`` mapping entry.
+
+    Returns ``(reference, None)`` for a usable entry, or ``(None, problem)`` describing
+    what is wrong. The schema treats ``secrets`` values as opaque references and only
+    rejects ones that are *clearly* raw key material; see :data:`_MAX_SECRET_REFERENCE_LEN`.
+    """
+    if not _SECRET_NAME_RE.match(key):
+        return None, f"secret name {key!r} must match ^[a-z][a-z0-9_]*$"
+    if not isinstance(raw_value, str):
+        return None, f"secret reference for {key!r} must be a string"
+    ref: str = raw_value
+    if ref != ref.strip() or not ref.strip():
+        return None, f"secret reference for {key!r} must be a non-empty string with no surrounding whitespace"
+    if any(ch in ref for ch in "\r\n\t"):
+        return None, (
+            f"secret reference for {key!r} must be a single line; the root config holds a reference "
+            "(a provider secret name, a GitHub Actions secret name, an env var, or 'prompt'), not the "
+            "secret value itself"
+        )
+    if ref.startswith("-----BEGIN"):
+        return None, (
+            f"secret reference for {key!r} looks like raw PEM key/certificate material; store the value in "
+            "a secret store and reference it by name"
+        )
+    if len(ref) > _MAX_SECRET_REFERENCE_LEN:
+        return None, (
+            f"secret reference for {key!r} is implausibly long for a reference ({len(ref)} characters, "
+            f"limit {_MAX_SECRET_REFERENCE_LEN}); the root config holds a reference, not the secret value itself"
+        )
+    return ref, None
+
+
 def _validate_secrets(value: Any) -> dict[str, str]:
     # A *present* ``secrets:`` key must be a mapping. An explicit YAML null (a dangling
     # ``secrets:``) is treated as a malformed block and rejected, not silently coerced
@@ -94,37 +127,11 @@ def _validate_secrets(value: Any) -> dict[str, str]:
     cleaned: dict[str, str] = {}
     for raw_key, raw_value in value.items():
         key = str(raw_key)
-        if not _SECRET_NAME_RE.match(key):
-            problems.append(f"secret name {key!r} must match ^[a-z][a-z0-9_]*$")
-            continue
-        if not isinstance(raw_value, str):
-            problems.append(f"secret reference for {key!r} must be a string")
-            continue
-        ref = raw_value
-        if ref != ref.strip() or not ref.strip():
-            problems.append(f"secret reference for {key!r} must be a non-empty string with no surrounding whitespace")
-            continue
-        if any(ch in ref for ch in "\r\n\t"):
-            problems.append(
-                f"secret reference for {key!r} must be a single line; the root config holds a reference "
-                "(a provider secret name, a GitHub Actions secret name, an env var, or 'prompt'), not the "
-                "secret value itself"
-            )
-            continue
-        if ref.startswith("-----BEGIN"):
-            problems.append(
-                f"secret reference for {key!r} looks like raw PEM key/certificate material; store the value in "
-                "a secret store and reference it by name"
-            )
-            continue
-        if len(ref) > _MAX_SECRET_REFERENCE_LEN:
-            problems.append(
-                f"secret reference for {key!r} is implausibly long for a reference ({len(ref)} characters, "
-                f"limit {_MAX_SECRET_REFERENCE_LEN}); the root config holds a reference, not the secret value "
-                "itself"
-            )
-            continue
-        cleaned[key] = ref
+        ref, problem = _validate_secret_entry(key, raw_value)
+        if problem is not None:
+            problems.append(problem)
+        elif ref is not None:
+            cleaned[key] = ref
     if problems:
         raise ValueError("; ".join(problems))
     return cleaned

--- a/shifter/installation/tests/conftest.py
+++ b/shifter/installation/tests/conftest.py
@@ -1,0 +1,74 @@
+"""Shared fixtures for the installation package tests."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+PACKAGE_ROOT = Path(__file__).resolve().parent.parent
+EXAMPLES_DIR = PACKAGE_ROOT / "examples"
+
+
+def _minimal_config() -> dict[str, Any]:
+    """The smallest valid root config, matching the architecture doc example."""
+    return {
+        "backend": "aws",
+        "deployment": {
+            "name": "shifter",
+            "domain": "shifter.example.com",
+        },
+    }
+
+
+@pytest.fixture
+def minimal_config() -> dict[str, Any]:
+    return _minimal_config()
+
+
+@pytest.fixture
+def full_config() -> dict[str, Any]:
+    return {
+        "version": 1,
+        "backend": "gcp",
+        "deployment": {
+            "name": "acme-range",
+            "domain": "range.acme.example.com",
+            "profile": "prod",
+        },
+        "secrets": {
+            "django_secret_key": "shifter/prod/django-secret-key",
+            "oidc_client_secret": "projects/acme/secrets/oidc-client-secret",
+        },
+        "settings": {
+            "region": "us-central1",
+            "project_id": "acme-shifter",
+        },
+    }
+
+
+@pytest.fixture
+def examples_dir() -> Path:
+    return EXAMPLES_DIR
+
+
+@pytest.fixture
+def write_config(tmp_path: Path) -> Callable[..., Path]:
+    """Return a factory that serialises a mapping to ``shifter.yaml`` under tmp_path.
+
+    Pass ``raw=<str>`` to write arbitrary file content instead of YAML-dumping a mapping
+    (used to exercise the YAML-parse error path).
+    """
+
+    def _write(data: Any | None = None, *, name: str = "shifter.yaml", raw: str | None = None) -> Path:
+        path = tmp_path / name
+        if raw is not None:
+            path.write_text(raw, encoding="utf-8")
+        else:
+            path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+        return path
+
+    return _write

--- a/shifter/installation/tests/test_cli.py
+++ b/shifter/installation/tests/test_cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import subprocess
 import sys
 
+import pytest
 import yaml
 
 from installation.cli import main
@@ -64,8 +65,13 @@ class TestArgParsing:
         assert rc != 0
 
 
+@pytest.mark.integration
 class TestModuleEntrypoint:
-    """``python -m installation`` is the documented entry point — exercise it end to end."""
+    """``python -m installation`` is the documented entry point — exercise it end to end.
+
+    Marked ``integration`` because it spawns a subprocess (the test interpreter) rather
+    than calling ``cli.main`` in process.
+    """
 
     def test_python_m_installation_validates_an_example(self, examples_dir):
         example = examples_dir / "aws.yaml"

--- a/shifter/installation/tests/test_cli.py
+++ b/shifter/installation/tests/test_cli.py
@@ -1,0 +1,89 @@
+"""Tests for the ``shifter-config`` CLI (``installation.cli``)."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import yaml
+
+from installation.cli import main
+
+
+def _write_yaml(path, data):
+    path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+
+
+class TestValidateCommand:
+    def test_valid_file_exits_zero_and_reports_ok(self, tmp_path, capsys, minimal_config):
+        cfg_path = tmp_path / "shifter.yaml"
+        _write_yaml(cfg_path, minimal_config)
+        rc = main(["validate", str(cfg_path)])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "OK" in out
+        assert "aws" in out
+
+    def test_invalid_file_exits_nonzero_and_reports_issues_on_stderr(self, tmp_path, capsys):
+        cfg_path = tmp_path / "shifter.yaml"
+        _write_yaml(cfg_path, {"backend": "azure", "deployment": {"name": "Bad Name", "domain": "localhost"}})
+        rc = main(["validate", str(cfg_path)])
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert "backend" in captured.err
+        assert "deployment.name" in captured.err
+
+    def test_missing_file_exits_nonzero(self, tmp_path, capsys):
+        rc = main(["validate", str(tmp_path / "does-not-exist.yaml")])
+        assert rc == 1
+        assert "does-not-exist.yaml" in capsys.readouterr().err
+
+    def test_default_path_is_shifter_yaml_in_cwd(self, tmp_path, monkeypatch, capsys, minimal_config):
+        _write_yaml(tmp_path / "shifter.yaml", minimal_config)
+        monkeypatch.chdir(tmp_path)
+        assert main(["validate"]) == 0
+        assert "shifter.yaml" in capsys.readouterr().out
+
+    def test_default_path_missing_exits_nonzero(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.chdir(tmp_path)
+        assert main(["validate"]) == 1
+        assert "shifter.yaml" in capsys.readouterr().err
+
+
+class TestArgParsing:
+    def test_no_command_exits_nonzero(self, capsys):
+        rc = main([])
+        assert rc != 0
+
+    def test_unknown_command_exits_nonzero(self, capsys):
+        # argparse exits with SystemExit(2) for an unknown subcommand.
+        try:
+            rc = main(["frobnicate"])
+        except SystemExit as exc:
+            rc = exc.code
+        assert rc != 0
+
+
+class TestModuleEntrypoint:
+    """``python -m installation`` is the documented entry point — exercise it end to end."""
+
+    def test_python_m_installation_validates_an_example(self, examples_dir):
+        example = examples_dir / "aws.yaml"
+        result = subprocess.run(
+            [sys.executable, "-m", "installation", "validate", str(example)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "OK" in result.stdout
+
+    def test_python_m_installation_fails_on_missing_file(self, tmp_path):
+        result = subprocess.run(
+            [sys.executable, "-m", "installation", "validate", str(tmp_path / "nope.yaml")],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 1
+        assert "nope.yaml" in result.stderr

--- a/shifter/installation/tests/test_errors.py
+++ b/shifter/installation/tests/test_errors.py
@@ -1,0 +1,41 @@
+"""Tests for the installation error model (``installation.errors``)."""
+
+from __future__ import annotations
+
+from installation import ConfigIssue, InstallationConfigError
+
+
+class TestConfigIssue:
+    def test_render_without_hint(self):
+        assert ConfigIssue("deployment.domain", "must be lowercase").render() == "deployment.domain: must be lowercase"
+
+    def test_render_with_hint(self):
+        rendered = ConfigIssue("shifter.yaml", "not found", "copy an example").render()
+        assert "shifter.yaml: not found" in rendered
+        assert "copy an example" in rendered
+
+
+class TestInstallationConfigError:
+    def test_exposes_issues(self):
+        issues = [ConfigIssue("backend", "unknown backend 'azure'")]
+        exc = InstallationConfigError(issues)
+        assert exc.issues == issues
+        # The constructor stores a copy, not the caller's list.
+        issues.append(ConfigIssue("x", "y"))
+        assert len(exc.issues) == 1
+
+    def test_str_lists_each_issue(self):
+        exc = InstallationConfigError(
+            [ConfigIssue("backend", "unknown backend 'azure'"), ConfigIssue("deployment.domain", "must be lowercase")]
+        )
+        text = str(exc)
+        assert "2 problems" in text
+        assert "backend: unknown backend 'azure'" in text
+        assert "deployment.domain: must be lowercase" in text
+
+    def test_str_single_problem_is_singular(self):
+        assert "1 problem" in str(InstallationConfigError([ConfigIssue("backend", "bad")]))
+        assert "1 problems" not in str(InstallationConfigError([ConfigIssue("backend", "bad")]))
+
+    def test_str_with_no_issues_is_still_meaningful(self):
+        assert str(InstallationConfigError([])) == "invalid root installation config"

--- a/shifter/installation/tests/test_examples.py
+++ b/shifter/installation/tests/test_examples.py
@@ -1,0 +1,36 @@
+"""The shipped examples must validate against the same parser the rest of the system uses."""
+
+from __future__ import annotations
+
+import pytest
+
+from installation.loader import load_root_config
+
+
+def _example_files(examples_dir):
+    return sorted(examples_dir.glob("*.yaml"))
+
+
+def test_examples_directory_is_not_empty(examples_dir):
+    assert _example_files(examples_dir), "expected at least one example root config"
+
+
+def test_examples_cover_the_known_backends(examples_dir):
+    from installation import KNOWN_BACKENDS
+
+    stems = {p.stem for p in _example_files(examples_dir)}
+    # Every backend the schema accepts today ships a worked example.
+    assert stems >= KNOWN_BACKENDS
+
+
+def test_each_example_parses_and_matches_its_filename(examples_dir):
+    files = _example_files(examples_dir)
+    assert files
+    for path in files:
+        cfg = load_root_config(path)
+        assert cfg.backend == path.stem, f"{path.name}: backend should be {path.stem!r}, got {cfg.backend!r}"
+
+
+@pytest.mark.parametrize("example_name", ["aws.yaml", "gcp.yaml"])
+def test_required_examples_exist(examples_dir, example_name):
+    assert (examples_dir / example_name).is_file()

--- a/shifter/installation/tests/test_loader.py
+++ b/shifter/installation/tests/test_loader.py
@@ -1,0 +1,125 @@
+"""Tests for ``installation.loader`` — file loading and fail-fast validation."""
+
+from __future__ import annotations
+
+import pytest
+
+from installation import ConfigIssue, InstallationConfigError
+from installation.loader import load_root_config, validate_root_config_file
+from installation.schema import RootConfig
+
+
+class TestLoadRootConfig:
+    def test_valid_file_returns_root_config(self, write_config, minimal_config):
+        cfg = load_root_config(write_config(minimal_config))
+        assert isinstance(cfg, RootConfig)
+        assert cfg.backend == "aws"
+
+    def test_accepts_str_path(self, write_config, minimal_config):
+        cfg = load_root_config(str(write_config(minimal_config)))
+        assert cfg.backend == "aws"
+
+    def test_missing_file_raises(self, tmp_path):
+        with pytest.raises(InstallationConfigError) as exc:
+            load_root_config(tmp_path / "shifter.yaml")
+        assert exc.value.issues
+        assert "shifter.yaml" in str(exc.value)
+
+    def test_invalid_yaml_raises(self, write_config):
+        with pytest.raises(InstallationConfigError) as exc:
+            load_root_config(write_config(raw="backend: [unterminated\n"))
+        assert exc.value.issues
+        assert "yaml" in str(exc.value).lower()
+
+    @pytest.mark.parametrize("raw", ["- a\n- b\n", "just a string\n", ""])
+    def test_non_mapping_top_level_raises(self, write_config, raw):
+        with pytest.raises(InstallationConfigError) as exc:
+            load_root_config(write_config(raw=raw))
+        assert "mapping" in str(exc.value).lower()
+
+    def test_duplicate_top_level_key_raises(self, write_config):
+        raw = "backend: aws\ndeployment:\n  name: shifter\n  domain: shifter.example.com\nbackend: gcp\n"
+        with pytest.raises(InstallationConfigError) as exc:
+            load_root_config(write_config(raw=raw))
+        rendered = str(exc.value).lower()
+        assert "duplicate" in rendered and "backend" in rendered
+
+    def test_duplicate_nested_key_raises(self, write_config):
+        raw = "backend: aws\ndeployment:\n  name: shifter\n  name: other\n  domain: shifter.example.com\n"
+        with pytest.raises(InstallationConfigError) as exc:
+            load_root_config(write_config(raw=raw))
+        assert "duplicate" in str(exc.value).lower()
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            # Inline merge key.
+            "backend: aws\ndeployment:\n  <<: {name: shifter, domain: shifter.example.com}\n  name: other\n",
+            # Merge key via an anchor/alias — this is the case that would otherwise let a
+            # "merged" key and an explicit key of the same name coexist undetected.
+            (
+                "anchored: &base\n  name: shifter\n  domain: shifter.example.com\n"
+                "backend: aws\ndeployment:\n  <<: *base\n  name: other\n"
+            ),
+        ],
+    )
+    def test_yaml_merge_keys_rejected(self, write_config, raw):
+        with pytest.raises(InstallationConfigError) as exc:
+            load_root_config(write_config(raw=raw))
+        assert "merge" in str(exc.value).lower()
+
+    def test_recursive_alias_graph_does_not_recurse_forever(self, write_config):
+        # A self-referential alias graph must not blow the stack while scanning for
+        # duplicate keys; it surfaces as a normal validation failure instead.
+        with pytest.raises(InstallationConfigError):
+            load_root_config(write_config(raw="backend: &a\n  x: *a\n"))
+
+    def test_aggregates_all_problems(self, write_config):
+        bad = {"backend": "azure", "deployment": {"name": "Bad Name", "domain": "localhost"}}
+        with pytest.raises(InstallationConfigError) as exc:
+            load_root_config(write_config(bad))
+        paths = {issue.path for issue in exc.value.issues}
+        assert "backend" in paths
+        assert "deployment.name" in paths
+        assert "deployment.domain" in paths
+
+    @pytest.mark.parametrize(
+        "raw_value",
+        [
+            "SUPERSECRETMARKER\nMORE SECRET DATA ON A SECOND LINE",  # pasted multi-line key body
+            "SUPERSECRETMARKER-" + "ab12" * 300,  # implausibly long for a reference
+        ],
+    )
+    def test_error_message_does_not_leak_raw_secret_values(self, write_config, raw_value):
+        # A user who pastes a raw secret into the config gets a validation error,
+        # and the error surface (exception message and every ConfigIssue) must not
+        # echo the raw value back.
+        bad = {
+            "backend": "aws",
+            "deployment": {"name": "shifter", "domain": "shifter.example.com"},
+            "secrets": {"db_password": raw_value},
+        }
+        with pytest.raises(InstallationConfigError) as exc:
+            load_root_config(write_config(bad))
+        rendered = str(exc.value)
+        assert raw_value not in rendered
+        assert "SUPERSECRETMARKER" not in rendered
+        for issue in exc.value.issues:
+            assert raw_value not in issue.message
+            assert raw_value not in issue.path
+            assert "SUPERSECRETMARKER" not in issue.message
+
+
+class TestValidateRootConfigFile:
+    def test_valid_file_returns_empty_list(self, write_config, minimal_config):
+        assert validate_root_config_file(write_config(minimal_config)) == []
+
+    def test_invalid_file_returns_issue_list_without_raising(self, write_config):
+        issues = validate_root_config_file(write_config({"deployment": {"name": "x"}}))
+        assert issues
+        assert all(isinstance(i, ConfigIssue) for i in issues)
+
+    def test_missing_file_returns_issue_list_without_raising(self, tmp_path):
+        issues = validate_root_config_file(tmp_path / "shifter.yaml")
+        assert issues
+        assert all(isinstance(i, ConfigIssue) for i in issues)

--- a/shifter/installation/tests/test_schema.py
+++ b/shifter/installation/tests/test_schema.py
@@ -1,0 +1,304 @@
+"""Tests for the root installation config schema (``installation.schema``)."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from installation import ALLOWED_PROFILES, KNOWN_BACKENDS, KNOWN_PROFILES
+from installation.schema import RootConfig
+
+
+def _locs(exc: ValidationError) -> set[tuple[object, ...]]:
+    return {err["loc"] for err in exc.errors()}
+
+
+def _with_deployment(minimal_config: dict, **overrides: object) -> dict:
+    """Return ``minimal_config`` with ``deployment`` keys overridden/added."""
+    return {**minimal_config, "deployment": {**minimal_config["deployment"], **overrides}}
+
+
+# Built from fragments at runtime so the ``detect-private-key`` pre-commit hook does
+# not flag this test file for containing a PEM private-key header literal.
+_RAW_KEY_MATERIAL_HEADER = "-----BEGIN " + "RSA PRIVATE" + " KEY-----"
+
+
+class TestDefaultsAndShape:
+    def test_minimal_config_parses_with_defaults(self, minimal_config):
+        cfg = RootConfig.model_validate(minimal_config)
+        assert cfg.backend == "aws"
+        assert cfg.deployment.name == "shifter"
+        assert cfg.deployment.domain == "shifter.example.com"
+        # Defaults applied for everything the user did not set.
+        assert cfg.version == 1
+        assert cfg.deployment.profile == "prod"
+        assert cfg.secrets == {}
+        assert cfg.settings == {}
+
+    def test_full_config_parses(self, full_config):
+        cfg = RootConfig.model_validate(full_config)
+        assert cfg.backend == "gcp"
+        assert cfg.deployment.profile == "prod"
+        assert cfg.secrets["django_secret_key"] == "shifter/prod/django-secret-key"
+        assert cfg.settings["region"] == "us-central1"
+
+    def test_root_models_exactly_one_standalone_deployment(self):
+        # GEN-2001: the root contract has no fleet / install-registry / parent-child
+        # / tenant-mapping shape. Pin the field set so cross-install concepts cannot
+        # be added without an explicit schema change.
+        assert set(RootConfig.model_fields) == {"version", "backend", "deployment", "secrets", "settings"}
+
+    @pytest.mark.parametrize("orchestration_key", ["fleet", "installs", "tenants", "parent", "clusters"])
+    def test_cross_install_orchestration_keys_rejected(self, minimal_config, orchestration_key):
+        # GEN-2001: orchestration-shaped keys are rejected by extra="forbid".
+        bad = {**minimal_config, orchestration_key: ["other-install"]}
+        with pytest.raises(ValidationError) as exc:
+            RootConfig.model_validate(bad)
+        assert any(orchestration_key in err["loc"] for err in exc.value.errors())
+
+
+class TestRequiredFields:
+    @pytest.mark.parametrize(
+        "drop_path, expected_loc",
+        [
+            (("backend",), ("backend",)),
+            (("deployment",), ("deployment",)),
+            (("deployment", "name"), ("deployment", "name")),
+            (("deployment", "domain"), ("deployment", "domain")),
+        ],
+    )
+    def test_missing_required_field(self, minimal_config, drop_path, expected_loc):
+        data = {k: dict(v) if isinstance(v, dict) else v for k, v in minimal_config.items()}
+        target = data
+        for key in drop_path[:-1]:
+            target = target[key]
+        del target[drop_path[-1]]
+        with pytest.raises(ValidationError) as exc:
+            RootConfig.model_validate(data)
+        assert expected_loc in _locs(exc.value)
+
+
+class TestUnknownKeys:
+    def test_unknown_top_level_key_rejected(self, minimal_config):
+        with pytest.raises(ValidationError) as exc:
+            RootConfig.model_validate({**minimal_config, "frontend": "react"})
+        assert ("frontend",) in _locs(exc.value)
+
+    def test_unknown_deployment_key_rejected(self, minimal_config):
+        with pytest.raises(ValidationError) as exc:
+            RootConfig.model_validate(_with_deployment(minimal_config, region="us-east-2"))
+        assert ("deployment", "region") in _locs(exc.value)
+
+
+class TestBackend:
+    def test_known_backends_nonempty(self):
+        assert KNOWN_BACKENDS
+        assert "aws" in KNOWN_BACKENDS
+        assert "gcp" in KNOWN_BACKENDS
+
+    def test_registry_is_the_single_source_of_truth(self):
+        # ALLOWED_PROFILES is authoritative; the other sets are derived from it, so a
+        # future backend or profile only needs to be added in one place.
+        assert frozenset(ALLOWED_PROFILES) == KNOWN_BACKENDS
+        assert frozenset().union(*ALLOWED_PROFILES.values()) == KNOWN_PROFILES
+
+    @pytest.mark.parametrize("backend", ["azure", "k8s", "", "AWS", "local"])
+    def test_unknown_backend_rejected_and_message_lists_valid_backends(self, minimal_config, backend):
+        with pytest.raises(ValidationError) as exc:
+            RootConfig.model_validate({**minimal_config, "backend": backend})
+        assert ("backend",) in _locs(exc.value)
+        # The error names the supported backends so the user can fix it.
+        rendered = str(exc.value)
+        for known in KNOWN_BACKENDS:
+            assert known in rendered
+
+    def test_backend_must_be_string(self, minimal_config):
+        with pytest.raises(ValidationError):
+            RootConfig.model_validate({**minimal_config, "backend": ["aws"]})
+
+
+class TestDeploymentName:
+    @pytest.mark.parametrize("name", ["shifter", "acme-range", "r", "shifter-prod-01"])
+    def test_valid_names(self, minimal_config, name):
+        cfg = RootConfig.model_validate(_with_deployment(minimal_config, name=name))
+        assert cfg.deployment.name == name
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "",  # empty
+            "Shifter",  # uppercase
+            "-shifter",  # leading hyphen
+            "shifter-",  # trailing hyphen
+            "shifter range",  # space
+            "shifter_range",  # underscore
+            "x" * 41,  # too long
+        ],
+    )
+    def test_invalid_names_rejected(self, minimal_config, name):
+        with pytest.raises(ValidationError) as exc:
+            RootConfig.model_validate(_with_deployment(minimal_config, name=name))
+        assert ("deployment", "name") in _locs(exc.value)
+
+
+class TestDeploymentDomain:
+    @pytest.mark.parametrize("domain", ["shifter.example.com", "range.acme.example.com", "shifter.io"])
+    def test_valid_domains(self, minimal_config, domain):
+        cfg = RootConfig.model_validate(_with_deployment(minimal_config, domain=domain))
+        assert cfg.deployment.domain == domain
+
+    @pytest.mark.parametrize(
+        "domain",
+        [
+            "",  # empty
+            "localhost",  # bare localhost
+            "shifter",  # single label
+            "10.0.0.1",  # IPv4 literal
+            "::1",  # IPv6 literal
+            "10.0",  # numeric, not a public hostname
+            "shifter.123",  # all-numeric TLD
+            "shifter.x",  # one-character TLD
+            "shifter..com",  # empty label
+            "-bad.example.com",  # label starts with hyphen
+            "shifter.example.com.",  # trailing dot
+            "http://shifter.example.com",  # scheme included
+            "x" * 254 + ".com",  # too long overall
+        ],
+    )
+    def test_invalid_domains_rejected(self, minimal_config, domain):
+        with pytest.raises(ValidationError) as exc:
+            RootConfig.model_validate(_with_deployment(minimal_config, domain=domain))
+        assert ("deployment", "domain") in _locs(exc.value)
+
+
+class TestProfile:
+    @pytest.mark.parametrize("profile", ["prod", "dev"])
+    def test_valid_profiles(self, minimal_config, profile):
+        cfg = RootConfig.model_validate(_with_deployment(minimal_config, profile=profile))
+        assert cfg.deployment.profile == profile
+
+    @pytest.mark.parametrize("profile", ["staging", "production", "PROD", ""])
+    def test_invalid_profile_rejected(self, minimal_config, profile):
+        with pytest.raises(ValidationError) as exc:
+            RootConfig.model_validate(_with_deployment(minimal_config, profile=profile))
+        assert ("deployment", "profile") in _locs(exc.value)
+
+    def test_profile_not_allowed_for_backend_rejected(self, monkeypatch, minimal_config):
+        # Cross-field: an otherwise-valid profile that the selected backend does not
+        # allow must fail (the "unsupported profile/backend combination" case).
+        from installation import backends as backends_mod
+
+        monkeypatch.setattr(
+            backends_mod, "ALLOWED_PROFILES", {"aws": frozenset({"prod"}), "gcp": frozenset({"prod", "dev"})}
+        )
+        bad = {**_with_deployment(minimal_config, profile="dev"), "backend": "aws"}
+        with pytest.raises(ValidationError) as exc:
+            RootConfig.model_validate(bad)
+        rendered = str(exc.value)
+        assert "dev" in rendered and "aws" in rendered
+
+
+class TestVersion:
+    def test_default_version_is_one(self, minimal_config):
+        assert RootConfig.model_validate(minimal_config).version == 1
+
+    @pytest.mark.parametrize("version", [0, 2, 99, "1", 1.0])
+    def test_unsupported_version_rejected(self, minimal_config, version):
+        with pytest.raises(ValidationError) as exc:
+            RootConfig.model_validate({**minimal_config, "version": version})
+        assert ("version",) in _locs(exc.value)
+
+
+class TestSecrets:
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "shifter/prod/django-secret-key",
+            "projects/acme/secrets/db-password/versions/latest",
+            "prompt",
+            "arn:aws:secretsmanager:us-east-2:123456789012:secret:shifter/prod/db-password-AbCdEf",
+            "GH_SHIFTER_DJANGO_SECRET_KEY",
+            "x" * 512,  # long, but still a plausible provider secret name
+        ],
+    )
+    def test_valid_secret_references(self, minimal_config, value):
+        cfg = RootConfig.model_validate({**minimal_config, "secrets": {"some_key": value}})
+        assert cfg.secrets["some_key"] == value
+
+    def test_multiple_valid_secret_references(self, minimal_config):
+        cfg = RootConfig.model_validate(
+            {
+                **minimal_config,
+                "secrets": {
+                    "django_secret_key": "shifter/prod/django-secret-key",
+                    "db_password": "projects/acme/secrets/db-password/versions/latest",
+                    "oidc": "prompt",
+                },
+            }
+        )
+        assert cfg.secrets["oidc"] == "prompt"
+
+    @pytest.mark.parametrize("value", [["a", "b"], "us-east-2", 5, None])
+    def test_non_mapping_secrets_rejected(self, minimal_config, value):
+        # A present-but-non-mapping ``secrets:`` (including an explicit YAML null) is a
+        # malformed block, not an empty default — omit the key to get ``{}``.
+        with pytest.raises(ValidationError) as exc:
+            RootConfig.model_validate({**minimal_config, "secrets": value})
+        assert ("secrets",) in _locs(exc.value)
+
+    def test_omitted_secrets_defaults_to_empty(self, minimal_config):
+        assert RootConfig.model_validate(minimal_config).secrets == {}
+
+    @pytest.mark.parametrize("key", ["Django", "1secret", "db-password", "", "db password"])
+    def test_invalid_secret_key_rejected(self, minimal_config, key):
+        with pytest.raises(ValidationError):
+            RootConfig.model_validate({**minimal_config, "secrets": {key: "ref"}})
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "",  # empty
+            "   ",  # whitespace only
+            "ref with\nnewline",  # multi-line
+            "x" * 1025,  # implausibly long for a reference
+            _RAW_KEY_MATERIAL_HEADER,  # looks like a pasted PEM private key
+            "-----BEGIN CERTIFICATE-----",  # looks like pasted PEM cert material
+        ],
+    )
+    def test_invalid_secret_value_rejected(self, minimal_config, value):
+        with pytest.raises(ValidationError):
+            RootConfig.model_validate({**minimal_config, "secrets": {"k": value}})
+
+    def test_non_string_secret_value_rejected(self, minimal_config):
+        with pytest.raises(ValidationError):
+            RootConfig.model_validate({**minimal_config, "secrets": {"k": 1234}})
+
+
+class TestSettings:
+    def test_settings_opaque_mapping_accepted(self, minimal_config):
+        cfg = RootConfig.model_validate(
+            {**minimal_config, "settings": {"region": "us-east-2", "nested": {"a": 1}, "list": [1, 2]}}
+        )
+        assert cfg.settings["region"] == "us-east-2"
+        assert cfg.settings["nested"] == {"a": 1}
+
+    @pytest.mark.parametrize("value", [["a"], "us-east-2", 5, None])
+    def test_non_mapping_settings_rejected(self, minimal_config, value):
+        # A present-but-non-mapping ``settings:`` (including an explicit YAML null) is a
+        # malformed block, not an empty default — omit the key to get ``{}``.
+        with pytest.raises(ValidationError) as exc:
+            RootConfig.model_validate({**minimal_config, "settings": value})
+        assert ("settings",) in _locs(exc.value)
+
+    def test_omitted_settings_defaults_to_empty(self, minimal_config):
+        assert RootConfig.model_validate(minimal_config).settings == {}
+
+
+class TestAggregatedErrors:
+    def test_multiple_problems_reported_together(self):
+        with pytest.raises(ValidationError) as exc:
+            RootConfig.model_validate({"backend": "azure", "deployment": {"name": "Bad Name", "domain": "localhost"}})
+        locs = _locs(exc.value)
+        assert ("backend",) in locs
+        assert ("deployment", "name") in locs
+        assert ("deployment", "domain") in locs

--- a/shifter/installation/uv.lock
+++ b/shifter/installation/uv.lock
@@ -1,0 +1,453 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "bandit"
+version = "1.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "stevedore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c3/0cb80dfe0f3076e5da7e4c5ad8e57bac6ac357ff4a6406205501cade4965/bandit-1.9.4.tar.gz", hash = "sha256:b589e5de2afe70bd4d53fa0c1da6199f4085af666fde00e8a034f152a52cd628", size = 4242677, upload-time = "2026-02-25T06:44:15.503Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/a4/a26d5b25671d27e03afb5401a0be5899d94ff8fab6a698b1ac5be3ec29ef/bandit-1.9.4-py3-none-any.whl", hash = "sha256:f89ffa663767f5a0585ea075f01020207e966a9c0f2b9ef56a57c7963a3f6f8e", size = 134741, upload-time = "2026-02-25T06:44:13.694Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.13.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/e0/70553e3000e345daff267cec284ce4cbf3fc141b6da229ac52775b5428f1/coverage-7.13.5.tar.gz", hash = "sha256:c81f6515c4c40141f83f502b07bbfa5c240ba25bbe73da7b33f1e5b6120ff179", size = 915967, upload-time = "2026-03-17T10:33:18.341Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c3/a396306ba7db865bf96fc1fb3b7fd29bcbf3d829df642e77b13555163cd6/coverage-7.13.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:460cf0114c5016fa841214ff5564aa4864f11948da9440bc97e21ad1f4ba1e01", size = 219554, upload-time = "2026-03-17T10:30:42.208Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/16/a68a19e5384e93f811dccc51034b1fd0b865841c390e3c931dcc4699e035/coverage-7.13.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e223ce4b4ed47f065bfb123687686512e37629be25cc63728557ae7db261422", size = 219908, upload-time = "2026-03-17T10:30:43.906Z" },
+    { url = "https://files.pythonhosted.org/packages/29/72/20b917c6793af3a5ceb7fb9c50033f3ec7865f2911a1416b34a7cfa0813b/coverage-7.13.5-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:6e3370441f4513c6252bf042b9c36d22491142385049243253c7e48398a15a9f", size = 251419, upload-time = "2026-03-17T10:30:45.545Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/49/cd14b789536ac6a4778c453c6a2338bc0a2fb60c5a5a41b4008328b9acc1/coverage-7.13.5-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:03ccc709a17a1de074fb1d11f217342fb0d2b1582ed544f554fc9fc3f07e95f5", size = 254159, upload-time = "2026-03-17T10:30:47.204Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/00/7b0edcfe64e2ed4c0340dac14a52ad0f4c9bd0b8b5e531af7d55b703db7c/coverage-7.13.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3f4818d065964db3c1c66dc0fbdac5ac692ecbc875555e13374fdbe7eedb4376", size = 255270, upload-time = "2026-03-17T10:30:48.812Z" },
+    { url = "https://files.pythonhosted.org/packages/93/89/7ffc4ba0f5d0a55c1e84ea7cee39c9fc06af7b170513d83fbf3bbefce280/coverage-7.13.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:012d5319e66e9d5a218834642d6c35d265515a62f01157a45bcc036ecf947256", size = 257538, upload-time = "2026-03-17T10:30:50.77Z" },
+    { url = "https://files.pythonhosted.org/packages/81/bd/73ddf85f93f7e6fa83e77ccecb6162d9415c79007b4bc124008a4995e4a7/coverage-7.13.5-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8dd02af98971bdb956363e4827d34425cb3df19ee550ef92855b0acb9c7ce51c", size = 251821, upload-time = "2026-03-17T10:30:52.5Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/81/278aff4e8dec4926a0bcb9486320752811f543a3ce5b602cc7a29978d073/coverage-7.13.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f08fd75c50a760c7eb068ae823777268daaf16a80b918fa58eea888f8e3919f5", size = 253191, upload-time = "2026-03-17T10:30:54.543Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ee/fe1621488e2e0a58d7e94c4800f0d96f79671553488d401a612bebae324b/coverage-7.13.5-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:843ea8643cf967d1ac7e8ecd4bb00c99135adf4816c0c0593fdcc47b597fcf09", size = 251337, upload-time = "2026-03-17T10:30:56.663Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a6/f79fb37aa104b562207cc23cb5711ab6793608e246cae1e93f26b2236ed9/coverage-7.13.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:9d44d7aa963820b1b971dbecd90bfe5fe8f81cff79787eb6cca15750bd2f79b9", size = 255404, upload-time = "2026-03-17T10:30:58.427Z" },
+    { url = "https://files.pythonhosted.org/packages/75/f0/ed15262a58ec81ce457ceb717b7f78752a1713556b19081b76e90896e8d4/coverage-7.13.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7132bed4bd7b836200c591410ae7d97bf7ae8be6fc87d160b2bd881df929e7bf", size = 250903, upload-time = "2026-03-17T10:31:00.093Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/e9/9129958f20e7e9d4d56d51d42ccf708d15cac355ff4ac6e736e97a9393d2/coverage-7.13.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a698e363641b98843c517817db75373c83254781426e94ada3197cabbc2c919c", size = 252780, upload-time = "2026-03-17T10:31:01.916Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/d7/0ad9b15812d81272db94379fe4c6df8fd17781cc7671fdfa30c76ba5ff7b/coverage-7.13.5-cp312-cp312-win32.whl", hash = "sha256:bdba0a6b8812e8c7df002d908a9a2ea3c36e92611b5708633c50869e6d922fdf", size = 222093, upload-time = "2026-03-17T10:31:03.642Z" },
+    { url = "https://files.pythonhosted.org/packages/29/3d/821a9a5799fac2556bcf0bd37a70d1d11fa9e49784b6d22e92e8b2f85f18/coverage-7.13.5-cp312-cp312-win_amd64.whl", hash = "sha256:d2c87e0c473a10bffe991502eac389220533024c8082ec1ce849f4218dded810", size = 222900, upload-time = "2026-03-17T10:31:05.651Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/fa/2238c2ad08e35cf4f020ea721f717e09ec3152aea75d191a7faf3ef009a8/coverage-7.13.5-cp312-cp312-win_arm64.whl", hash = "sha256:bf69236a9a81bdca3bff53796237aab096cdbf8d78a66ad61e992d9dac7eb2de", size = 221515, upload-time = "2026-03-17T10:31:07.293Z" },
+    { url = "https://files.pythonhosted.org/packages/74/8c/74fedc9663dcf168b0a059d4ea756ecae4da77a489048f94b5f512a8d0b3/coverage-7.13.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5ec4af212df513e399cf11610cc27063f1586419e814755ab362e50a85ea69c1", size = 219576, upload-time = "2026-03-17T10:31:09.045Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/c9/44fb661c55062f0818a6ffd2685c67aa30816200d5f2817543717d4b92eb/coverage-7.13.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:941617e518602e2d64942c88ec8499f7fbd49d3f6c4327d3a71d43a1973032f3", size = 219942, upload-time = "2026-03-17T10:31:10.708Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/13/93419671cee82b780bab7ea96b67c8ef448f5f295f36bf5031154ec9a790/coverage-7.13.5-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:da305e9937617ee95c2e39d8ff9f040e0487cbf1ac174f777ed5eddd7a7c1f26", size = 250935, upload-time = "2026-03-17T10:31:12.392Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/68/1666e3a4462f8202d836920114fa7a5ee9275d1fa45366d336c551a162dd/coverage-7.13.5-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:78e696e1cc714e57e8b25760b33a8b1026b7048d270140d25dafe1b0a1ee05a3", size = 253541, upload-time = "2026-03-17T10:31:14.247Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/5e/3ee3b835647be646dcf3c65a7c6c18f87c27326a858f72ab22c12730773d/coverage-7.13.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:02ca0eed225b2ff301c474aeeeae27d26e2537942aa0f87491d3e147e784a82b", size = 254780, upload-time = "2026-03-17T10:31:16.193Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b3/cb5bd1a04cfcc49ede6cd8409d80bee17661167686741e041abc7ee1b9a9/coverage-7.13.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:04690832cbea4e4663d9149e05dba142546ca05cb1848816760e7f58285c970a", size = 256912, upload-time = "2026-03-17T10:31:17.89Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/66/c1dceb7b9714473800b075f5c8a84f4588f887a90eb8645282031676e242/coverage-7.13.5-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0590e44dd2745c696a778f7bab6aa95256de2cbc8b8cff4f7db8ff09813d6969", size = 251165, upload-time = "2026-03-17T10:31:19.605Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/62/5502b73b97aa2e53ea22a39cf8649ff44827bef76d90bf638777daa27a9d/coverage-7.13.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d7cfad2d6d81dd298ab6b89fe72c3b7b05ec7544bdda3b707ddaecff8d25c161", size = 252908, upload-time = "2026-03-17T10:31:21.312Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/37/7792c2d69854397ca77a55c4646e5897c467928b0e27f2d235d83b5d08c6/coverage-7.13.5-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:e092b9499de38ae0fbfbc603a74660eb6ff3e869e507b50d85a13b6db9863e15", size = 250873, upload-time = "2026-03-17T10:31:23.565Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/23/bc866fb6163be52a8a9e5d708ba0d3b1283c12158cefca0a8bbb6e247a43/coverage-7.13.5-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:48c39bc4a04d983a54a705a6389512883d4a3b9862991b3617d547940e9f52b1", size = 255030, upload-time = "2026-03-17T10:31:25.58Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/8b/ef67e1c222ef49860701d346b8bbb70881bef283bd5f6cbba68a39a086c7/coverage-7.13.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:2d3807015f138ffea1ed9afeeb8624fd781703f2858b62a8dd8da5a0994c57b6", size = 250694, upload-time = "2026-03-17T10:31:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/46/0d/866d1f74f0acddbb906db212e096dee77a8e2158ca5e6bb44729f9d93298/coverage-7.13.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ee2aa19e03161671ec964004fb74b2257805d9710bf14a5c704558b9d8dbaf17", size = 252469, upload-time = "2026-03-17T10:31:29.472Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/f5/be742fec31118f02ce42b21c6af187ad6a344fed546b56ca60caacc6a9a0/coverage-7.13.5-cp313-cp313-win32.whl", hash = "sha256:ce1998c0483007608c8382f4ff50164bfc5bd07a2246dd272aa4043b75e61e85", size = 222112, upload-time = "2026-03-17T10:31:31.526Z" },
+    { url = "https://files.pythonhosted.org/packages/66/40/7732d648ab9d069a46e686043241f01206348e2bbf128daea85be4d6414b/coverage-7.13.5-cp313-cp313-win_amd64.whl", hash = "sha256:631efb83f01569670a5e866ceb80fe483e7c159fac6f167e6571522636104a0b", size = 222923, upload-time = "2026-03-17T10:31:33.633Z" },
+    { url = "https://files.pythonhosted.org/packages/48/af/fea819c12a095781f6ccd504890aaddaf88b8fab263c4940e82c7b770124/coverage-7.13.5-cp313-cp313-win_arm64.whl", hash = "sha256:f4cd16206ad171cbc2470dbea9103cf9a7607d5fe8c242fdf1edf36174020664", size = 221540, upload-time = "2026-03-17T10:31:35.445Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d2/17879af479df7fbbd44bd528a31692a48f6b25055d16482fdf5cdb633805/coverage-7.13.5-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0428cbef5783ad91fe240f673cc1f76b25e74bbfe1a13115e4aa30d3f538162d", size = 220262, upload-time = "2026-03-17T10:31:37.184Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/4c/d20e554f988c8f91d6a02c5118f9abbbf73a8768a3048cb4962230d5743f/coverage-7.13.5-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e0b216a19534b2427cc201a26c25da4a48633f29a487c61258643e89d28200c0", size = 220617, upload-time = "2026-03-17T10:31:39.245Z" },
+    { url = "https://files.pythonhosted.org/packages/29/9c/f9f5277b95184f764b24e7231e166dfdb5780a46d408a2ac665969416d61/coverage-7.13.5-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:972a9cd27894afe4bc2b1480107054e062df08e671df7c2f18c205e805ccd806", size = 261912, upload-time = "2026-03-17T10:31:41.324Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/f6/7f1ab39393eeb50cfe4747ae8ef0e4fc564b989225aa1152e13a180d74f8/coverage-7.13.5-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4b59148601efcd2bac8c4dbf1f0ad6391693ccf7a74b8205781751637076aee3", size = 263987, upload-time = "2026-03-17T10:31:43.724Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/d7/62c084fb489ed9c6fbdf57e006752e7c516ea46fd690e5ed8b8617c7d52e/coverage-7.13.5-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:505d7083c8b0c87a8fa8c07370c285847c1f77739b22e299ad75a6af6c32c5c9", size = 266416, upload-time = "2026-03-17T10:31:45.769Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f6/df63d8660e1a0bff6125947afda112a0502736f470d62ca68b288ea762d8/coverage-7.13.5-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:60365289c3741e4db327e7baff2a4aaacf22f788e80fa4683393891b70a89fbd", size = 267558, upload-time = "2026-03-17T10:31:48.293Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/02/353ca81d36779bd108f6d384425f7139ac3c58c750dcfaafe5d0bee6436b/coverage-7.13.5-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1b88c69c8ef5d4b6fe7dea66d6636056a0f6a7527c440e890cf9259011f5e606", size = 261163, upload-time = "2026-03-17T10:31:50.125Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/16/2e79106d5749bcaf3aee6d309123548e3276517cd7851faa8da213bc61bf/coverage-7.13.5-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:5b13955d31d1633cf9376908089b7cebe7d15ddad7aeaabcbe969a595a97e95e", size = 263981, upload-time = "2026-03-17T10:31:51.961Z" },
+    { url = "https://files.pythonhosted.org/packages/29/c7/c29e0c59ffa6942030ae6f50b88ae49988e7e8da06de7ecdbf49c6d4feae/coverage-7.13.5-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:f70c9ab2595c56f81a89620e22899eea8b212a4041bd728ac6f4a28bf5d3ddd0", size = 261604, upload-time = "2026-03-17T10:31:53.872Z" },
+    { url = "https://files.pythonhosted.org/packages/40/48/097cdc3db342f34006a308ab41c3a7c11c3f0d84750d340f45d88a782e00/coverage-7.13.5-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:084b84a8c63e8d6fc7e3931b316a9bcafca1458d753c539db82d31ed20091a87", size = 265321, upload-time = "2026-03-17T10:31:55.997Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/1f/4994af354689e14fd03a75f8ec85a9a68d94e0188bbdab3fc1516b55e512/coverage-7.13.5-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ad14385487393e386e2ea988b09d62dd42c397662ac2dabc3832d71253eee479", size = 260502, upload-time = "2026-03-17T10:31:58.308Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c6/9bb9ef55903e628033560885f5c31aa227e46878118b63ab15dc7ba87797/coverage-7.13.5-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:7f2c47b36fe7709a6e83bfadf4eefb90bd25fbe4014d715224c4316f808e59a2", size = 262688, upload-time = "2026-03-17T10:32:00.141Z" },
+    { url = "https://files.pythonhosted.org/packages/14/4f/f5df9007e50b15e53e01edea486814783a7f019893733d9e4d6caad75557/coverage-7.13.5-cp313-cp313t-win32.whl", hash = "sha256:67e9bc5449801fad0e5dff329499fb090ba4c5800b86805c80617b4e29809b2a", size = 222788, upload-time = "2026-03-17T10:32:02.246Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/98/aa7fccaa97d0f3192bec013c4e6fd6d294a6ed44b640e6bb61f479e00ed5/coverage-7.13.5-cp313-cp313t-win_amd64.whl", hash = "sha256:da86cdcf10d2519e10cabb8ac2de03da1bcb6e4853790b7fbd48523332e3a819", size = 223851, upload-time = "2026-03-17T10:32:04.416Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/8b/e5c469f7352651e5f013198e9e21f97510b23de957dd06a84071683b4b60/coverage-7.13.5-cp313-cp313t-win_arm64.whl", hash = "sha256:0ecf12ecb326fe2c339d93fc131816f3a7367d223db37817208905c89bded911", size = 222104, upload-time = "2026-03-17T10:32:06.65Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/77/39703f0d1d4b478bfd30191d3c14f53caf596fac00efb3f8f6ee23646439/coverage-7.13.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fbabfaceaeb587e16f7008f7795cd80d20ec548dc7f94fbb0d4ec2e038ce563f", size = 219621, upload-time = "2026-03-17T10:32:08.589Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/3e/51dff36d99ae14639a133d9b164d63e628532e2974d8b1edb99dd1ebc733/coverage-7.13.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9bb2a28101a443669a423b665939381084412b81c3f8c0fcfbac57f4e30b5b8e", size = 219953, upload-time = "2026-03-17T10:32:10.507Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6c/1f1917b01eb647c2f2adc9962bd66c79eb978951cab61bdc1acab3290c07/coverage-7.13.5-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:bd3a2fbc1c6cccb3c5106140d87cc6a8715110373ef42b63cf5aea29df8c217a", size = 250992, upload-time = "2026-03-17T10:32:12.41Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e5/06b1f88f42a5a99df42ce61208bdec3bddb3d261412874280a19796fc09c/coverage-7.13.5-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6c36ddb64ed9d7e496028d1d00dfec3e428e0aabf4006583bb1839958d280510", size = 253503, upload-time = "2026-03-17T10:32:14.449Z" },
+    { url = "https://files.pythonhosted.org/packages/80/28/2a148a51e5907e504fa7b85490277734e6771d8844ebcc48764a15e28155/coverage-7.13.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:380e8e9084d8eb38db3a9176a1a4f3c0082c3806fa0dc882d1d87abc3c789247", size = 254852, upload-time = "2026-03-17T10:32:16.56Z" },
+    { url = "https://files.pythonhosted.org/packages/61/77/50e8d3d85cc0b7ebe09f30f151d670e302c7ff4a1bf6243f71dd8b0981fa/coverage-7.13.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e808af52a0513762df4d945ea164a24b37f2f518cbe97e03deaa0ee66139b4d6", size = 257161, upload-time = "2026-03-17T10:32:19.004Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/c4/b5fd1d4b7bf8d0e75d997afd3925c59ba629fc8616f1b3aae7605132e256/coverage-7.13.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e301d30dd7e95ae068671d746ba8c34e945a82682e62918e41b2679acd2051a0", size = 251021, upload-time = "2026-03-17T10:32:21.344Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/66/6ea21f910e92d69ef0b1c3346ea5922a51bad4446c9126db2ae96ee24c4c/coverage-7.13.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:800bc829053c80d240a687ceeb927a94fd108bbdc68dfbe505d0d75ab578a882", size = 252858, upload-time = "2026-03-17T10:32:23.506Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ea/879c83cb5d61aa2a35fb80e72715e92672daef8191b84911a643f533840c/coverage-7.13.5-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:0b67af5492adb31940ee418a5a655c28e48165da5afab8c7fa6fd72a142f8740", size = 250823, upload-time = "2026-03-17T10:32:25.516Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/fb/616d95d3adb88b9803b275580bdeee8bd1b69a886d057652521f83d7322f/coverage-7.13.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:c9136ff29c3a91e25b1d1552b5308e53a1e0653a23e53b6366d7c2dcbbaf8a16", size = 255099, upload-time = "2026-03-17T10:32:27.944Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/93/25e6917c90ec1c9a56b0b26f6cad6408e5f13bb6b35d484a0d75c9cf000d/coverage-7.13.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:cff784eef7f0b8f6cb28804fbddcfa99f89efe4cc35fb5627e3ac58f91ed3ac0", size = 250638, upload-time = "2026-03-17T10:32:29.914Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/7b/dc1776b0464145a929deed214aef9fb1493f159b59ff3c7eeeedf91eddd0/coverage-7.13.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:68a4953be99b17ac3c23b6efbc8a38330d99680c9458927491d18700ef23ded0", size = 252295, upload-time = "2026-03-17T10:32:31.981Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/fb/99cbbc56a26e07762a2740713f3c8f9f3f3106e3a3dd8cc4474954bccd34/coverage-7.13.5-cp314-cp314-win32.whl", hash = "sha256:35a31f2b1578185fbe6aa2e74cea1b1d0bbf4c552774247d9160d29b80ed56cc", size = 222360, upload-time = "2026-03-17T10:32:34.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/b7/4758d4f73fb536347cc5e4ad63662f9d60ba9118cb6785e9616b2ce5d7fa/coverage-7.13.5-cp314-cp314-win_amd64.whl", hash = "sha256:2aa055ae1857258f9e0045be26a6d62bdb47a72448b62d7b55f4820f361a2633", size = 223174, upload-time = "2026-03-17T10:32:36.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/f2/24d84e1dfe70f8ac9fdf30d338239860d0d1d5da0bda528959d0ebc9da28/coverage-7.13.5-cp314-cp314-win_arm64.whl", hash = "sha256:1b11eef33edeae9d142f9b4358edb76273b3bfd30bc3df9a4f95d0e49caf94e8", size = 221739, upload-time = "2026-03-17T10:32:38.736Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5b/4a168591057b3668c2428bff25dd3ebc21b629d666d90bcdfa0217940e84/coverage-7.13.5-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:10a0c37f0b646eaff7cce1874c31d1f1ccb297688d4c747291f4f4c70741cc8b", size = 220351, upload-time = "2026-03-17T10:32:41.196Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/21/1fd5c4dbfe4a58b6b99649125635df46decdfd4a784c3cd6d410d303e370/coverage-7.13.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b5db73ba3c41c7008037fa731ad5459fc3944cb7452fc0aa9f822ad3533c583c", size = 220612, upload-time = "2026-03-17T10:32:43.204Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/fe/2a924b3055a5e7e4512655a9d4609781b0d62334fa0140c3e742926834e2/coverage-7.13.5-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:750db93a81e3e5a9831b534be7b1229df848b2e125a604fe6651e48aa070e5f9", size = 261985, upload-time = "2026-03-17T10:32:45.514Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/c8928f2bd518c45990fe1a2ab8db42e914ef9b726c975facc4282578c3eb/coverage-7.13.5-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9ddb4f4a5479f2539644be484da179b653273bca1a323947d48ab107b3ed1f29", size = 264107, upload-time = "2026-03-17T10:32:47.971Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/ae/4ae35bbd9a0af9d820362751f0766582833c211224b38665c0f8de3d487f/coverage-7.13.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d8a7a2049c14f413163e2bdabd37e41179b1d1ccb10ffc6ccc4b7a718429c607", size = 266513, upload-time = "2026-03-17T10:32:50.1Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/20/d326174c55af36f74eac6ae781612d9492f060ce8244b570bb9d50d9d609/coverage-7.13.5-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1c85e0b6c05c592ea6d8768a66a254bfb3874b53774b12d4c89c481eb78cb90", size = 267650, upload-time = "2026-03-17T10:32:52.391Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/5e/31484d62cbd0eabd3412e30d74386ece4a0837d4f6c3040a653878bfc019/coverage-7.13.5-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:777c4d1eff1b67876139d24288aaf1817f6c03d6bae9c5cc8d27b83bcfe38fe3", size = 261089, upload-time = "2026-03-17T10:32:54.544Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d8/49a72d6de146eebb0b7e48cc0f4bc2c0dd858e3d4790ab2b39a2872b62bd/coverage-7.13.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6697e29b93707167687543480a40f0db8f356e86d9f67ddf2e37e2dfd91a9dab", size = 263982, upload-time = "2026-03-17T10:32:56.803Z" },
+    { url = "https://files.pythonhosted.org/packages/06/3b/0351f1bd566e6e4dd39e978efe7958bde1d32f879e85589de147654f57bb/coverage-7.13.5-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:8fdf453a942c3e4d99bd80088141c4c6960bb232c409d9c3558e2dbaa3998562", size = 261579, upload-time = "2026-03-17T10:32:59.466Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ce/796a2a2f4017f554d7810f5c573449b35b1e46788424a548d4d19201b222/coverage-7.13.5-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:32ca0c0114c9834a43f045a87dcebd69d108d8ffb666957ea65aa132f50332e2", size = 265316, upload-time = "2026-03-17T10:33:01.847Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/16/d5ae91455541d1a78bc90abf495be600588aff8f6db5c8b0dae739fa39c9/coverage-7.13.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:8769751c10f339021e2638cd354e13adeac54004d1941119b2c96fe5276d45ea", size = 260427, upload-time = "2026-03-17T10:33:03.945Z" },
+    { url = "https://files.pythonhosted.org/packages/48/11/07f413dba62db21fb3fad5d0de013a50e073cc4e2dc4306e770360f6dfc8/coverage-7.13.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cec2d83125531bd153175354055cdb7a09987af08a9430bd173c937c6d0fba2a", size = 262745, upload-time = "2026-03-17T10:33:06.285Z" },
+    { url = "https://files.pythonhosted.org/packages/91/15/d792371332eb4663115becf4bad47e047d16234b1aff687b1b18c58d60ae/coverage-7.13.5-cp314-cp314t-win32.whl", hash = "sha256:0cd9ed7a8b181775459296e402ca4fb27db1279740a24e93b3b41942ebe4b215", size = 223146, upload-time = "2026-03-17T10:33:08.756Z" },
+    { url = "https://files.pythonhosted.org/packages/db/51/37221f59a111dca5e85be7dbf09696323b5b9f13ff65e0641d535ed06ea8/coverage-7.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:301e3b7dfefecaca37c9f1aa6f0049b7d4ab8dd933742b607765d757aca77d43", size = 224254, upload-time = "2026-03-17T10:33:11.174Z" },
+    { url = "https://files.pythonhosted.org/packages/54/83/6acacc889de8987441aa7d5adfbdbf33d288dad28704a67e574f1df9bcbb/coverage-7.13.5-cp314-cp314t-win_arm64.whl", hash = "sha256:9dacc2ad679b292709e0f5fc1ac74a6d4d5562e424058962c7bb0c658ad25e45", size = 222276, upload-time = "2026-03-17T10:33:13.466Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ee/a4cf96b8ce1e566ed238f0659ac2d3f007ed1d14b181bcb684e19561a69a/coverage-7.13.5-py3-none-any.whl", hash = "sha256:34b02417cf070e173989b3db962f7ed56d2f644307b2cf9d5a0f258e13084a61", size = 211346, upload-time = "2026-03-17T10:33:15.691Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "installation"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "pydantic" },
+    { name = "pyyaml" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "bandit" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "ruff" },
+    { name = "types-pyyaml" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pydantic", specifier = ">=2.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "bandit", specifier = ">=1.9.2" },
+    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "pytest-cov", specifier = ">=7.0.0" },
+    { name = "ruff", specifier = ">=0.14.10" },
+    { name = "types-pyyaml", specifier = ">=6.0" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852, upload-time = "2026-04-24T18:17:14.305Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713, upload-time = "2026-04-24T18:17:22.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c", size = 11069267, upload-time = "2026-04-24T18:17:30.105Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5", size = 10397182, upload-time = "2026-04-24T18:17:07.177Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/3310fc6d1b5e1fdea22bf3b1b807c7e187b581021b0d7d4514cccdb5fb71/ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002", size = 10758012, upload-time = "2026-04-24T18:16:55.759Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c1/a606911aee04c324ddaa883ae418f3569792fd3c4a10c50e0dd0a2311e1e/ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5", size = 10447479, upload-time = "2026-04-24T18:16:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/68/4201e8444f0894f21ab4aeeaee68aa4f10b51613514a20d80bd628d57e88/ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6", size = 11234040, upload-time = "2026-04-24T18:17:16.529Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ff/8a6d6cf4ccc23fd67060874e832c18919d1557a0611ebef03fdb01fff11e/ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33", size = 12087377, upload-time = "2026-04-24T18:17:04.944Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f6/c669cf73f5152f623d34e69866a46d5e6185816b19fcd5b6dd8a2d299922/ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847", size = 11367784, upload-time = "2026-04-24T18:17:25.409Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088, upload-time = "2026-04-24T18:17:12.258Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/8d/49afab3645e31e12c590acb6d3b5b69d7aab5b81926dbaf7461f9441f37a/ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339", size = 11271770, upload-time = "2026-04-24T18:17:02.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/06/33f41fe94403e2b755481cdfb9b7ef3e4e0ed031c4581124658d935d52b4/ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5", size = 10719355, upload-time = "2026-04-24T18:17:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/59/18aa4e014debbf559670e4048e39260a85c7fcee84acfd761ac01e7b8d35/ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd", size = 10462758, upload-time = "2026-04-24T18:17:32.347Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e7/cc9f16fd0f3b5fddcbd7ec3d6ae30c8f3fde1047f32a4093a98d633c6570/ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b", size = 10953498, upload-time = "2026-04-24T18:17:20.674Z" },
+    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765, upload-time = "2026-04-24T18:17:09.755Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
+]
+
+[[package]]
+name = "stevedore"
+version = "5.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6d/90764092216fa560f6587f83bb70113a8ba510ba436c6476a2b47359057c/stevedore-5.7.0.tar.gz", hash = "sha256:31dd6fe6b3cbe921e21dcefabc9a5f1cf848cf538a1f27543721b8ca09948aa3", size = 516200, upload-time = "2026-02-20T13:27:06.765Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/06/36d260a695f383345ab5bbc3fd447249594ae2fa8dfd19c533d5ae23f46b/stevedore-5.7.0-py3-none-any.whl", hash = "sha256:fd25efbb32f1abb4c9e502f385f0018632baac11f9ee5d1b70f88cc5e22ad4ed", size = 54483, upload-time = "2026-02-20T13:27:05.561Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260508"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/6b/f9d82598121b2f0532238381aec27734c24a0ff548ac352b358c2857a176/types_pyyaml-6.0.12.20260508.tar.gz", hash = "sha256:5ae42149c3ebf7aaaf6c65ee49af590c80f0ba52e9e3f75a75c5564b33556fa6", size = 17776, upload-time = "2026-05-08T04:48:28.682Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/80/96690460fe7f4e4b4ab0ecd79a8609aec2ae63927ad97625f3c747ca6a1d/types_pyyaml-6.0.12.20260508-py3-none-any.whl", hash = "sha256:edc094ed3a918b0c6232f71a5b67fdf38e76e17517b7d87bfbb9fc27d442fb51", size = 20309, upload-time = "2026-05-08T04:48:27.822Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]

--- a/shifter/shifter_platform/Dockerfile
+++ b/shifter/shifter_platform/Dockerfile
@@ -5,18 +5,23 @@ FROM ghcr.io/astral-sh/uv:python3.12-trixie-slim AS builder
 
 WORKDIR /app
 
-# Copy cyberscript library first (better layer caching)
+# Copy the Django-free shared packages first (better layer caching)
 COPY cyberscript /cyberscript
+COPY installation /installation
 
 # Copy dependency files
 COPY shifter_platform/pyproject.toml shifter_platform/uv.lock shifter_platform/requirements-gcp.txt ./
 
-# Export requirements and install dependencies into system Python
-# Install cyberscript as a local package
+# Export the platform's frozen lock to requirements.txt and install everything from
+# it (this pins pydantic, pyyaml, etc. at the locked versions). The local shared
+# packages — cyberscript (data contracts) and installation (root installation config;
+# Django/workers/provisioner derive runtime config from it) — are then installed with
+# --no-deps so their dependencies stay resolved by the frozen lock rather than by an
+# unpinned rebuild-time resolution.
 RUN uv export --no-hashes --no-emit-project --frozen > requirements.txt && \
     uv pip install --system --no-cache -r requirements.txt && \
     uv pip install --system --no-cache -r requirements-gcp.txt && \
-    uv pip install --system --no-cache /cyberscript
+    uv pip install --system --no-cache --no-deps /cyberscript /installation
 
 # Production stage
 FROM python:3.12-slim-trixie AS production

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,8 +4,8 @@ sonar.projectName=Shifter
 sonar.projectVersion=2.3.2
 
 # Source paths
-sonar.sources=shifter/shifter_platform,shifter/engine/provisioner,shifter/packer,scripts/bootstrap,scripts/check_layer_imports,mcp/shifter-db,mcp/ngfw,mcp/ops,mcp/shared,mcp/aws
-sonar.tests=shifter/shifter_platform/tests,shifter/engine/provisioner/tests,shifter/packer/tests,scripts/bootstrap/tests,scripts/check_layer_imports/tests
+sonar.sources=shifter/shifter_platform,shifter/engine/provisioner,shifter/packer,shifter/installation,scripts/bootstrap,scripts/check_layer_imports,mcp/shifter-db,mcp/ngfw,mcp/ops,mcp/shared,mcp/aws
+sonar.tests=shifter/shifter_platform/tests,shifter/engine/provisioner/tests,shifter/packer/tests,shifter/installation/tests,scripts/bootstrap/tests,scripts/check_layer_imports/tests
 
 # Exclusions (including test files - don't need bug/smell analysis on tests)
 # scenario-dev/** holds intentionally-vulnerable CTF target content; temp/** is scratch
@@ -27,7 +27,7 @@ sonar.cpd.exclusions=mcp/**/*.test.js
 sonar.coverage.exclusions=**/tests/**,**/conftest.py,**/dev_auth.py
 
 # Coverage report paths
-sonar.python.coverage.reportPaths=shifter/shifter_platform/coverage.xml,shifter/engine/provisioner/coverage.xml,shifter/packer/coverage.xml,scripts/bootstrap/coverage.xml,scripts/check_layer_imports/coverage.xml
+sonar.python.coverage.reportPaths=shifter/shifter_platform/coverage.xml,shifter/engine/provisioner/coverage.xml,shifter/packer/coverage.xml,shifter/installation/coverage.xml,scripts/bootstrap/coverage.xml,scripts/check_layer_imports/coverage.xml
 sonar.javascript.lcov.reportPaths=coverage/js/lcov.info
 
 # Encoding


### PR DESCRIPTION
Defines the single authoritative root installation config (`shifter.yaml`) that an OSS Shifter deployment edits to choose and configure a backend bundle. Constrained by ADR-011.

## Requirements

- `PLAT-2001` — root installation configuration: typed `RootConfig`/`DeploymentConfig` schema for `version`, `backend`, `deployment` (`name`, `domain`, `profile`), `secrets`, `settings`; fail-fast aggregated validation before Terraform/Helm/Django/workers/deploy scripts run.
- `GEN-2001` — standalone OSS deployment scope: the schema models exactly one deployment (no fleet / install-registry / cross-install orchestration keys; `extra="forbid"`).
- `GEN-2002` — backend-aware setup and validation UX (the *validation* part): `installation.loader.load_root_config` / `validate_root_config_file` and the `shifter-config validate` CLI; the setup/doctor command UX is #1115.

## What this ships

- **`installation` package** (`shifter/installation/`, Django-free, pydantic v2 + PyYAML): `schema.py` (typed models, root-shape validation — unknown keys, missing required keys, unknown backend, unsupported profile/backend combo, malformed deployment name/domain incl. non-public-hostname checks, duplicate/merge YAML keys, raw-key-material `secrets` values), `backends.py` (provisional `ALLOWED_PROFILES` registry — single source of truth; `KNOWN_BACKENDS`/`KNOWN_PROFILES` derived; superseded by #1113), `loader.py` (load + aggregated fail-fast errors; YAML parse errors reported from the parser's position only, never echoing file content), `errors.py` (`ConfigIssue` / `InstallationConfigError` — never carries the rejected input, so a mistyped secret cannot leak), `cli.py` + `__main__.py` + `shifter-config` console script. Backend-specific `settings` contents and the per-backend required-settings set are the backend bundle contract's responsibility (#1113), not this schema.
- **Examples**: machine-validated `examples/aws.yaml` and `examples/gcp.yaml` (the test suite loads every example through the same parser, so they can't drift).
- **Tests**: 132 tests; ruff/ruff-format/bandit clean; 98% coverage.
- **Wiring**: `installation-lint` / `installation-sast` / `installation-tests` jobs in `.github/workflows/_quality.yml` (on GitHub-hosted `ubuntu-latest` ephemeral runners — they execute PR-controlled Python); ruff/ruff-format/bandit/pytest pre-commit hooks scoped to `shifter/installation/`; `sonar.sources` / `sonar.tests` / coverage report path; ADR-011 evidence in `docs/adr/index.yaml`; built into the Shifter Platform Docker image alongside `cyberscript` (installed `--no-deps` from the frozen lock); `docs/architecture/root-configured-backend-bundles.md` records the resolved root-config filename; `CHANGELOG.md` 3.99.0.

## Out of scope (per the codex architecture preflight)

Backend bundle contract / registry / per-backend `settings` validation (#1113); runtime/Django config derivation (#1114); backend-aware setup/doctor command UX (#1115); AWS/GCP bundle migration (#1116/#1117); branch-targeted deploy docs and CI-routing rework — including the over-broad `deploy.yml` `shifter/**` path filter (#1118); `local` backend scope and example (#1119).

Plan and codex review decisions are recorded on the issue thread.

Closes #1112
