### PR TITLE
Add Kubernetes network policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.101.1] - 2026-05-10
+
+### Security
+
+- **Added default-deny Kubernetes NetworkPolicies for the GCP control plane
+  (#958).** The Helm chart and static GCP base manifests now isolate
+  `shifter-platform` and `shifter-jobs` by default, with explicit allow rules
+  for GCLB ingress, DNS, Guacamole-to-guacd traffic, Google APIs, and generated
+  private service CIDRs.
+
 ## [3.101.0] - 2026-05-10
 
 ### Added

--- a/docs/adr/exceptions.yaml
+++ b/docs/adr/exceptions.yaml
@@ -1,10 +1,1 @@
-[
-  {
-    "rule_id": "ADR-006-R3",
-    "owner": "platform",
-    "reason": "NetworkPolicies not yet authored; deferred until network segmentation design is complete.",
-    "expires_on": "2026-07-08",
-    "checks": [],
-    "paths": ["platform/k8s/gcp/base/"]
-  }
-]
+[]

--- a/docs/adr/index.yaml
+++ b/docs/adr/index.yaml
@@ -177,14 +177,16 @@
       },
       {
         "id": "ADR-006-R3",
-        "description": "Each namespace must have at least one NetworkPolicy (deferred until policies are authored).",
-        "checks": []
+        "description": "Each Shifter Kubernetes namespace must have a default-deny NetworkPolicy covering both ingress and egress, and Shifter NetworkPolicies must use explicit service CIDRs instead of broad internet egress ranges.",
+        "checks": ["k8s-network-policy-coverage"]
       }
     ],
     "exceptions": [],
     "enforcement": ["pre-commit", "ci"],
     "evidence": [
       "platform/k8s/gcp/base/namespaces.yaml",
+      "platform/k8s/gcp/base/networkpolicies.yaml",
+      "platform/charts/shifter/templates/networkpolicies.yaml",
       ".kube-linter.yaml",
       ".pre-commit-config.yaml",
       "scripts/adr_guard/adr_guard.py",

--- a/platform/charts/shifter/templates/networkpolicies.yaml
+++ b/platform/charts/shifter/templates/networkpolicies.yaml
@@ -1,0 +1,223 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-platform
+  namespace: {{ .Values.namespaces.platform }}
+  labels:
+    {{- include "shifter.partOfLabels" . | nindent 4 }}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress: []
+  egress: []
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-jobs
+  namespace: {{ .Values.namespaces.jobs }}
+  labels:
+    {{- include "shifter.partOfLabels" . | nindent 4 }}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress: []
+  egress: []
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-platform-dns-egress
+  namespace: {{ .Values.namespaces.platform }}
+  labels:
+    {{- include "shifter.partOfLabels" . | nindent 4 }}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-jobs-dns-egress
+  namespace: {{ .Values.namespaces.jobs }}
+  labels:
+    {{- include "shifter.partOfLabels" . | nindent 4 }}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-public-ingress-to-platform-backends
+  namespace: {{ .Values.namespaces.platform }}
+  labels:
+    {{- include "shifter.partOfLabels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchExpressions:
+      - key: app.kubernetes.io/component
+        operator: In
+        values:
+          - portal
+          - guacamole-client
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        {{- range .Values.networkPolicy.gclbSourceRanges }}
+        - ipBlock:
+            cidr: {{ . | quote }}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: 8000
+        - protocol: TCP
+          port: 8080
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-guacamole-client-to-guacd
+  namespace: {{ .Values.namespaces.platform }}
+  labels:
+    {{- include "shifter.partOfLabels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: guacd
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: guacamole-client
+      ports:
+        - protocol: TCP
+          port: 4822
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-guacamole-client-egress-to-guacd
+  namespace: {{ .Values.namespaces.platform }}
+  labels:
+    {{- include "shifter.partOfLabels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: guacamole-client
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: guacd
+      ports:
+        - protocol: TCP
+          port: 4822
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-platform-google-apis-egress
+  namespace: {{ .Values.namespaces.platform }}
+  labels:
+    {{- include "shifter.partOfLabels" . | nindent 4 }}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        {{- range .Values.networkPolicy.googleApiCidrs }}
+        - ipBlock:
+            cidr: {{ . | quote }}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: 443
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-jobs-google-apis-egress
+  namespace: {{ .Values.namespaces.jobs }}
+  labels:
+    {{- include "shifter.partOfLabels" . | nindent 4 }}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        {{- range .Values.networkPolicy.googleApiCidrs }}
+        - ipBlock:
+            cidr: {{ . | quote }}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: 443
+{{- if .Values.networkPolicy.privateServiceCidrs }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-platform-private-service-egress
+  namespace: {{ .Values.namespaces.platform }}
+  labels:
+    {{- include "shifter.partOfLabels" . | nindent 4 }}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        {{- range .Values.networkPolicy.privateServiceCidrs }}
+        - ipBlock:
+            cidr: {{ . | quote }}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: 443
+        - protocol: TCP
+          port: 5432
+        - protocol: TCP
+          port: 6379
+{{- end }}
+{{- end }}

--- a/platform/charts/shifter/values.yaml
+++ b/platform/charts/shifter/values.yaml
@@ -158,6 +158,16 @@ services:
       name: guacamole-client
       securityPolicyName: ""
 
+networkPolicy:
+  enabled: true
+  gclbSourceRanges:
+    - 35.191.0.0/16 # NOSONAR - Google Cloud Load Balancer health check/proxy range.
+    - 130.211.0.0/22 # NOSONAR - Google Cloud Load Balancer health check/proxy range.
+  googleApiCidrs:
+    - 199.36.153.4/30 # NOSONAR - restricted.googleapis.com VIP range.
+    - 199.36.153.8/30 # NOSONAR - private.googleapis.com VIP range.
+  privateServiceCidrs: []
+
 ingress:
   enabled: true
   class: gce

--- a/platform/k8s/gcp/base/kustomization.yaml
+++ b/platform/k8s/gcp/base/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - namespaces.yaml
   - serviceaccounts.yaml
   - rbac-job-launcher.yaml
+  - networkpolicies.yaml
   - web-service.yaml
   - web-deployment.yaml
   - guacd-service.yaml

--- a/platform/k8s/gcp/base/networkpolicies.yaml
+++ b/platform/k8s/gcp/base/networkpolicies.yaml
@@ -1,0 +1,203 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-platform
+  namespace: shifter-platform
+  labels:
+    app.kubernetes.io/name: shifter
+    app.kubernetes.io/part-of: shifter
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress: []
+  egress: []
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-jobs
+  namespace: shifter-jobs
+  labels:
+    app.kubernetes.io/name: shifter
+    app.kubernetes.io/part-of: shifter
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress: []
+  egress: []
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-platform-dns-egress
+  namespace: shifter-platform
+  labels:
+    app.kubernetes.io/name: shifter
+    app.kubernetes.io/part-of: shifter
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-jobs-dns-egress
+  namespace: shifter-jobs
+  labels:
+    app.kubernetes.io/name: shifter
+    app.kubernetes.io/part-of: shifter
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-public-ingress-to-platform-backends
+  namespace: shifter-platform
+  labels:
+    app.kubernetes.io/name: shifter
+    app.kubernetes.io/part-of: shifter
+spec:
+  podSelector:
+    matchExpressions:
+      - key: app.kubernetes.io/component
+        operator: In
+        values:
+          - portal
+          - guacamole-client
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - ipBlock:
+            cidr: 35.191.0.0/16 # NOSONAR - Google Cloud Load Balancer health check/proxy range.
+        - ipBlock:
+            cidr: 130.211.0.0/22 # NOSONAR - Google Cloud Load Balancer health check/proxy range.
+      ports:
+        - protocol: TCP
+          port: 8000
+        - protocol: TCP
+          port: 8080
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-guacamole-client-to-guacd
+  namespace: shifter-platform
+  labels:
+    app.kubernetes.io/name: shifter
+    app.kubernetes.io/part-of: shifter
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: guacd
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: guacamole-client
+      ports:
+        - protocol: TCP
+          port: 4822
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-guacamole-client-egress-to-guacd
+  namespace: shifter-platform
+  labels:
+    app.kubernetes.io/name: shifter
+    app.kubernetes.io/part-of: shifter
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: guacamole-client
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: guacd
+      ports:
+        - protocol: TCP
+          port: 4822
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-platform-google-apis-egress
+  namespace: shifter-platform
+  labels:
+    app.kubernetes.io/name: shifter
+    app.kubernetes.io/part-of: shifter
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 199.36.153.4/30 # NOSONAR - restricted.googleapis.com VIP range.
+        - ipBlock:
+            cidr: 199.36.153.8/30 # NOSONAR - private.googleapis.com VIP range.
+      ports:
+        - protocol: TCP
+          port: 443
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-jobs-google-apis-egress
+  namespace: shifter-jobs
+  labels:
+    app.kubernetes.io/name: shifter
+    app.kubernetes.io/part-of: shifter
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 199.36.153.4/30 # NOSONAR - restricted.googleapis.com VIP range.
+        - ipBlock:
+            cidr: 199.36.153.8/30 # NOSONAR - private.googleapis.com VIP range.
+      ports:
+        - protocol: TCP
+          port: 443

--- a/platform/terraform/gcp/environments/gcp-dev/outputs.tf
+++ b/platform/terraform/gcp/environments/gcp-dev/outputs.tf
@@ -28,6 +28,11 @@ output "portal_network_cidrs" {
   value       = module.platform_core.portal_network_cidrs
 }
 
+output "gke_services_cidr" {
+  description = "GKE service CIDR used by in-cluster clients to reach Kubernetes service IPs."
+  value       = module.platform_core.gke_services_cidr
+}
+
 output "gke_cluster_name" {
   description = "Name of the GKE cluster."
   value       = module.platform_core.gke_cluster_name

--- a/platform/terraform/gcp/modules/platform-core/outputs.tf
+++ b/platform/terraform/gcp/modules/platform-core/outputs.tf
@@ -28,6 +28,11 @@ output "portal_network_cidrs" {
   value       = local.portal_network_cidrs
 }
 
+output "gke_services_cidr" {
+  description = "GKE service CIDR used by in-cluster clients to reach Kubernetes service IPs."
+  value       = var.gke_services_cidr
+}
+
 output "gke_subnetwork_name" {
   description = "Name of the GKE subnetwork."
   value       = google_compute_subnetwork.gke.name

--- a/scripts/adr_guard/adr_guard.py
+++ b/scripts/adr_guard/adr_guard.py
@@ -1160,6 +1160,204 @@ def _validate_chart_renders(repo_root: Path) -> list[Violation]:
     return violations
 
 
+def _network_policy_violation(path: str, message: str) -> Violation:
+    return Violation(
+        "k8s-network-policy-coverage",
+        "ADR-006-R3",
+        path,
+        message,
+    )
+
+
+def _as_network_policy_violations(violations: list[Violation]) -> list[Violation]:
+    return [
+        _network_policy_violation(violation.path, violation.message)
+        for violation in violations
+    ]
+
+
+def _is_shifter_namespace(name: object) -> bool:
+    return isinstance(name, str) and name.startswith("shifter-")
+
+
+def _document_namespace(doc: object) -> str | None:
+    if not isinstance(doc, dict):
+        return None
+    metadata = doc.get("metadata")
+    if not isinstance(metadata, dict):
+        return None
+    namespace = metadata.get("namespace")
+    if isinstance(namespace, str):
+        return namespace
+    return None
+
+
+def _collect_shifter_namespaces(docs: list[object]) -> set[str]:
+    namespaces: set[str] = set()
+    for doc in docs:
+        if not isinstance(doc, dict):
+            continue
+        metadata = doc.get("metadata")
+        if not isinstance(metadata, dict):
+            continue
+        if doc.get("kind") == "Namespace":
+            name = metadata.get("name")
+            if _is_shifter_namespace(name):
+                namespaces.add(name)
+        namespace = metadata.get("namespace")
+        if _is_shifter_namespace(namespace):
+            namespaces.add(namespace)
+    return namespaces
+
+
+def _is_default_deny_network_policy(doc: dict) -> bool:
+    spec = doc.get("spec")
+    if not isinstance(spec, dict):
+        return False
+    policy_types = spec.get("policyTypes")
+    if not isinstance(policy_types, list):
+        return False
+    if not {"Ingress", "Egress"}.issubset(set(policy_types)):
+        return False
+    if spec.get("podSelector") != {}:
+        return False
+    ingress = spec.get("ingress", [])
+    egress = spec.get("egress", [])
+    return ingress == [] and egress == []
+
+
+def _network_policy_name(doc: dict) -> str:
+    metadata = doc.get("metadata")
+    if isinstance(metadata, dict) and isinstance(metadata.get("name"), str):
+        return metadata["name"]
+    return "<unnamed>"
+
+
+def _shifter_network_policy_docs(docs: list[object]) -> list[tuple[dict, str]]:
+    policies: list[tuple[dict, str]] = []
+    for doc in docs:
+        if not isinstance(doc, dict) or doc.get("kind") != "NetworkPolicy":
+            continue
+        namespace = _document_namespace(doc)
+        if not _is_shifter_namespace(namespace):
+            continue
+        policies.append((doc, namespace))
+    return policies
+
+
+def _default_deny_network_policy_namespaces(
+    policies: list[tuple[dict, str]],
+) -> set[str]:
+    return {
+        namespace
+        for doc, namespace in policies
+        if _is_default_deny_network_policy(doc)
+    }
+
+
+def _iter_egress_destinations(doc: dict) -> list[tuple[int, object]]:
+    spec = doc.get("spec")
+    if not isinstance(spec, dict):
+        return []
+    egress_rules = spec.get("egress", [])
+    if not isinstance(egress_rules, list):
+        return []
+
+    destinations: list[tuple[int, object]] = []
+    for rule_index, rule in enumerate(egress_rules):
+        if not isinstance(rule, dict) or not isinstance(rule.get("to"), list):
+            continue
+        destinations.extend((rule_index, destination) for destination in rule["to"])
+    return destinations
+
+
+def _destination_ip_block_cidr(destination: object) -> object:
+    if not isinstance(destination, dict):
+        return None
+    ip_block = destination.get("ipBlock")
+    if not isinstance(ip_block, dict):
+        return None
+    return ip_block.get("cidr")
+
+
+def _broad_egress_network_policy_violations(
+    policies: list[tuple[dict, str]], rel: str
+) -> list[Violation]:
+    violations: list[Violation] = []
+    broad_cidrs = {"0.0.0.0/0", "::/0"}
+    for doc, namespace in policies:
+        for rule_index, destination in _iter_egress_destinations(doc):
+            cidr = _destination_ip_block_cidr(destination)
+            if cidr not in broad_cidrs:
+                continue
+            violations.append(
+                _network_policy_violation(
+                    rel,
+                    f"NetworkPolicy {namespace}/{_network_policy_name(doc)} "
+                    f"egress rule {rule_index} allows broad CIDR {cidr}; "
+                    "ADR-006-R3 requires explicit service ranges",
+                )
+            )
+    return violations
+
+
+def _missing_default_deny_network_policy_violations(
+    namespaces: set[str], default_deny_namespaces: set[str], rel: str
+) -> list[Violation]:
+    return [
+        _network_policy_violation(
+            rel,
+            f"namespace {namespace} lacks a default-deny NetworkPolicy "
+            "covering both ingress and egress",
+        )
+        for namespace in sorted(namespaces - default_deny_namespaces)
+    ]
+
+
+def _validate_network_policy_documents(
+    docs: list[object], rel: str
+) -> list[Violation]:
+    namespaces = _collect_shifter_namespaces(docs)
+    policies = _shifter_network_policy_docs(docs)
+    default_deny_namespaces = _default_deny_network_policy_namespaces(policies)
+    return [
+        *_broad_egress_network_policy_violations(policies, rel),
+        *_missing_default_deny_network_policy_violations(
+            namespaces, default_deny_namespaces, rel
+        ),
+    ]
+
+
+def _validate_network_policy_base_files(
+    repo_root: Path, base_files: list[Path]
+) -> list[Violation]:
+    violations: list[Violation] = []
+    docs: list[object] = []
+    for path in base_files:
+        rel = _repo_relative(path, repo_root)
+        parsed, parse_violations = _iter_yaml_documents(
+            path.read_text(encoding="utf-8"), rel
+        )
+        docs.extend(parsed)
+        violations.extend(_as_network_policy_violations(parse_violations))
+    if base_files:
+        violations.extend(
+            _validate_network_policy_documents(docs, K8S_BASE_DEPLOYMENT_DIR)
+        )
+    return violations
+
+
+def _validate_network_policy_chart_renders(repo_root: Path) -> list[Violation]:
+    violations: list[Violation] = []
+    rendered, render_violations = _render_chart_for_validation(
+        repo_root, HELM_VALUES_FILES
+    )
+    violations.extend(_as_network_policy_violations(render_violations))
+    for docs, label in rendered:
+        violations.extend(_validate_network_policy_documents(docs, label))
+    return violations
+
+
 def check_k8s_deployment_security_context(
     repo_root: Path, files: list[str] | None
 ) -> list[Violation]:
@@ -1203,6 +1401,22 @@ def check_k8s_deployment_security_context(
         violations.extend(_validate_base_files(repo_root, base_files))
     if scan_chart:
         violations.extend(_validate_chart_renders(repo_root))
+    return violations
+
+
+def check_k8s_network_policy_coverage(
+    repo_root: Path, files: list[str] | None
+) -> list[Violation]:
+    """Verify Shifter namespaces are isolated by default-deny NetworkPolicies."""
+    scan_base, scan_chart, base_files = _scan_targets(repo_root, files)
+    if not (scan_base or scan_chart):
+        return []
+
+    violations: list[Violation] = []
+    if scan_base:
+        violations.extend(_validate_network_policy_base_files(repo_root, base_files))
+    if scan_chart:
+        violations.extend(_validate_network_policy_chart_renders(repo_root))
     return violations
 
 
@@ -1576,6 +1790,7 @@ CHECKS = {
     "cloud-factory-seam": check_cloud_factory_seam,
     "mcp-no-shell-exec": check_mcp_no_shell_exec,
     "k8s-deployment-security-context": check_k8s_deployment_security_context,
+    "k8s-network-policy-coverage": check_k8s_network_policy_coverage,
     "no-plaintext-secrets-in-tfvars": check_no_plaintext_secrets_in_tfvars,
 }
 CHECK_LEVELS = {
@@ -1595,6 +1810,7 @@ CHECK_LEVELS = {
         "cloud-factory-seam",
         "mcp-no-shell-exec",
         "k8s-deployment-security-context",
+        "k8s-network-policy-coverage",
         "no-plaintext-secrets-in-tfvars",
     ],
     "all": list(CHECKS),

--- a/scripts/adr_guard/tests/test_adr_guard.py
+++ b/scripts/adr_guard/tests/test_adr_guard.py
@@ -1241,6 +1241,112 @@ class K8sDeploymentSecurityContextTests(unittest.TestCase):
             self.assertTrue(any("runAsGroup" in v.message for v in violations))
 
 
+class K8sNetworkPolicyCoverageTests(unittest.TestCase):
+    """Tests for the k8s-network-policy-coverage ADR-006-R3 check."""
+
+    NAMESPACES = (
+        "apiVersion: v1\n"
+        "kind: Namespace\n"
+        "metadata:\n"
+        "  name: shifter-platform\n"
+        "---\n"
+        "apiVersion: v1\n"
+        "kind: Namespace\n"
+        "metadata:\n"
+        "  name: shifter-jobs\n"
+    )
+
+    DEFAULT_DENY_PLATFORM = (
+        "apiVersion: networking.k8s.io/v1\n"
+        "kind: NetworkPolicy\n"
+        "metadata:\n"
+        "  name: default-deny\n"
+        "  namespace: shifter-platform\n"
+        "spec:\n"
+        "  podSelector: {}\n"
+        "  policyTypes:\n"
+        "    - Ingress\n"
+        "    - Egress\n"
+        "  ingress: []\n"
+        "  egress: []\n"
+    )
+
+    DEFAULT_DENY_JOBS = DEFAULT_DENY_PLATFORM.replace(
+        "namespace: shifter-platform", "namespace: shifter-jobs"
+    )
+
+    def _write(self, repo_root: Path, rel: str, body: str) -> None:
+        path = repo_root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body, encoding="utf-8")
+
+    def _run(self, repo_root: Path, files: list[str] | None = None) -> list:
+        if files is None:
+            base = repo_root / ADR_GUARD.K8S_BASE_DEPLOYMENT_DIR
+            files = sorted(
+                ADR_GUARD._repo_relative(p, repo_root)
+                for p in list(base.rglob("*.yaml")) + list(base.rglob("*.yml"))
+            )
+        return ADR_GUARD.check_k8s_network_policy_coverage(repo_root, files)
+
+    def test_each_namespace_requires_default_deny_network_policy(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            self._write(repo_root, "platform/k8s/gcp/base/namespaces.yaml", self.NAMESPACES)
+            self._write(
+                repo_root,
+                "platform/k8s/gcp/base/networkpolicies.yaml",
+                self.DEFAULT_DENY_PLATFORM,
+            )
+
+            violations = self._run(repo_root)
+
+            self.assertTrue(any("shifter-jobs" in v.message for v in violations))
+            self.assertTrue(all(v.rule_id == "ADR-006-R3" for v in violations))
+
+    def test_default_deny_network_policy_coverage_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            self._write(repo_root, "platform/k8s/gcp/base/namespaces.yaml", self.NAMESPACES)
+            self._write(
+                repo_root,
+                "platform/k8s/gcp/base/networkpolicies.yaml",
+                self.DEFAULT_DENY_PLATFORM + "---\n" + self.DEFAULT_DENY_JOBS,
+            )
+
+            self.assertEqual(self._run(repo_root), [])
+
+    def test_broad_egress_ip_block_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            broad_allow = (
+                self.DEFAULT_DENY_PLATFORM
+                + "---\n"
+                + "apiVersion: networking.k8s.io/v1\n"
+                + "kind: NetworkPolicy\n"
+                + "metadata:\n"
+                + "  name: broad-egress\n"
+                + "  namespace: shifter-platform\n"
+                + "spec:\n"
+                + "  podSelector: {}\n"
+                + "  policyTypes: [Egress]\n"
+                + "  egress:\n"
+                + "    - to:\n"
+                + "        - ipBlock:\n"
+                + "            cidr: 0.0.0.0/0\n"
+            )
+            self._write(repo_root, "platform/k8s/gcp/base/namespaces.yaml", self.NAMESPACES)
+            self._write(
+                repo_root,
+                "platform/k8s/gcp/base/networkpolicies.yaml",
+                broad_allow + "---\n" + self.DEFAULT_DENY_JOBS,
+            )
+
+            violations = self._run(repo_root)
+
+            self.assertTrue(any("0.0.0.0/0" in v.message for v in violations))
+
+
 class K8sDeploymentSecurityContextRobustnessTests(unittest.TestCase):
     """Cycle-3 robustness coverage: PyYAML-backed parsing, kind-based filtering,
     pod-level inheritance, multi-document files, and unsupported shapes."""

--- a/scripts/bootstrap/deploy.py
+++ b/scripts/bootstrap/deploy.py
@@ -20,6 +20,7 @@ Usage:
 import argparse
 import getpass
 import importlib.util
+import ipaddress
 import json
 import os
 import re
@@ -1726,6 +1727,36 @@ def _merge_csv_env_values(*groups: list[str]) -> str:
     return ",".join(ordered)
 
 
+def _unique_nonempty_strings(values: list[str | None]) -> list[str]:
+    """Return non-empty strings in first-seen order."""
+    ordered: list[str] = []
+    seen: set[str] = set()
+    for raw_value in values:
+        value = (raw_value or "").strip()
+        if not value or value in seen:
+            continue
+        seen.add(value)
+        ordered.append(value)
+    return ordered
+
+
+def _host_as_single_address_cidr(value: object) -> str | None:
+    """Convert a Terraform host/IP output into a /32 or /128 CIDR."""
+    if value is None:
+        return None
+    host = str(value).strip()
+    if not host:
+        return None
+    if "/" in host:
+        return host
+    try:
+        address = ipaddress.ip_address(host)
+    except ValueError as exc:
+        raise ValueError(f"Expected IP address Terraform output, got {host!r}") from exc
+    prefix = 32 if address.version == 4 else 128
+    return f"{address}/{prefix}"
+
+
 def render_gcp_platform_runtime_env(
     config: GDCBootstrapConfig,
     *,
@@ -1995,6 +2026,17 @@ def render_gcp_helm_values(
         **parse_env_contract(runtime_renderer.render_env(outputs, secure_portal_mode=True)),
     }
     edge_policy_name = str(_get_output_value(outputs, "cloud_armor_security_policy_name")).strip()
+    control_plane_database = _get_output_value(outputs, "control_plane_database")
+    control_plane_cache = _get_output_value(outputs, "control_plane_cache")
+    guacamole_database = _get_output_value(outputs, "guacamole_database")
+    private_service_cidrs = _unique_nonempty_strings(
+        [
+            _host_as_single_address_cidr(control_plane_database.get("private_ip")),
+            _host_as_single_address_cidr(control_plane_cache.get("host")),
+            _host_as_single_address_cidr(guacamole_database.get("host")),
+            str(_get_output_value(outputs, "gke_services_cidr")).strip(),
+        ]
+    )
 
     return {
         "releaseNamespace": "shifter-system",
@@ -2068,6 +2110,18 @@ def render_gcp_helm_values(
                     "securityPolicyName": edge_policy_name,
                 }
             },
+        },
+        "networkPolicy": {
+            "enabled": True,
+            "gclbSourceRanges": [
+                "35.191.0.0/16",  # NOSONAR - Google Cloud Load Balancer health check/proxy range.
+                "130.211.0.0/22",  # NOSONAR - Google Cloud Load Balancer health check/proxy range.
+            ],
+            "googleApiCidrs": [
+                "199.36.153.4/30",  # NOSONAR - restricted.googleapis.com VIP range.
+                "199.36.153.8/30",  # NOSONAR - private.googleapis.com VIP range.
+            ],
+            "privateServiceCidrs": private_service_cidrs,
         },
     }
 

--- a/scripts/bootstrap/tests/test_deploy.py
+++ b/scripts/bootstrap/tests/test_deploy.py
@@ -93,6 +93,7 @@ def _sample_gcp_control_plane_outputs(project_id: str = "prod-rwctxzl6shxk") -> 
         "range_network_cidr": {"value": "10.50.0.0/16"},
         "range_network_region": {"value": "us-central1"},
         "portal_network_cidrs": {"value": ["10.40.0.0/20", "10.44.0.0/16"]},
+        "gke_services_cidr": {"value": "10.48.0.0/20"},
         "workload_service_accounts": {
             "value": {
                 "portal": f"shiftergcpdev-portal@{project_id}.iam.gserviceaccount.com",
@@ -1496,6 +1497,18 @@ class TestGdcControlPlaneHelmValues:
         assert values["services"]["guacamoleClient"]["backendConfig"]["enabled"] is True
         assert values["services"]["guacamoleClient"]["backendConfig"]["name"] == "guacamole-client"
         assert values["services"]["guacamoleClient"]["backendConfig"]["securityPolicyName"] == "shifter-gcp-dev-edge"
+        assert values["networkPolicy"] == {
+            "enabled": True,
+            "gclbSourceRanges": [
+                "35.191.0.0/16",  # NOSONAR - Google Cloud Load Balancer range.
+                "130.211.0.0/22",  # NOSONAR - Google Cloud Load Balancer range.
+            ],
+            "googleApiCidrs": [
+                "199.36.153.4/30",  # NOSONAR - restricted.googleapis.com VIP.
+                "199.36.153.8/30",  # NOSONAR - private.googleapis.com VIP.
+            ],
+            "privateServiceCidrs": ["10.40.0.10/32", "10.40.0.20/32", "10.48.0.0/20"],
+        }
 
     def test_rejects_insecure_public_bootstrap_values(self):
         """The Helm values renderer must refuse public bare-IP debug deployments on GCP."""
@@ -1570,6 +1583,11 @@ class TestGdcControlPlaneHelmChart:
         assert "runAsGroup: 1001" in output
         assert "kind: Namespace" not in output
         assert "kind: BackendConfig" in output
+        assert "kind: NetworkPolicy" in output
+        assert "name: default-deny-platform" in output
+        assert "name: default-deny-jobs" in output
+        assert "199.36.153.4/30" in output
+        assert "10.40.0.10/32" in output
         assert 'requestPath: "/health/"' in output
         assert "securityPolicy:" in output
         assert "name: shifter-gcp-dev-edge" in output

--- a/shifter/shifter_platform/documentation/docs/technical/dev/adr-enforcement.md
+++ b/shifter/shifter_platform/documentation/docs/technical/dev/adr-enforcement.md
@@ -179,6 +179,18 @@ The first slice intentionally stays small:
   stays under SonarCloud's cognitive-complexity threshold and tests
   can target each clause independently.
 
+- `k8s-network-policy-coverage`
+  Enforces ADR-006-R3 against the base manifest snapshots under
+  `platform/k8s/gcp/base/` and the rendered Helm chart output for
+  each supported values file. Every Shifter namespace discovered in
+  those manifests must have a default-deny `NetworkPolicy` with an
+  empty pod selector and both `Ingress` and `Egress` policy types.
+  The check also rejects broad egress `ipBlock` CIDRs (`0.0.0.0/0`
+  and `::/0`) in Shifter NetworkPolicies, forcing policies to use
+  explicit GCLB, Google API, private service, and in-cluster service
+  ranges. Runs in the `ci` level and shares the Helm-rendered
+  validation boundary with `k8s-deployment-security-context`.
+
 - `no-plaintext-secrets-in-tfvars`
   Architecture check that scans `*.tfvars` files committed under
   `platform/terraform/environments/` and flags any line that assigns a


### PR DESCRIPTION
## Summary
- Add default-deny NetworkPolicies for `shifter-platform` and `shifter-jobs` in the Helm chart and GCP base snapshots.
- Allow only explicit traffic paths for GCLB ingress, DNS, Guacamole-to-guacd, Google API egress, and generated private service CIDRs.
- Enforce ADR-006-R3 with a new ADR guard check and remove the temporary NetworkPolicy exception.

Closes #958

## Validation
- `python3 scripts/adr_guard/adr_guard.py --all --level ci`
- `kube-linter lint --config .kube-linter.yaml platform/k8s/`
- `kubeconform -strict -summary -ignore-missing-schemas -kubernetes-version 1.31.0 platform/k8s/gcp/base/*.yaml`
- `actionlint`
- `tflint --recursive --config /home/atomik/src/shifter-codex/.tflint.hcl`
- `helm lint platform/charts/shifter -f platform/charts/shifter/values-gcp-dev.yaml`
- `helm lint platform/charts/shifter -f platform/charts/shifter/values-gcp-prod.yaml`
- pre-commit hook suite on commit