### PR TITLE
Scope engine provisioner EC2 lifecycle IAM

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -173,6 +173,12 @@ repos:
         language: system
         files: ^(scripts/polaris-aws-range/|shifter/engine/provisioner/terraform/modules/range/).*\.tf$
 
+      - id: check-tf-iam-ec2-scope
+        name: AWS EC2 lifecycle IAM scoping (engine provisioner)
+        entry: python3 scripts/check_tf_iam_ec2_scope/check_tf_iam_ec2_scope.py
+        language: system
+        files: ^platform/terraform/modules/engine-provisioner/iam\.tf$
+
   # Kubernetes schema validation
   - repo: local
     hooks:

--- a/changelog.d/55.security.md
+++ b/changelog.d/55.security.md
@@ -1,0 +1,4 @@
+**Scoped the engine provisioner EC2 lifecycle IAM permissions to Shifter-owned
+instances.** Mutable instance actions now require the existing runtime ownership
+tags instead of allowing the task role to manage every EC2 instance in the
+account.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -27,6 +27,9 @@ Current mechanisms:
 
 - `scripts/adr_guard/adr_guard.py`: repo-native policy runner
 - `.pre-commit-config.yaml`: local fast checks
+  - `check-tf-iam-ec2-scope`: local Terraform IAM hardening check that
+    keeps engine-provisioner EC2 instance lifecycle actions scoped to
+    Shifter-owned, Terraform-managed instances.
 - `.github/workflows/_quality.yml`: CI architecture gate
 - `.claude/hooks/adr_guard_hook.py`: Claude post-edit validation
 - `AGENTS.md`: Codex repo-local policy. Points at `.ground-control.yaml` and `.gc/plan-rules.md` for Ground Control workflow context (requirements and plan rules); enforcement of ADR rules still lives here.

--- a/platform/terraform/modules/engine-provisioner/iam.tf
+++ b/platform/terraform/modules/engine-provisioner/iam.tf
@@ -145,7 +145,15 @@ resource "aws_iam_role_policy" "ec2_provisioning" {
           "ec2:ImportKeyPair",
           "ec2:DeleteKeyPair"
         ]
