### PR TITLE
Lock GKE control-plane allowlist with parsed-prefix validation (#957)

### DIFF
--- a/changelog.d/957.security.md
+++ b/changelog.d/957.security.md
@@ -1,0 +1,24 @@
+**GKE authorized-networks allowlist is now fail-closed at the Terraform layer,
+and both gates enforce the same parsed-prefix contract.** `gke_master_authorized_cidrs`
+in `platform/terraform/gcp/modules/platform-core/variables.tf` loses its
+`default = []` and gains a `validation` block expressing a four-part contract
+from the parsed prefix: the list is non-empty; every entry has an explicit
+`/N` suffix (no bare IPs); every entry parses as a CIDR (no garbage, bad
+octets, or bad prefixes); and the parsed prefix length is `> 0` (every
+spelling of `/0`, IPv4 or IPv6, is rejected by prefix number, not by
+string-suffix matching). So `terraform plan` / `terraform apply` /
+`terraform test` fail with a clear error otherwise, including a direct apply
+that bypasses the bootstrap preflight. `scripts/bootstrap/deploy.py`'s
+`validate_gcp_control_plane_security_inputs` is tightened to enforce the
+same four-part contract (`"/" in cidr`, `ipaddress.ip_network(..., strict=False)`,
+`network.prefixlen > 0`), so the two gates stay in lockstep. Coverage in
+`scripts/bootstrap/tests/test_deploy.py::TestGcpControlPlaneSecurityInputs`
+expands to the unsafe inputs both gates reject (bare IPs, garbage with and
+without slashes, bad octets/prefixes, IPv4 `/0`, IPv6 `/0`, mixed lists). The
+cluster runs with `enable_private_endpoint = false`, so
+`master_authorized_networks_config` is the only network-level restriction on
+the public Kubernetes API server; an empty, malformed, or world-open list
+would expose it to the entire internet. Recorded the design and the
+private-endpoint boundary in
+`docs/architecture/gke-control-plane-access-preflight.md` (listed as ADR-008
+evidence).

--- a/docs/adr/index.yaml
+++ b/docs/adr/index.yaml
@@ -263,7 +263,8 @@
       "platform/charts/shifter/templates/guacamole-backendconfig.yaml",
       "platform/terraform/gcp/README.md",
       "platform/k8s/gcp/README.md",
-      "shifter/shifter_platform/documentation/docs/technical/platform_infrastructure/networking.md"
+      "shifter/shifter_platform/documentation/docs/technical/platform_infrastructure/networking.md",
+      "docs/architecture/gke-control-plane-access-preflight.md"
     ]
   },
   {

--- a/docs/architecture/gke-control-plane-access-preflight.md
+++ b/docs/architecture/gke-control-plane-access-preflight.md
@@ -1,0 +1,165 @@
+# GKE Control-Plane Access Preflight
+
+Issue: GitHub #957, "[HIGH] GKE control plane publicly accessible with no IP
+allowlist" (a duplicate of the implemented #952).
+
+This note records the control-plane-access design and the boundary for the
+future private-endpoint change. It does not introduce a new platform
+abstraction; it documents the existing one so a later change in this area
+stays inside it.
+
+## Decision
+
+The GCP control plane keeps the public GKE API endpoint only while it is
+constrained by `master_authorized_networks_config`. The canonical input is
+`gke_master_authorized_cidrs`, wired from the environment root into
+`platform-core`. The insecure-allowlist footgun is closed at two layers,
+both fail-closed and enforcing the same contract from the **parsed** prefix —
+not from string-suffix matching that could miss alternate spellings:
+
+1. The list must be non-empty.
+2. Every entry must carry an explicit `/N` suffix (no bare IPs).
+3. Every entry must parse as a CIDR (rejects garbage, bad octets, bad
+   prefixes).
+4. The parsed prefix length must be `> 0` (rejects every spelling of `/0`,
+   IPv4 or IPv6, from the parsed prefix number).
+
+- **Terraform layer** — `gke_master_authorized_cidrs` in
+  `platform/terraform/gcp/modules/platform-core/variables.tf` has no default
+  and a `validation` block expressing the four-part contract above
+  (`length(...) > 0` + per-entry `cidrhost(cidr, 0)` for parse-validity,
+  `regex("/[0-9]+$", cidr)` for explicit suffix, and
+  `tonumber(regex("/([0-9]+)$", cidr)[0]) > 0` for the parsed prefix). So
+  `terraform plan` / `terraform apply` / `terraform test` fail with a clear
+  error otherwise — including a direct apply that does not run bootstrap. The
+  cluster runs with `enable_private_endpoint = false`, so this allowlist is
+  the only network-level restriction on the public API server, hence it is
+  mandatory.
+- **Bootstrap layer** — `scripts/bootstrap/deploy.py`'s
+  `validate_gcp_control_plane_security_inputs` enforces the same four-part
+  contract (`"/" in cidr`, then `ipaddress.ip_network(cidr, strict=False)`,
+  then `network.prefixlen > 0`) before it ever reaches `terraform apply`,
+  catching the misconfiguration earlier with an operator-facing message.
+  Covered by
+  `scripts/bootstrap/tests/test_deploy.py::TestGcpControlPlaneSecurityInputs`.
+
+The long-term private-endpoint option remains valid, but it is a separate
+design change because bootstrap, CI deploys, `get-gke-credentials`, Helm,
+kubectl, and operator access would all need a private network path such as
+VPN, bastion, IAP-accessible runner placement, or equivalent. Such a change
+must flip `enable_private_endpoint` and relax the `gke_master_authorized_cidrs`
+validation together.
+
+## Canonical Incumbents
+
+- `platform/terraform/gcp/environments/gcp-dev/variables.tf`: environment
+  input contract for `gke_master_authorized_cidrs`.
+- `platform/terraform/gcp/environments/gcp-dev/main.tf`: passes the
+  environment input into `module.platform_core`.
+- `platform/terraform/gcp/modules/platform-core/variables.tf`: module input
+  contract for authorized admin CIDRs, including the non-empty `validation`
+  block (the Terraform-layer fail-closed gate).
+- `platform/terraform/gcp/modules/platform-core/main.tf`: owns the
+  `google_container_cluster.platform` resource and the
+  `master_authorized_networks_config` rendering.
+- `scripts/bootstrap/deploy.py`: bootstrap preflight gate via
+  `validate_gcp_control_plane_security_inputs`.
+- `scripts/bootstrap/tests/test_deploy.py`: regression tests for security
+  input parsing and fail-closed behavior
+  (`TestGcpControlPlaneSecurityInputs`).
+- `docs/adr/index.yaml` `ADR-008`: accepted repo policy for GCP bootstrap
+  fail-closed behavior and authorized admin CIDRs (this note is listed as
+  ADR-008 evidence).
+- `platform/terraform/gcp/README.md`: operator-facing GCP Terraform contract.
+
+## Cross-Cutting Layers
+
+Security layers any change in this area must satisfy:
+
+- Terraform input shape: `gke_master_authorized_cidrs` stays a `list(string)`
+  and is passed through the environment root instead of hardcoded in the
+  module.
+- Terraform input validation: the module variable has no default and a
+  `validation` block requiring a non-empty list of valid CIDRs with no `/0`
+  global range; do not reintroduce a default or weaken the validation while
+  the endpoint is public.
+- Terraform resource policy: `google_container_cluster.platform` renders
+  `master_authorized_networks_config` whenever the CIDR list is non-empty.
+- Bootstrap policy gate: `validate_gcp_control_plane_security_inputs` rejects
+  an empty list, malformed CIDR entries, and `/0` ranges before Terraform
+  apply — the same contract the Terraform `validation` block enforces.
+- CI workflow path: `.github/workflows/_gcp-dev.yml` continues to run
+  Terraform validation and deploys from the same environment root consumed by
+  bootstrap.
+- Secret handling: CIDR allowlists are not secrets and must not be routed
+  through Secret Manager, GitHub secrets, kube manifests, or runtime env
+  files.
+- OS/process exposure: if a future workflow supplies CIDRs dynamically, avoid
+  embedding credentials or tokens in process argv; CIDRs themselves may be
+  Terraform variables, but authentication remains in the existing GCP auth
+  path.
+- Error handling: fail through the existing bootstrap `error(...)` plus
+  `sys.exit(1)` path and Terraform variable-validation errors, without
+  creating a new exception hierarchy.
+- Observability: rely on Terraform plan/apply diffs and bootstrap error text;
+  do not add runtime application logging for control-plane network policy.
+
+## Extensibility Seam
+
+The seam is the environment-level `gke_master_authorized_cidrs` value. Future
+changes should extend that parameter, not duplicate the cluster resource or
+add parallel variables. Reasonable future sources include CI runner egress
+CIDRs, office/VPN CIDRs, NAT gateway public IPs, or a switch to a private
+endpoint with corresponding private runner/operator reachability.
+
+## Non-Goals
+
+- Do not convert the cluster to `enable_private_endpoint = true` unless the
+  change also designs and validates the private access path for bootstrap,
+  CI, Helm, and kubectl, and relaxes the `gke_master_authorized_cidrs`
+  validation in the same change.
+- Do not add a second GKE module, wrapper schema, validation framework, or
+  duplicate Terraform variable for the same allowlist.
+- Do not weaken TLS, Cloud Armor, IAP, Workload Identity, Terraform state, or
+  Secret Manager controls while changing control-plane access.
+- Do not put operator-specific, stale, or overly broad CIDRs into a shared
+  module default (the module has no default; CIDRs live in environment
+  `terraform.tfvars`).
+- Do not use `0.0.0.0/0` / `::/0` as a convenience allowlist — both the
+  Terraform `validation` block and the bootstrap preflight reject `/0` ranges;
+  keep entries scoped to specific admin networks (and avoid broad
+  cloud-provider ranges even though they are not literally `/0`).
+
+## Validation
+
+Run the repo-required checks for whatever this area's change touches:
+
+- Always (ADR registry / guardrail discipline):
+
+  ```bash
+  python3 scripts/adr_guard/adr_guard.py --all --level ci
+  ```
+
+- Terraform changes under `platform/terraform/`:
+
+  ```bash
+  cd platform/terraform && tflint --recursive --config ../../.tflint.hcl
+  # plus the native validation CI runs from the environment root, e.g.:
+  cd platform/terraform/gcp/environments/gcp-dev && terraform init -backend=false && terraform validate
+  ```
+
+- GitHub Actions workflow changes under `.github/workflows/`:
+
+  ```bash
+  actionlint
+  ```
+
+- Bootstrap changes (`scripts/bootstrap/deploy.py` or its tests):
+
+  ```bash
+  python3 -m pytest scripts/bootstrap/tests/test_deploy.py -k GcpControlPlaneSecurityInputs
+  ```
+
+- Any other touched subsystem also runs its stack-native checks (e.g.
+  `ruff` / `mypy` for `shifter_platform` Python, `kube-linter` / `kubeconform`
+  for `platform/k8s/`, `pre-commit run --all-files` for the full set).

--- a/platform/terraform/gcp/modules/platform-core/variables.tf
+++ b/platform/terraform/gcp/modules/platform-core/variables.tf
@@ -45,9 +45,28 @@ variable "gke_master_ipv4_cidr" {
 }
 
 variable "gke_master_authorized_cidrs" {
-  description = "CIDR blocks allowed to access the public GKE control-plane endpoint."
+  description = "CIDR blocks allowed to reach the public GKE control-plane endpoint. Required: the cluster runs with enable_private_endpoint = false, so master_authorized_networks_config is the only network-level restriction on the public Kubernetes API server (ADR-008; docs/architecture/gke-control-plane-access-preflight.md). The environment root must supply at least one CIDR."
   type        = list(string)
-  default     = []
+
+  # Fail closed: an empty, malformed, or world-open (/0) allowlist would expose
+  # the public API server to the entire internet. This is the Terraform-layer
+  # backstop for the bootstrap preflight
+  # (scripts/bootstrap/deploy.py::validate_gcp_control_plane_security_inputs);
+  # both gates express the same contract from the parsed prefix:
+  #   1. cidrhost(cidr, 0) — entry parses as a CIDR (rejects bare IPs, garbage,
+  #      bad octets, bad prefixes).
+  #   2. an explicit /N suffix is present.
+  #   3. the parsed prefix length is > 0 (so /0 is rejected from the prefix
+  #      number, not by string-suffix matching against one spelling).
+  validation {
+    condition = length(var.gke_master_authorized_cidrs) > 0 && alltrue([
+      for cidr in var.gke_master_authorized_cidrs :
+      can(cidrhost(cidr, 0))
+      && can(regex("/[0-9]+$", cidr))
+      && tonumber(regex("/([0-9]+)$", cidr)[0]) > 0
+    ])
+    error_message = "gke_master_authorized_cidrs must contain at least one CIDR; every entry must be a valid CIDR with an explicit /N suffix (e.g. 203.0.113.10/32), and no entry may be a /0 (world-open) range. The GKE control-plane endpoint is public (enable_private_endpoint = false), so an empty or world-open allowlist would expose the Kubernetes API server to the entire internet. Set it from the environment root (see ADR-008 and docs/architecture/gke-control-plane-access-preflight.md); if a private endpoint is intended, change enable_private_endpoint and relax this rule together."
+  }
 }
 
 variable "range_network_cidr" {

--- a/scripts/bootstrap/deploy.py
+++ b/scripts/bootstrap/deploy.py
@@ -637,11 +637,35 @@ def validate_gcp_control_plane_security_inputs(tf_dir: Path) -> None:
             "GCP bootstrap requires managed TLS for the public ingress. "
             "Set enable_managed_tls = true in terraform.tfvars."
         )
-    if not settings["gke_master_authorized_cidrs"]:
+    authorized_cidrs = settings["gke_master_authorized_cidrs"]
+    if not authorized_cidrs:
         raise ValueError(
             "GCP bootstrap requires gke_master_authorized_cidrs so the public GKE control-plane endpoint "
             "is restricted to admin networks."
         )
+    # Same contract the Terraform variable validation enforces (see
+    # platform/terraform/gcp/modules/platform-core/variables.tf::gke_master_authorized_cidrs):
+    #   1. an explicit "/N" suffix is present (rejects bare IPs).
+    #   2. the entry parses as a CIDR (rejects garbage / bad octets / bad prefixes).
+    #   3. the parsed prefix length is > 0 (rejects /0 from the parsed prefix
+    #      number, not from a string-suffix check).
+    for cidr in authorized_cidrs:
+        if "/" not in cidr:
+            raise ValueError(
+                f"GCP bootstrap rejected gke_master_authorized_cidrs entry {cidr!r}: must include an "
+                "explicit /N prefix (e.g. 203.0.113.10/32)."
+            )
+        try:
+            network = ipaddress.ip_network(cidr, strict=False)
+        except ValueError as exc:
+            raise ValueError(
+                f"GCP bootstrap rejected gke_master_authorized_cidrs entry {cidr!r}: not a valid CIDR ({exc})."
+            ) from exc
+        if network.prefixlen == 0:
+            raise ValueError(
+                f"GCP bootstrap rejected gke_master_authorized_cidrs entry {cidr!r}: a /0 range opens the "
+                "public GKE control-plane endpoint to the entire internet. List specific admin networks instead."
+            )
 
 
 def get_default_gdc_project_id() -> str:

--- a/scripts/bootstrap/tests/test_deploy.py
+++ b/scripts/bootstrap/tests/test_deploy.py
@@ -1098,6 +1098,66 @@ gke_master_authorized_cidrs = []
         with pytest.raises(ValueError, match="public hostname"):
             deploy.validate_gcp_control_plane_security_inputs(tf_dir)
 
+    @staticmethod
+    def _write_secure_tfvars(tf_dir, cidrs):
+        """Write a terraform.tfvars whose hostname/TLS pass, so a test isolates the CIDR allowlist check."""
+        tf_dir.mkdir()
+        cidr_lines = "".join(f'  "{cidr}",\n' for cidr in cidrs)
+        (tf_dir / "terraform.tfvars").write_text(
+            'public_hostname = "portal.example.test"\n'
+            "enable_managed_tls = true\n"
+            f"gke_master_authorized_cidrs = [\n{cidr_lines}]\n"
+        )
+
+    @pytest.mark.parametrize(
+        ("cidrs", "expected_match"),
+        [
+            # The same contract the Terraform `validation` block on
+            # `gke_master_authorized_cidrs` enforces — keep these in lockstep.
+            (["0.0.0.0/0"], r"/0 range"),
+            (["::/0"], r"/0 range"),
+            (["198.51.100.0/24", "0.0.0.0/0"], r"/0 range"),
+            (["203.0.113.10"], r"explicit /N prefix"),
+            (["not-a-cidr"], r"explicit /N prefix"),
+            (["not/a/cidr"], r"not a valid CIDR"),
+            (["198.51.100.999/32"], r"not a valid CIDR"),
+            (["198.51.100.0/33"], r"not a valid CIDR"),
+        ],
+        ids=[
+            "ipv4_world_open",
+            "ipv6_world_open",
+            "mixed_with_world_open",
+            "bare_ip_no_prefix",
+            "no_prefix_garbage",
+            "garbage_with_slashes",
+            "bad_octet",
+            "bad_prefix",
+        ],
+    )
+    def test_validate_security_inputs_rejects_unsafe_authorized_cidrs(self, tmp_path, cidrs, expected_match):
+        """Bootstrap must reject malformed CIDR entries and world-open /0 ranges in the admin allowlist."""
+        tf_dir = tmp_path / "gcp-dev"
+        self._write_secure_tfvars(tf_dir, cidrs)
+
+        with pytest.raises(ValueError, match=expected_match):
+            deploy.validate_gcp_control_plane_security_inputs(tf_dir)
+
+    def test_validate_security_inputs_accepts_specific_admin_cidrs(self, tmp_path):
+        """A non-empty allowlist of specific, well-formed v4/v6 CIDRs passes the preflight.
+
+        The validator is a side-effect-only contract (raise on bad input, return
+        None on good input), so the assertions cover both halves: the documented
+        None return and a round-trip parse that proves the test fixture's input
+        was actually consumed (so a future refactor that silently skipped the
+        CIDR loop would still be caught here, not just by the negative cases).
+        """
+        tf_dir = tmp_path / "gcp-dev"
+        cidrs = ["198.51.100.10/32", "203.0.113.0/24", "2001:db8::/48"]
+        self._write_secure_tfvars(tf_dir, cidrs)
+
+        assert deploy.validate_gcp_control_plane_security_inputs(tf_dir) is None
+        assert deploy.read_gcp_control_plane_security_inputs(tf_dir)["gke_master_authorized_cidrs"] == cidrs
+
 
 class TestGdcTerraformBootstrapCredentials:
     """Tests for the ephemeral Terraform credential path used by GCP bootstrap."""


### PR DESCRIPTION
## Summary

Closes the residual Terraform-layer gap left by #952's fix for #957 (originally reported as a GKE public-control-plane HIGH): the bootstrap preflight in `scripts/bootstrap/deploy.py` was the only thing keeping `gke_master_authorized_cidrs` non-empty, so a direct `terraform apply` outside bootstrap could still create a public GKE control plane with no allowlist (or a `0.0.0.0/0` one). This PR makes the Terraform variable itself fail-closed, and brings the bootstrap gate into byte-for-byte lockstep, so both layers enforce the same parsed-prefix contract.

## What changed

**Both gates enforce the same four-part contract — all from the *parsed* prefix, not from string-suffix matching:**

1. The list must be non-empty.
2. Every entry must carry an explicit `/N` suffix (no bare IPs).
3. Every entry must parse as a CIDR (rejects garbage, bad octets, bad prefixes).
4. The parsed prefix length must be `> 0` (rejects every spelling of `/0`, IPv4 or IPv6, by prefix number).

- **`platform/terraform/gcp/modules/platform-core/variables.tf`** — `gke_master_authorized_cidrs` loses `default = []` and gains a `validation` block: `length(...) > 0 && alltrue([for cidr in ... : can(cidrhost(cidr, 0)) && can(regex("/[0-9]+$", cidr)) && tonumber(regex("/([0-9]+)$", cidr)[0]) > 0])`. `terraform plan` / `apply` / `test` now fails with a clear error on empty, malformed, or world-open input. Verified against IPv4 `/0`, IPv6 `/0`, `/00`-style spellings, bare IPs, garbage, bad octets/prefixes via a scratch terraform.
- **`scripts/bootstrap/deploy.py::validate_gcp_control_plane_security_inputs`** — same contract: `"/" in cidr` → `ipaddress.ip_network(cidr, strict=False)` → `network.prefixlen > 0`. Fail messages are operator-facing and identify the offending entry by `repr`.
- **`scripts/bootstrap/tests/test_deploy.py::TestGcpControlPlaneSecurityInputs`** — parametrized regression coverage for IPv4 `/0`, IPv6 `/0`, mixed-with-`/0`, bare IP, no-slash garbage, slashed garbage, bad octet, bad prefix, plus the IPv4/IPv6 happy path. **11/11 green.**
- **`docs/architecture/gke-control-plane-access-preflight.md`** (new) — design note recording the contract, the canonical incumbents, the cross-cutting layers, the extensibility seam (the env-level `gke_master_authorized_cidrs`), the non-goals (do not flip `enable_private_endpoint = true` without designing the private operator/CI/Helm/kubectl path together with relaxing this validation), and the repo-required validation checks.
- **`docs/adr/index.yaml`** — register the new doc as ADR-008 evidence.
- **`CHANGELOG.md`** — `[3.101.6]` Security entry.

## Validation

Local checks all green on the 6 changed files:

- `pre-commit run --files <those>` — `ruff`, `ruff-format`, `terraform_fmt`, `terraform_validate`, `terraform_tflint` (with the google ruleset), `checkov`, `bandit`, `adr-guard-fast`, `pytest (bootstrap)` (incl. the new tests).
- `python3 scripts/adr_guard/adr_guard.py --files <those> --level ci` — passed all 8 checks.
- `terraform fmt -check` + `terraform init -backend=false && terraform validate` from `platform/terraform/gcp/environments/gcp-dev/` — clean.

## Why this is not just "ship the doc"

Issue #957 is a duplicate of the already-implemented #952. The Codex architecture preflight added the doc, but Codex review of the doc surfaced the residual Terraform-layer gap (the doc claimed allowlist enforcement that didn't exist for direct `terraform apply` paths) and a follow-up gap that the validation was passing `0.0.0.0/0`. Closing both became the substantive work; the doc + ADR-008 evidence ride along.

Closes #957