### PR TITLE
Correct stale /app-ownership note in provisioner CHANGELOG

### DIFF
--- a/shifter/engine/provisioner/CHANGELOG.md
+++ b/shifter/engine/provisioner/CHANGELOG.md
@@ -15,14 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   privileges before `ENTRYPOINT`. `HOME` / `TF_PLUGIN_CACHE_DIR` /
   `PULUMI_HOME` are set explicitly and the matching cache directories
   under `/home/appuser` are pre-created so Terraform/Pulumi can write
-  under the non-root identity. `/app` is chowned to `appuser:appgroup`
-  so Terraform can write `.terraform/` and `terraform.tfvars.json`
-  inside module working directories. This reduces the blast radius of a
-  container compromise but does not eliminate the risk of host root via
-  a kernel-level container escape. Added `tests/test_dockerfile.py` as
-  a structural regression gate plus an opt-in (`RUN_DOCKER_TESTS=1`)
+  under the non-root identity. Application code under `/app` remains
+  root-owned image content; Terraform writes are staged under
+  `TERRAFORM_WORKSPACE_DIR` so a process compromise cannot mutate the
+  running application tree. This reduces the blast radius of a container
+  compromise but does not eliminate the risk of host root via a
+  kernel-level container escape. Added `tests/test_dockerfile.py` as a
+  structural regression gate plus an opt-in (`RUN_DOCKER_TESTS=1`)
   Docker smoke test that verifies the running container's UID, HOME,
-  and writable cache paths.
+  writable cache paths, and read-only `/app` contract.
 
 ## [3.31.0] - 2026-03-22
 


### PR DESCRIPTION
## Summary

The provisioner container's non-root hardening — the substance of #955 (a verbatim duplicate of #950, "Provisioner container runs as root") — already shipped under #950 (PR #1104) and was further hardened by #1103:

- `shifter/engine/provisioner/Dockerfile` creates `appgroup`/`appuser` (gid/uid 1000), runs `USER 1000:1000` (numeric, so Kubernetes `runAsNonRoot` admission can verify it) after dependency installs and before `ENTRYPOINT`, keeps `/app` root-owned + immutable, and stages Terraform/Pulumi writes under `TERRAFORM_WORKSPACE_DIR`.
- `shifter/engine/provisioner/tests/test_dockerfile.py::TestDockerfileNonRootUser` is the structural regression gate for that whole contract (plus an opt-in `RUN_DOCKER_TESTS=1` runtime smoke test).

The Codex architecture preflight for #955 surfaced one stale-doc defect in the area: the `shifter/engine/provisioner/CHANGELOG.md` Security entry still said "`/app` is chowned to `appuser:appgroup`" — that described the pre-#1103 design. This PR corrects the prose to match the shipped, tested contract (immutable root-owned `/app`; Terraform writes staged under `TERRAFORM_WORKSPACE_DIR`; smoke test verifying the read-only-`/app` behaviour).

**Scope: documentation only** — one prose correction in `shifter/engine/provisioner/CHANGELOG.md`. No executable code, schema, config, or workflow change. Implemented under the `/implement` documentation-only TDD carve-out; the contract the corrected text describes is already protected by `test_dockerfile.py`.

Closes #955