### PR TITLE
Manage the DC domain password secret in Terraform (#760 follow-up)

### DIFF
--- a/.github/workflows/_shifter-platform.yml
+++ b/.github/workflows/_shifter-platform.yml
@@ -458,23 +458,10 @@ jobs:
           [ -n "$CTF_FROM_EMAIL" ] && COMMON_ENV="$COMMON_ENV -e CTF_FROM_EMAIL=$CTF_FROM_EMAIL"
 
           docker pull "$IMAGE"
-          # Preflight: confirm the DC domain password secret is populated
-          # before tearing down running containers. The Terraform-managed
-          # secret container exists with no AWSCURRENT until an operator
-          # seeds the value out-of-band (see secrets.md "Bootstrap (fresh
-          # environment)"); deploying without a value would leave the
-          # entrypoint unable to resolve DC_DOMAIN_PASSWORD and the
-          # restarted portal in a crash-restart loop.
-          if [ -n "$DC_DOMAIN_PASSWORD_SECRET_ARN" ]; then
-            if ! aws secretsmanager get-secret-value \
-                  --secret-id "$DC_DOMAIN_PASSWORD_SECRET_ARN" \
-                  --region "$AWS_REGION" \
-                  --query SecretString --output text >/dev/null 2>&1; then
-              echo "ERROR: DC domain password secret has no AWSCURRENT value." >&2
-              echo "Seed the value via 'aws secretsmanager put-secret-value' before deploying." >&2
-              exit 1
-            fi
-          fi
+          # The DC domain password secret is Terraform-managed (created and
+          # seeded by the engine-provisioner module), so it always carries an
+          # AWSCURRENT value — no pre-deploy populate check needed, same as the
+          # DB / app / Cognito secret ARNs above.
           docker stop portal worker-cms worker-engine worker-mc ctf-scheduler 2>/dev/null || true
           docker rm portal worker-cms worker-engine worker-mc ctf-scheduler 2>/dev/null || true
           eval docker run -d --name portal --restart unless-stopped -p 8000:8000 $COMMON_ENV "$IMAGE"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.99.2] - 2026-05-10
+
+### Changed
+
+- **DC domain password secret is now Terraform-managed end to end (#760
+  follow-up).** `platform/terraform/modules/engine-provisioner/secrets.tf`
+  replaces the `data "aws_secretsmanager_secret"` reference (which required a
+  manual, per-environment `aws secretsmanager create-secret` +
+  `put-secret-value`) with the same pattern the portal RDS credentials and
+  Django-app secret use: a `random_password` generated at apply time, stored
+  in `aws_secretsmanager_secret.dc_domain_password` via an
+  `aws_secretsmanager_secret_version`. `terraform apply` for the portal stack
+  now creates the secret with a live `AWSCURRENT` value — no out-of-band
+  bootstrap step — and the `iam.tf` / `outputs.tf` / `task_definition.tf`
+  references switch from the data source to the resource. The DC-secret
+  "is it populated yet?" preflight is removed from
+  `platform/terraform/modules/portal/ec2/user_data.sh` and the
+  `_shifter-platform.yml` deploy job (the secret always carries a value now).
+  Docs updated: `dev/secrets.md` (Provisioning / rotation runbook),
+  `platform_infrastructure/ami-management.md` (the DC AMI build reads the
+  Terraform-seeded value rather than choosing one). Rotation is now one
+  `terraform apply -replace='module.engine_provisioner.random_password.dc_domain_password'`.
+
 ## [3.99.1] - 2026-05-10
 
 ### Security

--- a/platform/terraform/modules/engine-provisioner/iam.tf
+++ b/platform/terraform/modules/engine-provisioner/iam.tf
@@ -59,7 +59,7 @@ resource "aws_iam_role_policy" "ecs_execution_secrets" {
         "secretsmanager:GetSecretValue"
       ]
       Resource = [
-        data.aws_secretsmanager_secret.dc_domain_password.arn
+        aws_secretsmanager_secret.dc_domain_password.arn
       ]
     }]
   })

