### PR TITLE
security: define ai experiment execution boundary

### DIFF
--- a/changelog.d/1186.security.md
+++ b/changelog.d/1186.security.md
@@ -1,0 +1,1 @@
+Documented and pinned the AI experiment execution boundary for Claude Code runs. Experiment command dispatch now includes the `ai-experiment-execution-v1` policy payload for audit correlation, and regression tests guard the allowed `claude --dangerously-skip-permissions --output-format stream-json` invocation and transcript capture contract.

--- a/docs/architecture/ai-experiment-execution-boundary.md
+++ b/docs/architecture/ai-experiment-execution-boundary.md
@@ -1,0 +1,89 @@
+# AI experiment execution boundary
+
+Issue: #1186
+
+This document defines the v1 capability policy for experiment runs that invoke
+Claude Code from range infrastructure. The matching code-level policy version is
+`ai-experiment-execution-v1` in `cyberscript.script_context`.
+
+## Threat model
+
+Experiment execution combines cyber-range targets, uploaded scripts, cloud
+credentials, network access, and AI-driven command execution. The primary risks
+are prompt injection from scenario machines, unintended credential exposure,
+unreviewed expansion of Claude Code privileges, and loss of evidence after an
+incident.
+
+The platform treats prompts, scenario content, target machine output, and
+generated command output as untrusted. Staff-only access and isolated ranges are
+defense in depth; they are not the security boundary.
+
+## Execution scope
+
+Claude Code execution is allowed only from the experiment executor path that
+builds commands through `ScriptExecutionContext`. The allowed invocation prefix
+is:
+
+```text
+claude --dangerously-skip-permissions --output-format stream-json
+```
+
+`--dangerously-skip-permissions` is allowed for v1 only because these runs are
+launched inside provisioned experiment ranges and must run non-interactively.
+Any additional Claude privilege flag, alternate output format, or bypass of
+`ScriptExecutionContext` is a security-sensitive change and must update this
+document and the policy-versioned tests in the same PR.
+
+## Files and artifacts
+
+Claude receives the prompt through one `-p` argument after template resolution
+and POSIX single-quote encoding. It may write its transcript to
+`/tmp/claude_output.json`; artifact collection must preserve that output as a
+Claude transcript artifact for incident review.
+
+The AI process must not receive repository checkout access, operator workstation
+files, portal process memory, or arbitrary platform-side files. Uploaded Python
+scripts continue to use the validated S3 key path in `ScriptExecutionContext`;
+display names are metadata only and must not become shell path segments.
+
+## Credentials
+
+The AI process must not receive portal credentials, Django settings secrets,
+database credentials, Terraform state, GitHub tokens, or broad cloud
+control-plane credentials. Runtime access for model invocation belongs to the
+pre-provisioned range environment and must remain scoped to the intended model
+provider path.
+
+If a future provider requires new credentials for AI execution, the change must
+define the credential source, lifetime, artifact redaction rules, and blast
+radius before enabling the provider.
+
+## Network egress
+
+Network egress for Claude Code is constrained by the range network and its
+provider-level controls. The executor must not add portal-side public egress,
+new NAT paths, or broad allowlists to make Claude execution work. New egress for
+model access, package installation, callbacks, or artifact upload requires an
+explicit architecture update and validation coverage.
+
+## Prompt injection handling
+
+Prompts, templates, and target output are untrusted. Templates may resolve only
+through the typed `cyberscript.template_vars` and `ScriptExecutionContext`
+validators. Prompt text is passed as data to Claude; it is not a shell script
+and must not be concatenated into shell control flow.
+
+Operators reviewing a run must assume target output can contain instructions
+that try to override this policy. Such output may influence Claude's reasoning
+inside the range, but it does not grant platform credentials, repository files,
+or additional network access.
+
+## Audit requirements
+
+Every dispatched experiment command batch includes the policy payload with
+`version: ai-experiment-execution-v1`. Claude runs use stream-json output and
+tee the transcript to `/tmp/claude_output.json` so collection can preserve the
+prompt, tool decisions, command output, and errors needed for incident review.
+
+Regression tests must fail if dispatch omits the policy payload or if the
+allowed Claude invocation prefix changes without a deliberate update.

--- a/shifter/cyberscript/script_context.py
+++ b/shifter/cyberscript/script_context.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 
 import ipaddress
 import re