-        Resource = "*"
+        Resource = [
+          "arn:aws:ec2:${local.region}:${local.account_id}:instance/*",
+          "arn:aws:ec2:${local.region}:${local.account_id}:volume/*",
+          "arn:aws:ec2:${local.region}:${local.account_id}:network-interface/*",
+          "arn:aws:ec2:${local.region}:${local.account_id}:subnet/*",
+          "arn:aws:ec2:${local.region}:${local.account_id}:security-group/*",
+          "arn:aws:ec2:${local.region}:${local.account_id}:key-pair/*",
+          "arn:aws:ec2:${local.region}::image/*"
+        ]
       },
       {
         # Instance creation is restricted by the runtime Terraform tags that
@@ -155,7 +163,20 @@ resource "aws_iam_role_policy" "ec2_provisioning" {
         Action = [
           "ec2:RunInstances"
         ]
-        Resource = "*"
+        Resource = [
+          "arn:aws:ec2:${local.region}:${local.account_id}:instance/*",
+          "arn:aws:ec2:${local.region}:${local.account_id}:volume/*",
+          "arn:aws:ec2:${local.region}:${local.account_id}:network-interface/*",
+          "arn:aws:ec2:${local.region}:${local.account_id}:subnet/*",
+          "arn:aws:ec2:${local.region}:${local.account_id}:security-group/*",
+          "arn:aws:ec2:${local.region}:${local.account_id}:route-table/*",
+          "arn:aws:ec2:${local.region}:${local.account_id}:internet-gateway/*",
+          "arn:aws:ec2:${local.region}:${local.account_id}:elastic-ip/*",
+          "arn:aws:ec2:${local.region}:${local.account_id}:natgateway/*",
+          "arn:aws:ec2:${local.region}:${local.account_id}:vpc-endpoint/*",
+          "arn:aws:ec2:${local.region}:${local.account_id}:vpc-endpoint-service/*",
+          "arn:aws:ec2:${local.region}:${local.account_id}:key-pair/*"
+        ]
         Condition = {
           StringEquals = {
             "aws:RequestTag/shifter:system"      = "shifter"

--- a/platform/terraform/modules/engine-provisioner/iam.tf
+++ b/platform/terraform/modules/engine-provisioner/iam.tf
@@ -136,17 +136,74 @@ resource "aws_iam_role_policy" "ec2_provisioning" {
     Version = "2012-10-17"
     Statement = [
       {
-        # Full EC2 instance lifecycle management
-        # - RunInstances, TerminateInstances for create/destroy
-        # - StopInstances, StartInstances for power management
-        # - ModifyInstanceAttribute for runtime changes
-        # - CreateTags, DeleteTags for tagging
-        # - Describe* for state queries
-        # - ImportKeyPair/DeleteKeyPair for SSH key management
-        Sid    = "EC2InstanceOperations"
+        # EC2 read and key-pair operations. Describe APIs require
+        # Resource=*; key-pair names are generated per range/NGFW run.
+        Sid    = "EC2DescribeAndKeyPairOperations"
         Effect = "Allow"
         Action = [
-          "ec2:RunInstances",
+          "ec2:Describe*",
+          "ec2:ImportKeyPair",
+          "ec2:DeleteKeyPair"
+        ]
+        Resource = "*"
+      },
+      {
+        # Instance creation is restricted by the runtime Terraform tags that
+        # the provisioner applies to every managed range/NGFW instance.
+        Sid    = "EC2TaggedInstanceCreate"
+        Effect = "Allow"
+        Action = [
+          "ec2:RunInstances"
+        ]
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "aws:RequestTag/shifter:system"      = "shifter"
+            "aws:RequestTag/shifter:environment" = var.environment
+            "aws:RequestTag/ManagedBy"           = "terraform"
+          }
+        }
+      },
+      {
+        # Tagging at create time is needed for the EC2 resources provisioner
+        # Terraform creates and is bound to create APIs so it cannot retag
+        # arbitrary EC2 resources.
+        Sid    = "EC2TagOnCreate"
+        Effect = "Allow"
+        Action = [
+          "ec2:CreateTags"
+        ]
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "ec2:CreateAction" = [
+              "AllocateAddress",
+              "CreateInternetGateway",
+              "CreateNatGateway",
+              "CreateNetworkInterface",
+              "CreateRouteTable",
+              "CreateSecurityGroup",
+              "CreateSubnet",
+              "CreateVpcEndpoint",
+              "CreateVpcEndpointServiceConfiguration",
+              "ImportKeyPair",
+              "RunInstances"
+            ]
+            "aws:RequestTag/shifter:system"      = "shifter"
+            "aws:RequestTag/shifter:environment" = var.environment
+            "aws:RequestTag/ManagedBy"           = "terraform"
+          }
+        }
+      },
+      {
+        # EC2 instance lifecycle management for provisioner-owned instances.
+        # - TerminateInstances for destroy
+        # - StopInstances, StartInstances for power management
+        # - ModifyInstanceAttribute for runtime changes
+        # - DeleteTags for cleanup
+        Sid    = "EC2TaggedInstanceLifecycle"
+        Effect = "Allow"
+        Action = [
           "ec2:TerminateInstances",
           "ec2:StopInstances",
           "ec2:StartInstances",
@@ -157,13 +214,16 @@ resource "aws_iam_role_policy" "ec2_provisioning" {
           # can't reach IMDS for instance-profile credentials and the
           # claude/Bedrock smoke test fails.
           "ec2:ModifyInstanceMetadataOptions",
-          "ec2:CreateTags",
-          "ec2:DeleteTags",
-          "ec2:Describe*",
-          "ec2:ImportKeyPair",
-          "ec2:DeleteKeyPair"
+          "ec2:DeleteTags"
         ]
-        Resource = "*"
+        Resource = "arn:aws:ec2:${local.region}:${local.account_id}:instance/*"
+        Condition = {
+          StringEquals = {
+            "ec2:ResourceTag/shifter:system"      = "shifter"
+            "ec2:ResourceTag/shifter:environment" = var.environment
+            "ec2:ResourceTag/ManagedBy"           = "terraform"
+          }
+        }
       },
       {
         # Network interface operations for NGFW ENI creation
@@ -185,7 +245,7 @@ resource "aws_iam_role_policy" "ec2_provisioning" {
         # - CreateSubnet, DeleteSubnet for create/destroy
         # - ModifySubnetAttribute for map_public_ip_on_launch, etc.
         # - DescribeSubnets for state queries
-        # Note: CreateTags is in EC2InstanceOperations and applies to all EC2 resources
+        # Note: tag-on-create support is in EC2TagOnCreate.
         Sid    = "EC2SubnetOperations"
         Effect = "Allow"
         Action = [

--- a/scripts/check_tf_iam_ec2_scope/__init__.py
+++ b/scripts/check_tf_iam_ec2_scope/__init__.py
@@ -1,0 +1,1 @@
+"""EC2 IAM scope checker tests."""

--- a/scripts/check_tf_iam_ec2_scope/check_tf_iam_ec2_scope.py
+++ b/scripts/check_tf_iam_ec2_scope/check_tf_iam_ec2_scope.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Lint EC2 instance lifecycle IAM statements in Terraform files.
+
+The engine provisioner legitimately needs to create and manage EC2 range
+instances, but mutable instance lifecycle APIs must not remain in wildcard
+statements that can target every EC2 instance in the account.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass
+from fnmatch import fnmatchcase
+from pathlib import Path
+
+MUTABLE_INSTANCE_ACTIONS: set[str] = {
+    "ec2:ModifyInstanceAttribute",
+    "ec2:ModifyInstanceMetadataOptions",
+    "ec2:StartInstances",
+    "ec2:StopInstances",
+    "ec2:TerminateInstances",
+}
+
+REQUIRED_RESOURCE_SNIPPET = (
+    'arn:aws:ec2:${local.region}:${local.account_id}:instance/*'
+)
+REQUIRED_TAG_KEYS: tuple[str, ...] = (
+    "ec2:ResourceTag/shifter:system",
+    "ec2:ResourceTag/shifter:environment",
+    "ec2:ResourceTag/ManagedBy",
+)
+
+_RESOURCE_RE = re.compile(r'^\s*resource\s+"aws_iam_role_policy"\s+"([^"]+)"\s*\{')
+_ACTION_RE = re.compile(r'"(ec2:[^"]+)"')
+
+
+@dataclass
+class Violation:
+    file: Path
+    line: int
+    reason: str
+
+    def __str__(self) -> str:
+        return f"{self.file}:{self.line}: {self.reason}"
+
+
+def _brace_delta(line: str) -> int:
+    return line.count("{") - line.count("}")
+
+
+def _extract_statement_blocks(lines: list[str]) -> list[tuple[int, str]]:
+    blocks: list[tuple[int, str]] = []
+    idx = 0
+    while idx < len(lines):
+        line = lines[idx]
+        if not re.match(r"^\s*\{\s*$", line):
+            idx += 1
+            continue
+
+        start_idx = idx
+        depth = _brace_delta(line)
+        idx += 1
+        while idx < len(lines) and depth > 0:
+            depth += _brace_delta(lines[idx])
+            idx += 1
+
+        block = "\n".join(lines[start_idx:idx])
+        if '"ec2:' in block:
+            blocks.append((start_idx + 1, block))
+    return blocks
+
+
+def _extract_policy_body(lines: list[str], resource_name: str) -> tuple[int, list[str]] | None:
+    in_resource = False
+    resource_depth = 0
+    resource_start = 0
+
+    for idx, line in enumerate(lines):
+        if not in_resource:
+            match = _RESOURCE_RE.match(line)
+            if match and match.group(1) == resource_name:
+                in_resource = True
+                resource_depth = _brace_delta(line)
+                resource_start = idx
+            continue
+
+        resource_depth += _brace_delta(line)
+        if resource_depth <= 0:
+            return resource_start + 1, lines[resource_start : idx + 1]
+
+    return None
+
+
+def _actions(block: str) -> set[str]:
+    return set(_ACTION_RE.findall(block))
+
+
+def _mutable_instance_action_matches(actions: set[str]) -> list[str]:
+    matches: set[str] = set()
+    for action in actions:
+        for mutable_action in MUTABLE_INSTANCE_ACTIONS:
+            if action == mutable_action or fnmatchcase(mutable_action, action):
+                matches.add(action)
+    return sorted(matches)
+
+
+def check_file(path: Path, resource_name: str = "ec2_provisioning") -> list[Violation]:
+    lines = path.read_text().splitlines()
+    policy = _extract_policy_body(lines, resource_name)
+    if policy is None:
+        return []
+
+    policy_start_line, policy_lines = policy
+    violations: list[Violation] = []
+    for relative_line, block in _extract_statement_blocks(policy_lines):
+        line = policy_start_line + relative_line - 1
+        mutable_actions = _mutable_instance_action_matches(_actions(block))
+        if not mutable_actions:
+            continue
+
+        wildcard_actions = [action for action in mutable_actions if "*" in action]
+        if wildcard_actions:
+            violations.append(
+                Violation(
+                    path,
+                    line,
+                    "mutable EC2 instance lifecycle actions must be enumerated, "
+                    f"not granted through wildcard action patterns ({', '.join(wildcard_actions)})",
+                )
+            )
+
+        if 'Resource = "*"' in block:
+            violations.append(
+                Violation(
+                    path,
+                    line,
+                    "mutable EC2 instance lifecycle actions must not use Resource=* "
+                    f"({', '.join(mutable_actions)})",
+                )
+            )
+        if REQUIRED_RESOURCE_SNIPPET not in block:
+            violations.append(
+                Violation(
+                    path,
+                    line,
+                    "mutable EC2 instance lifecycle actions must be scoped to EC2 "
+                    "instance ARNs",
+                )
+            )
+        for tag_key in REQUIRED_TAG_KEYS:
+            if tag_key not in block:
+                violations.append(
+                    Violation(
+                        path,
+                        line,
+                        "mutable EC2 instance lifecycle actions must require "
+                        f"{tag_key}",
+                    )
+                )
+        if "ec2:Describe*" in block:
+            violations.append(
+                Violation(
+                    path,
+                    line,
+                    "Describe APIs must stay separate from mutable lifecycle actions",
+                )
+            )
+    return violations
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print(
+            "usage: check_tf_iam_ec2_scope.py FILE.tf [FILE.tf ...]",
+            file=sys.stderr,
+        )
+        return 2
+
+    violations: list[Violation] = []
+    for arg in argv[1:]:
+        path = Path(arg)
+        if not path.exists():
+            print(f"{path}: file not found", file=sys.stderr)
+            return 2
+        if path.suffix == ".tf":
+            violations.extend(check_file(path))
+
+    if violations:
+        print(
+            "EC2 instance lifecycle IAM scope violations "
+            f"({len(violations)} total):",
+            file=sys.stderr,
+        )
+        for violation in violations:
+            print(f"  {violation}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/check_tf_iam_ec2_scope/check_tf_iam_ec2_scope.py
+++ b/scripts/check_tf_iam_ec2_scope/check_tf_iam_ec2_scope.py
@@ -105,6 +105,84 @@ def _mutable_instance_action_matches(actions: set[str]) -> list[str]:
     return sorted(matches)
 
 
+def _wildcard_action_violations(
+    path: Path, line: int, mutable_actions: list[str]
+) -> list[Violation]:
+    wildcard_actions = [action for action in mutable_actions if "*" in action]
+    if not wildcard_actions:
+        return []
+    return [
+        Violation(
+            path,
+            line,
+            "mutable EC2 instance lifecycle actions must be enumerated, "
+            f"not granted through wildcard action patterns ({', '.join(wildcard_actions)})",
+        )
+    ]
+
+
+def _statement_scope_violations(
+    path: Path, line: int, block: str, mutable_actions: list[str]
+) -> list[Violation]:
+    violations: list[Violation] = []
+    if 'Resource = "*"' in block:
+        violations.append(
+            Violation(
+                path,
+                line,
+                "mutable EC2 instance lifecycle actions must not use Resource=* "
+                f"({', '.join(mutable_actions)})",
+            )
+        )
+    if REQUIRED_RESOURCE_SNIPPET not in block:
+        violations.append(
+            Violation(
+                path,
+                line,
+                "mutable EC2 instance lifecycle actions must be scoped to EC2 "
+                "instance ARNs",
+            )
+        )
+    return violations
+
+
+def _required_tag_violations(path: Path, line: int, block: str) -> list[Violation]:
+    return [
+        Violation(
+            path,
+            line,
+            f"mutable EC2 instance lifecycle actions must require {tag_key}",
+        )
+        for tag_key in REQUIRED_TAG_KEYS
+        if tag_key not in block
+    ]
+
+
+def _statement_mixing_violations(path: Path, line: int, block: str) -> list[Violation]:
+    if "ec2:Describe*" not in block:
+        return []
+    return [
+        Violation(
+            path,
+            line,
+            "Describe APIs must stay separate from mutable lifecycle actions",
+        )
+    ]
+
+
+def _check_statement(path: Path, line: int, block: str) -> list[Violation]:
+    mutable_actions = _mutable_instance_action_matches(_actions(block))
+    if not mutable_actions:
+        return []
+
+    return [
+        *_wildcard_action_violations(path, line, mutable_actions),
+        *_statement_scope_violations(path, line, block, mutable_actions),
+        *_required_tag_violations(path, line, block),
+        *_statement_mixing_violations(path, line, block),
+    ]
+
+
 def check_file(path: Path, resource_name: str = "ec2_provisioning") -> list[Violation]:
     lines = path.read_text().splitlines()
     policy = _extract_policy_body(lines, resource_name)
@@ -115,57 +193,7 @@ def check_file(path: Path, resource_name: str = "ec2_provisioning") -> list[Viol
     violations: list[Violation] = []
     for relative_line, block in _extract_statement_blocks(policy_lines):
         line = policy_start_line + relative_line - 1
-        mutable_actions = _mutable_instance_action_matches(_actions(block))
-        if not mutable_actions:
-            continue
-
-        wildcard_actions = [action for action in mutable_actions if "*" in action]
-        if wildcard_actions:
-            violations.append(
-                Violation(
-                    path,
-                    line,
-                    "mutable EC2 instance lifecycle actions must be enumerated, "
-                    f"not granted through wildcard action patterns ({', '.join(wildcard_actions)})",
-                )
-            )
-
-        if 'Resource = "*"' in block:
-            violations.append(
-                Violation(
-                    path,
-                    line,
-                    "mutable EC2 instance lifecycle actions must not use Resource=* "
-                    f"({', '.join(mutable_actions)})",
-                )
-            )
-        if REQUIRED_RESOURCE_SNIPPET not in block:
-            violations.append(
-                Violation(
-                    path,
-                    line,
-                    "mutable EC2 instance lifecycle actions must be scoped to EC2 "
-                    "instance ARNs",
-                )
-            )
-        for tag_key in REQUIRED_TAG_KEYS:
-            if tag_key not in block:
-                violations.append(
-                    Violation(
-                        path,
-                        line,
-                        "mutable EC2 instance lifecycle actions must require "
-                        f"{tag_key}",
-                    )
-                )
-        if "ec2:Describe*" in block:
-            violations.append(
-                Violation(
-                    path,
-                    line,
-                    "Describe APIs must stay separate from mutable lifecycle actions",
-                )
-            )
+        violations.extend(_check_statement(path, line, block))
     return violations
 
 

--- a/scripts/check_tf_iam_ec2_scope/test_check_tf_iam_ec2_scope.py
+++ b/scripts/check_tf_iam_ec2_scope/test_check_tf_iam_ec2_scope.py
@@ -1,0 +1,131 @@
+"""Tests for check_tf_iam_ec2_scope.py.
+
+Run from the repo root:
+    python3 -m unittest scripts.check_tf_iam_ec2_scope.test_check_tf_iam_ec2_scope -v
+"""
+
+from __future__ import annotations
+
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+from .check_tf_iam_ec2_scope import check_file
+
+
+def _write(tmp_path: Path, body: str) -> Path:
+    path = tmp_path / "iam.tf"
+    path.write_text(textwrap.dedent(body).lstrip())
+    return path
+
+
+class CheckTfIamEc2ScopeTest(unittest.TestCase):
+    def test_wildcard_lifecycle_statement_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tf = _write(
+                Path(tmp),
+                """
+                resource "aws_iam_role_policy" "ec2_provisioning" {
+                  policy = jsonencode({
+                    Statement = [
+                      {
+                        Action = [
+                          "ec2:StartInstances",
+                          "ec2:StopInstances",
+                          "ec2:TerminateInstances",
+                          "ec2:Describe*"
+                        ]
+                        Resource = "*"
+                      }
+                    ]
+                  })
+                }
+                """,
+            )
+
+            reasons = [violation.reason for violation in check_file(tf)]
+
+        self.assertTrue(any("must not use Resource=*" in reason for reason in reasons))
+        self.assertTrue(
+            any("must be scoped to EC2 instance ARNs" in reason for reason in reasons)
+        )
+        self.assertTrue(any("ec2:ResourceTag/shifter:system" in reason for reason in reasons))
+        self.assertTrue(any("Describe APIs must stay separate" in reason for reason in reasons))
+
+    def test_scoped_lifecycle_statement_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tf = _write(
+                Path(tmp),
+                """
+                resource "aws_iam_role_policy" "ec2_provisioning" {
+                  policy = jsonencode({
+                    Statement = [
+                      {
+                        Sid = "EC2DescribeAndKeyPairOperations"
+                        Action = [
+                          "ec2:Describe*",
+                          "ec2:ImportKeyPair",
+                          "ec2:DeleteKeyPair"
+                        ]
+                        Resource = "*"
+                      },
+                      {
+                        Sid = "EC2TaggedInstanceLifecycle"
+                        Action = [
+                          "ec2:StartInstances",
+                          "ec2:StopInstances",
+                          "ec2:TerminateInstances",
+                          "ec2:ModifyInstanceAttribute",
+                          "ec2:ModifyInstanceMetadataOptions"
+                        ]
+                        Resource = "arn:aws:ec2:${local.region}:${local.account_id}:instance/*"
+                        Condition = {
+                          StringEquals = {
+                            "ec2:ResourceTag/shifter:system"      = "shifter"
+                            "ec2:ResourceTag/shifter:environment" = var.environment
+                            "ec2:ResourceTag/ManagedBy"           = "terraform"
+                          }
+                        }
+                      }
+                    ]
+                  })
+                }
+                """,
+            )
+
+            self.assertEqual(check_file(tf), [])
+
+    def test_wildcard_lifecycle_action_pattern_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tf = _write(
+                Path(tmp),
+                """
+                resource "aws_iam_role_policy" "ec2_provisioning" {
+                  policy = jsonencode({
+                    Statement = [
+                      {
+                        Action = [
+                          "ec2:*Instances"
+                        ]
+                        Resource = "*"
+                      }
+                    ]
+                  })
+                }
+                """,
+            )
+
+            reasons = [violation.reason for violation in check_file(tf)]
+
+        self.assertTrue(any("wildcard action patterns" in reason for reason in reasons))
+        self.assertTrue(any("must not use Resource=*" in reason for reason in reasons))
+
+    def test_current_engine_provisioner_policy_scopes_mutable_lifecycle_actions(self) -> None:
+        path = Path("platform/terraform/modules/engine-provisioner/iam.tf")
+
+        self.assertEqual(check_file(path), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- scope engine provisioner EC2 lifecycle actions to Shifter-owned Terraform-managed instances
- preserve wildcard/resource-required EC2 create and describe support in separate statements
- add a pre-commit structural checker and unittest coverage for lifecycle IAM scoping

## Validation
- python3 -m unittest scripts.check_tf_iam_ec2_scope.test_check_tf_iam_ec2_scope -v
- python3 scripts/adr_guard/adr_guard.py --all --level ci
- cd platform/terraform && tflint --recursive --config /home/atomik/src/shifter-codex/.tflint.hcl
- pre-commit run --all-files

Closes #55