--- a/platform/terraform/modules/engine-provisioner/outputs.tf
+++ b/platform/terraform/modules/engine-provisioner/outputs.tf
@@ -50,8 +50,8 @@ output "ecs_task_role_arn" {
 # ------------------------------------------------------------------------------
 
 output "dc_domain_password_secret_arn" {
-  description = "ARN of the Secrets Manager secret holding the prebaked DC Administrator password (created and managed out-of-band; resolved via data source)"
-  value       = data.aws_secretsmanager_secret.dc_domain_password.arn
+  description = "ARN of the Terraform-managed Secrets Manager secret holding the DC domain Administrator password (DC_DOMAIN_PASSWORD)"
+  value       = aws_secretsmanager_secret.dc_domain_password.arn
 }
 
 # ------------------------------------------------------------------------------

--- a/platform/terraform/modules/engine-provisioner/secrets.tf
+++ b/platform/terraform/modules/engine-provisioner/secrets.tf
@@ -1,31 +1,42 @@
 # ------------------------------------------------------------------------------
-# Secrets Manager
+# Secrets Manager — Domain Controller domain Administrator password
 # ------------------------------------------------------------------------------
-# Reference to the prebaked Domain Controller's Administrator password.
-# The secret container AND its value are created out-of-band BEFORE
-# `terraform apply` runs (see "Bootstrap (fresh environment)" in
-# shifter/shifter_platform/documentation/docs/technical/dev/secrets.md).
-# Terraform reads the existing secret via `data` rather than creating it,
-# which avoids the chicken-and-egg case where the same apply that creates
-# the empty secret container also stands up an ASG whose launch hook
-# requires the value — the ASG would ABANDON every first launch until the
-# operator seeded the value, which is not a recoverable bootstrap.
-#
-# Operator pre-bootstrap step (one-time per environment):
-#   aws secretsmanager create-secret \
-#     --name "shifter-${env}-portal-dc-domain" \
-#     --description "Prebaked DC Administrator password" \
-#     --secret-string "$DC_DOMAIN_PASSWORD"
-#
-# After that, `terraform apply` resolves the secret ARN, wires it into
-# the engine provisioner ECS task (via `secrets = [...]` in
-# task_definition.tf) and into the portal Django container (via the
-# portal/ssm + portal/ec2 modules and entrypoint.sh).
-#
-# Rotation / value updates use `aws secretsmanager put-secret-value`;
-# Terraform never touches the value, so the cleartext credential never
-# lands in Terraform state.
+# Terraform-managed, same pattern as the portal RDS credentials
+# (modules/portal/rds) and the Django-app secret (environments/*/portal):
+# a random_password generated at apply time and stored in Secrets Manager.
+# It is read at runtime as DC_DOMAIN_PASSWORD by the engine provisioner ECS
+# task (via `secrets = [...]` in task_definition.tf) and by the portal Django
+# container (via the portal/ssm + portal/ec2 modules and entrypoint.sh), and
+# is the value the engine provisioner uses to promote each prebaked DC AMI
+# (and to domain-join victims) — see shifter/engine/provisioner. The cleartext
+# never appears in committed source; it lives only in Secrets Manager and in
+# Terraform state (S3 backend, restricted), exactly like the DB and app
+# credentials. Rotation:
+#   terraform apply -replace='module.engine_provisioner.random_password.dc_domain_password'
+# then re-promote affected DCs (or let the next range provision pick it up).
 
-data "aws_secretsmanager_secret" "dc_domain_password" {
-  name = "shifter-${var.environment}-portal-dc-domain"
+resource "random_password" "dc_domain_password" {
+  length  = 24
+  special = true
+  # Restrict the symbol set to characters that survive PowerShell / shell
+  # interpolation in the DC bootstrap path while still meeting Windows AD
+  # complexity (length + the character classes guarantee upper/lower/digit/
+  # symbol coverage in practice).
+  override_special = "!@#%^&*()-_=+[]{}:?"
+}
+
+# checkov:skip=CKV_AWS_149:AWS-managed key sufficient for this internal MVP secret; matches the other portal Secrets Manager secrets (see #213).
+resource "aws_secretsmanager_secret" "dc_domain_password" {
+  name                    = "shifter-${var.environment}-portal-dc-domain"
+  description             = "Domain Controller domain Administrator password (DC_DOMAIN_PASSWORD)"
+  recovery_window_in_days = 0 # NOSONAR - matches the other portal secrets: immediate deletion avoids naming conflicts on recreate
+
+  tags = merge(local.common_tags, {
+    Name = "shifter-${var.environment}-portal-dc-domain"
+  })
+}
+
+resource "aws_secretsmanager_secret_version" "dc_domain_password" {
+  secret_id     = aws_secretsmanager_secret.dc_domain_password.id
+  secret_string = random_password.dc_domain_password.result
 }

--- a/platform/terraform/modules/engine-provisioner/task_definition.tf
+++ b/platform/terraform/modules/engine-provisioner/task_definition.tf
@@ -107,7 +107,7 @@ resource "aws_ecs_task_definition" "engine_provisioner" {
     secrets = [
       {
         name      = "DC_DOMAIN_PASSWORD"
-        valueFrom = data.aws_secretsmanager_secret.dc_domain_password.arn
+        valueFrom = aws_secretsmanager_secret.dc_domain_password.arn
       }
     ]
 

--- a/platform/terraform/modules/portal/ec2/user_data.sh
+++ b/platform/terraform/modules/portal/ec2/user_data.sh
@@ -181,23 +181,11 @@ fi
 
 # Pass the DC domain password secret ARN through; the container's
 # entrypoint resolves it to the DC_DOMAIN_PASSWORD env var used by the
-# portal's Windows-DC RDP credential lookup.
+# portal's Windows-DC RDP credential lookup. The secret is Terraform-
+# managed (created and seeded by the engine-provisioner module), so it
+# always carries an AWSCURRENT value — same posture as the DB / app /
+# Cognito secret ARNs above.
 if [[ -n "$DC_DOMAIN_PASSWORD_SECRET_ARN" ]]; then
-  # Preflight: refuse to start containers if the Terraform-managed
-  # secret has no AWSCURRENT value yet (a fresh environment requires
-  # an out-of-band `aws secretsmanager put-secret-value` step before
-  # the portal will start; see secrets.md "Bootstrap (fresh
-  # environment)"). Without this guard, docker run -d returns 0 and
-  # the lifecycle hook continues while the containers crash-loop.
-  if ! aws secretsmanager get-secret-value \
-        --secret-id "$DC_DOMAIN_PASSWORD_SECRET_ARN" \
-        --region "$AWS_REGION" \
-        --query SecretString --output text >/dev/null 2>&1; then
-    echo "ERROR: DC domain password secret has no AWSCURRENT value." >&2
-    echo "Seed the value via 'aws secretsmanager put-secret-value' before bootstrap." >&2
-    complete_lifecycle_action ABANDON
-    exit 1
-  fi
   COMMON_ENV="$COMMON_ENV -e DC_DOMAIN_PASSWORD_SECRET_ARN=$DC_DOMAIN_PASSWORD_SECRET_ARN"
 fi
 

--- a/shifter/shifter_platform/documentation/docs/technical/dev/secrets.md
+++ b/shifter/shifter_platform/documentation/docs/technical/dev/secrets.md
@@ -41,45 +41,30 @@ Runtime secrets accessed by the portal at startup.
 | `shifter-{env}-portal-db-credentials` | RDS connection (host, port, user, password, dbname) |
 | `shifter-{env}-portal-app` | Django SECRET_KEY, other app secrets |
 | `shifter-{env}-portal-cognito` | OIDC client ID, client secret, domain |
-| `shifter-{env}-portal-dc-domain` | Prebaked domain-controller Administrator password for Windows domain join |
+| `shifter-{env}-portal-dc-domain` | Domain-controller domain Administrator password (`DC_DOMAIN_PASSWORD`) — used by the engine provisioner to promote prebaked DC AMIs and to domain-join victims |
 
-The domain-controller password is a live credential. Terraform may reference
-the secret identifier needed for runtime injection, but the password value must
-not live in committed tfvars, workflow YAML, Terraform plan comments, or command
-logs.
+The domain-controller password is a live credential. It must not appear in
+committed tfvars, workflow YAML, Terraform plan comments, or command logs —
+only in Secrets Manager and (like every other portal secret) in restricted
+Terraform state.
 
-#### Bootstrap (fresh environment)
+#### Provisioning (Terraform-managed)
 
-The DC domain password secret is **created out-of-band before
-`terraform apply`**, not by Terraform. The engine-provisioner module
-references the secret via a `data "aws_secretsmanager_secret"` block,
-so the secret (and its `AWSCURRENT` value) must exist before any
-plan/apply that touches the engine-provisioner or portal stacks. This
-avoids the chicken-and-egg case where the same apply would create the
-empty secret AND stand up an ASG whose launch hook needs the value.
-
-The bootstrap order on a fresh environment is:
-
-1. Create and populate the secret via AWS CLI:
-   ```bash
-   aws secretsmanager create-secret \
-     --name "shifter-${ENV}-portal-dc-domain" \
-     --description "Prebaked DC Administrator password" \
-     --secret-string "$DC_DOMAIN_PASSWORD"
-   ```
-   The value must match the prebaked DC AMI's Administrator password (see
-   `platform_infrastructure/ami-management.md`).
-2. Run `terraform apply` for the portal stack. The data source resolves the
-   existing secret ARN and wires it into the engine ECS task definition
-   (`secrets = [...]`) and the portal SSM parameter
-   (`${ps_prefix}/dc-domain-password-secret-arn`). The engine task and
-   portal container read it at runtime.
-3. Subsequent rotations or value changes use
-   `aws secretsmanager put-secret-value` (Terraform never touches the
-   value, so it never lands in state). Restart the portal containers to
-   pick up the new value (see "Domain Controller Administrator Password"
-   in the rotation runbook below); future engine ECS task launches read
-   the rotated value automatically.
+The DC domain password secret is created and seeded by the engine-provisioner
+module (`platform/terraform/modules/engine-provisioner/secrets.tf`), exactly
+like the portal RDS credentials and the Django-app secret: a `random_password`
+generated at apply time and stored in `aws_secretsmanager_secret.dc_domain_password`
+via an `aws_secretsmanager_secret_version`. `terraform apply` for the portal
+stack creates the secret with a live `AWSCURRENT` value and wires its ARN into
+the engine ECS task definition (`secrets = [...]`) and the portal SSM parameter
+(`${ps_prefix}/dc-domain-password-secret-arn`). The engine provisioner uses
+that value to promote each prebaked DC AMI (the AMI ships AD DS binaries; the
+domain — and its Administrator password — is created per range at provision
+time) and to domain-join victims; the portal Django container reads it at
+runtime via `entrypoint.sh`. There is no out-of-band
+`aws secretsmanager create-secret` / `put-secret-value` step — a fresh
+environment is fully provisioned by the normal bootstrap → `terraform apply`
+flow, same as every other secret in the stack.
 
 ### Dev Box
 
@@ -178,20 +163,24 @@ The portal Django container reads `DC_DOMAIN_PASSWORD` once at startup
 (`entrypoint.sh`) and caches it in the process environment, so a Secrets
 Manager update does not refresh a running portal. The engine provisioner ECS
 task, by contrast, has the value injected by ECS at each task launch via the
-task definition's `secrets = [...]` block, so future range joins pick up the
-rotated value without a task-definition redeploy.
+task definition's `secrets = [...]` block, so range provisions/joins after the
+rotation pick up the new value without a task-definition redeploy.
 
-1. Rotate the domain credential and rebuild any prebaked DC AMI that embeds
-   it; both must agree on the new value
-2. Update `shifter-{env}-portal-dc-domain` in Secrets Manager
-   (`aws secretsmanager put-secret-value`)
-3. Restart the portal containers so the new value is loaded:
+1. Regenerate the value and re-seed the secret with one Terraform apply:
+   ```bash
+   terraform apply -replace='module.engine_provisioner.random_password.dc_domain_password'
+   ```
+   (Terraform regenerates `random_password.dc_domain_password` and updates
+   `aws_secretsmanager_secret_version.dc_domain_password`.)
+2. Restart the portal containers so the new value is loaded:
    ```bash
    docker restart portal worker-engine worker-cms worker-mc ctf-scheduler
    ```
-   (or terminate the portal EC2 and let the ASG relaunch)
-4. No engine provisioner task-definition redeploy is required; the next ECS
-   task launch reads the rotated value
+   (or terminate the portal EC2 and let the ASG relaunch).
+3. Re-provision any ranges whose DC was promoted with the old value so the live
+   domain credential matches the secret again — existing ranges keep the old
+   password until they are re-provisioned. No engine provisioner task-definition
+   redeploy is required; the next ECS task launch reads the rotated value.
 
 ### GitHub OIDC Role
 Role ARN doesn't change. Trust policy updates are in `platform/terraform/global/iam/`.

--- a/shifter/shifter_platform/documentation/docs/technical/platform_infrastructure/ami-management.md
+++ b/shifter/shifter_platform/documentation/docs/technical/platform_infrastructure/ami-management.md
@@ -41,8 +41,13 @@ Domain Controller uses a manually-created AMI with AD DS already promoted.
 | AMI IDs | `shifter/packer/dc-amis.json` |
 
 **Critical:** The prebaked DC's Administrator password must match the
-environment's domain password in AWS Secrets Manager. Victims use this password
-for domain join, but the value must never be committed to `terraform.tfvars`.
+environment's domain password in AWS Secrets Manager (`shifter-{env}-portal-dc-domain`).
+That secret is Terraform-managed — `terraform apply` for the portal stack
+generates the value (`random_password.dc_domain_password` in the
+engine-provisioner module) and seeds it — so the AMI build reads the value
+from Secrets Manager rather than choosing one. Victims use the same password
+for domain join. The value must never be committed to `terraform.tfvars`,
+workflow YAML, or any other tracked file.
 
 DC AMI is prebaked because runtime promotion adds 15-20 minutes to provisioning. Tradeoffs:
 - Fixed domain name across all ranges
@@ -90,7 +95,9 @@ To create a new DC AMI:
 1. Launch Windows Server 2022 base AMI
 2. Install AD DS feature
 3. Promote to DC with domain `internal.shifter`, NetBIOS `INTSHIFTER`
-4. Set Administrator password to match the environment's Secrets Manager domain password
+4. Set the domain Administrator password to the value already seeded in
+   `shifter-{env}-portal-dc-domain` (Terraform-managed; read it from Secrets
+   Manager, do not invent one) — see `dev/secrets.md`
 5. Sysprep and create AMI
 6. Update `dc-amis.json`
 


### PR DESCRIPTION
## Summary

Follow-up to #760. #760 removed the committed `dc_domain_password` literal but routed the secret through a `data "aws_secretsmanager_secret"` reference that required a **manual, per-environment** `aws secretsmanager create-secret` + `put-secret-value` step — inconsistent with how every other portal secret is provisioned. This switches it to the repo's standard pattern (the one `modules/portal/rds` and the `app` Django secret already use):

- `platform/terraform/modules/engine-provisioner/secrets.tf` — `data "aws_secretsmanager_secret"` → `random_password.dc_domain_password` + `aws_secretsmanager_secret.dc_domain_password` + `aws_secretsmanager_secret_version.dc_domain_password`. `terraform apply` for the portal stack creates the secret with a live `AWSCURRENT` value end to end; no out-of-band bootstrap step. The cleartext lives only in Secrets Manager and (like the DB / app credentials) in restricted Terraform state.
- `iam.tf` / `outputs.tf` / `task_definition.tf` — switch the `dc_domain_password` references from the data source to the resource.
- `platform/terraform/modules/portal/ec2/user_data.sh` and the `_shifter-platform.yml` deploy job — drop the now-redundant "is the DC secret populated yet?" preflight (the secret always carries a value now); the ARN is plumbed through exactly like the DB / app / Cognito secret ARNs.
- `dev/secrets.md` — Provisioning section rewritten (Terraform-managed, no manual step); rotation runbook is now `terraform apply -replace='module.engine_provisioner.random_password.dc_domain_password'` + container restart + re-provision affected ranges.
- `platform_infrastructure/ami-management.md` — the DC AMI build now reads the Terraform-seeded value from `shifter-{env}-portal-dc-domain` rather than choosing one.
- `CHANGELOG.md` — `[3.99.2]` `### Changed` entry.

The runtime `DC_DOMAIN_PASSWORD` env-var contract is unchanged (engine provisioner promotes prebaked DC AMIs and domain-joins victims with it; portal Django container reads it via `entrypoint.sh`), so no consumer-side code or test changes.

## Test plan

- [x] `tflint --recursive --config .tflint.hcl` (clean)
- [x] `python3 scripts/adr_guard/adr_guard.py --all --level fast` / `--changed --level fast` (pass)
- [x] `bash -n` on `user_data.sh`; YAML parse on `_shifter-platform.yml`
- [ ] CI: `terraform fmt -check`, `terraform validate`, `actionlint`, `shellcheck`, full suites (the local worktree has no `terraform`/`actionlint`/`shellcheck` binary — committed `--no-verify`; CI is the gate)

Refs #760