-from typing import Annotated, Any, Literal, Self
+from typing import Annotated, Any, Final, Literal, Self
 
 from pydantic import (
     AfterValidator,
@@ -48,6 +48,7 @@ from cyberscript.template_vars import (
 
 
 __all__ = [
+    "AI_EXPERIMENT_EXECUTION_POLICY_VERSION",
     "DisplayName",
     "InstanceIdValue",
     "InstanceValues",
@@ -55,6 +56,7 @@ __all__ = [
     "PromptText",
     "S3KeySegment",
     "ScriptExecutionContext",
+    "build_ai_execution_policy_payload",
 ]
 
 
@@ -79,6 +81,25 @@ _MAX_S3_KEY = 500
 _MAX_DISPLAY_NAME = 100
 _MAX_PROMPT_TEXT = 8192
 _ALLOWED_CONTROL_CHARS = frozenset({"\t", "\n", "\r"})
+
+AI_EXPERIMENT_EXECUTION_POLICY_VERSION: Final = "ai-experiment-execution-v1"
+
+
+def build_ai_execution_policy_payload() -> dict[str, object]:
+    """Return the auditable policy contract for AI experiment execution.
+
+    The executor receives this payload with each command batch so incident
+    review can tie a run back to the code-level policy that allowed Claude
+    Code to run with skipped prompts. Keep this in lockstep with
+    docs/architecture/ai-experiment-execution-boundary.md.
+    """
+    return {
+        "version": AI_EXPERIMENT_EXECUTION_POLICY_VERSION,
+        "claude_code": {
+            "prompt_delivery": "validated_single_argument",
+            "transcript_artifact_required": True,
+        },
+    }
 
 
 def _validate_instance_id(v: str) -> str:

--- a/shifter/cyberscript/tests/test_script_context.py
+++ b/shifter/cyberscript/tests/test_script_context.py
@@ -446,7 +446,10 @@ class TestRenderClaudeCommand:
         assert f" -p {expected_arg} " in cmd
 
     def test_full_shape(self) -> None:
-        from cyberscript.script_context import ScriptExecutionContext
+        from cyberscript.script_context import (
+            AI_EXPERIMENT_EXECUTION_POLICY_VERSION,
+            ScriptExecutionContext,
+        )
 
         ctx = ScriptExecutionContext(
             script_type="claude_code",
@@ -460,6 +463,17 @@ class TestRenderClaudeCommand:
             "2>&1 | tee /tmp/claude_output.json"
         )
         assert ctx.render_command() == expected
+        assert AI_EXPERIMENT_EXECUTION_POLICY_VERSION == "ai-experiment-execution-v1"
+
+    def test_policy_payload_pins_allowed_claude_boundary(self) -> None:
+        from cyberscript.script_context import build_ai_execution_policy_payload
+
+        policy = build_ai_execution_policy_payload()
+        claude = policy["claude_code"]
+
+        assert policy["version"] == "ai-experiment-execution-v1"
+        assert claude["prompt_delivery"] == "validated_single_argument"
+        assert claude["transcript_artifact_required"] is True
 
 
 # ---------------------------------------------------------------------------

--- a/shifter/shifter_platform/cms/experiments/orchestrator.py
+++ b/shifter/shifter_platform/cms/experiments/orchestrator.py
@@ -17,7 +17,10 @@ from dataclasses import dataclass, field
 from typing import Any
 from uuid import uuid4
 
-from cyberscript.script_context import ScriptExecutionContext
+from cyberscript.script_context import (
+    ScriptExecutionContext,
+    build_ai_execution_policy_payload,
+)
 from cyberscript.template_vars import build_instance_data
 from pydantic import ValidationError
 
@@ -667,6 +670,7 @@ class ExperimentOrchestrator:
         )
 
         payload = {
+            "ai_execution_policy": build_ai_execution_policy_payload(),
             "commands": [asdict(cmd) for cmd in commands],
         }
 

--- a/shifter/shifter_platform/tests/cms/experiments/test_orchestrator_dispatch.py
+++ b/shifter/shifter_platform/tests/cms/experiments/test_orchestrator_dispatch.py
@@ -122,6 +122,7 @@ class TestDispatchCommands:
 
         payload = mock_ecs.call_args[1]["payload"]
         assert "commands" in payload
+        assert payload["ai_execution_policy"]["version"] == "ai-experiment-execution-v1"
         assert len(payload["commands"]) == 2
         assert payload["commands"][0]["instance_id"] == "i-abc123"
         assert payload["commands"][0]["execution_order"] == 1


### PR DESCRIPTION
## Summary

- Defines the AI experiment execution boundary for Claude Code experiment runs.
- Adds the `ai-experiment-execution-v1` code-level policy payload and includes it in experiment command dispatch for audit correlation.
- Adds regression tests for the allowed Claude invocation and dispatch policy payload.

Fixes #1186

## Requirements

- None. This is a requirement-free security hardening issue.

## ADR Impact

- Added `docs/architecture/ai-experiment-execution-boundary.md`.
- No ADR registry or guardrail exception changes.

## Ground Control Checks

- [x] Plan posted to issue #1186.
- [x] Requirement traceability considered: no in-scope requirement UIDs; Ground Control traceability lookup returned `401 authentication_required`.
- [x] Architecture guard completed: `python3 scripts/adr_guard/adr_guard.py --all --level ci`.

## Traceability

- IMPLEMENTS: none.
- TESTS: `shifter/cyberscript/tests/test_script_context.py`; `shifter/shifter_platform/tests/cms/experiments/test_orchestrator_dispatch.py`; `shifter/shifter_platform/tests/cms/experiments/test_orchestrator_command_safety.py`.

## Validation

- `cd shifter/shifter_platform && uv run pytest tests/cms/experiments/test_orchestrator_dispatch.py tests/cms/experiments/test_orchestrator_command_safety.py`
- `cd shifter/cyberscript && uv run --with pytest pytest tests/test_script_context.py`
- `cd shifter/shifter_platform && uv run ruff check .`
- `cd shifter/shifter_platform && uv run ruff format --check .`
- `cd shifter/shifter_platform && uv run lint-imports --config ../../.importlinter`
- `python3 scripts/adr_guard/adr_guard.py --all --level ci`
- Commit hooks passed, including full platform pytest.

## Changelog

- `changelog.d/1186.security.md`