### PR TITLE
security: harden experiment command dispatch

### DIFF
--- a/changelog.d/1187.security.md
+++ b/changelog.d/1187.security.md
@@ -1,0 +1,1 @@
+**Experiment script dispatch no longer interpolates raw S3 keys or Claude prompts into remote shell syntax.** Script execution now uses fixed wrappers that decode validated payload data before invoking tools with structured argv.

--- a/docs/architecture/ai-experiment-execution-boundary.md
+++ b/docs/architecture/ai-experiment-execution-boundary.md
@@ -36,10 +36,12 @@ document and the policy-versioned tests in the same PR.
 
 ## Files and artifacts
 
-Claude receives the prompt through one `-p` argument after template resolution
-and POSIX single-quote encoding. It may write its transcript to
-`/tmp/claude_output.json`; artifact collection must preserve that output as a
-Claude transcript artifact for incident review.
+Claude receives the prompt through one `-p` argument after template resolution.
+The SSM shell transport receives a fixed Python wrapper plus base64-encoded
+prompt data; the wrapper decodes the prompt and invokes Claude with structured
+argv. Raw prompt text must not be interpolated into shell syntax. Claude may
+write its transcript to `/tmp/claude_output.json`; artifact collection must
+preserve that output as a Claude transcript artifact for incident review.
 
 The AI process must not receive repository checkout access, operator workstation
 files, portal process memory, or arbitrary platform-side files. Uploaded Python
@@ -70,8 +72,9 @@ explicit architecture update and validation coverage.
 
 Prompts, templates, and target output are untrusted. Templates may resolve only
 through the typed `cyberscript.template_vars` and `ScriptExecutionContext`
-validators. Prompt text is passed as data to Claude; it is not a shell script
-and must not be concatenated into shell control flow.
+validators. Prompt text is passed as encoded data through the remote shell
+transport and decoded inside the fixed wrapper before Claude invocation; it is
+not a shell script and must not be concatenated into shell control flow.
 
 Operators reviewing a run must assume target output can contain instructions
 that try to override this policy. Such output may influence Claude's reasoning

--- a/shifter/cyberscript/script_context.py
+++ b/shifter/cyberscript/script_context.py
@@ -13,20 +13,18 @@ Three principles:
    destination. Render methods read off validated fields and never apply
    their own sanitization — there is nothing left to sanitize.
 2. **Path identifier is the instance ID, not the display name.** EC2
-   instance IDs (`i-[0-9a-f]{8,17}`) are structurally safe to interpolate
-   into shell text. Display names may contain spaces, punctuation, and
-   unicode (e.g. "Workstation 1", "Domain Controller"); they are
-   metadata only.
-3. **The Claude prompt's single-quote encoder is the only surviving
-   ad-hoc shell encoder.** It lives inside `render_claude_command` and
-   operates on the already-validated `PromptText`. The prompt may carry
-   shell metacharacters (`$`, `;`, backticks, `|`); single-quote
-   wrapping neutralises them at the shell layer without altering the
-   semantic content of the prompt itself.
+   instance IDs (`i-[0-9a-f]{8,17}`) are the only per-instance value the
+   fixed shell wrapper embeds directly. Display names may contain spaces,
+   punctuation, and unicode (e.g. "Workstation 1", "Domain Controller");
+   they are metadata only.
+3. **Payloads cross the remote shell boundary as encoded data.** Render
+   methods emit fixed Python wrappers, base64-encode user-controlled payloads,
+   and invoke tools with structured argv inside the wrapper.
 """
 
 from __future__ import annotations
 
+import base64
 import ipaddress
 import re
 from typing import Annotated, Any, Final, Literal, Self
@@ -96,10 +94,15 @@ def build_ai_execution_policy_payload() -> dict[str, object]:
     return {
         "version": AI_EXPERIMENT_EXECUTION_POLICY_VERSION,
         "claude_code": {
-            "prompt_delivery": "validated_single_argument",
+            "prompt_delivery": "encoded_shell_wrapper",
             "transcript_artifact_required": True,
         },
     }
+
+
+def _encode_command_payload(value: str) -> str:
+    """Encode data for fixed shell wrappers using shell-safe base64."""
+    return base64.urlsafe_b64encode(value.encode()).decode()
 
 
 def _validate_instance_id(v: str) -> str:
@@ -337,36 +340,81 @@ class ScriptExecutionContext(BaseModel):
         return self.render_claude_command()
 
     def render_python_command(self) -> str:
-        """Build the `aws s3 cp … && python3 … | tee …` pipeline.
+        """Build the SSM shell wrapper for Python script execution.
 
-        The path segment is the instance ID (structurally `i-[0-9a-f]{8,17}`)
-        and the S3 key is whitelist-validated; both are safe to interpolate
-        directly into shell text.
+        The remote transport accepts one shell string, so the shell text stays
+        a fixed wrapper. The S3 key crosses that boundary as base64 data and
+        is decoded inside Python before structured argv subprocess calls.
         """
         seg = self.instance.instance_id
-        s3 = self.script_s3_key
-        return (
-            f"aws s3 cp s3://${{BUCKET_NAME}}/{s3} /tmp/script_{seg}.py "
-            f"&& python3 /tmp/script_{seg}.py "
-            f"2>&1 | tee /tmp/output_{seg}.log"
-        )
+        s3 = _encode_command_payload(self.script_s3_key or "")
+        return f"""python3 - <<'PY'
+import base64
+import os
+import subprocess
+import sys
+
+instance_id = "{seg}"
+script_s3_key = base64.urlsafe_b64decode("{s3}").decode()
+bucket_name = os.environ["BUCKET_NAME"]
+script_path = f"/tmp/script_{{instance_id}}.py"
+output_path = f"/tmp/output_{{instance_id}}.log"
+
+subprocess.run(
+    ["aws", "s3", "cp", f"s3://{{bucket_name}}/{{script_s3_key}}", script_path],
+    check=True,
+)
+with open(output_path, "wb") as output:
+    process = subprocess.Popen(
+        ["python3", script_path],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    assert process.stdout is not None
+    for chunk in iter(lambda: process.stdout.read(8192), b""):
+        sys.stdout.buffer.write(chunk)
+        sys.stdout.buffer.flush()
+        output.write(chunk)
+        output.flush()
+    raise SystemExit(process.wait())
+PY"""
 
     def render_claude_command(self) -> str:
-        """Build the `claude … -p '…' | tee …` invocation.
+        """Build the SSM shell wrapper for Claude Code execution.
 
-        Applies POSIX single-quote encoding to the validated prompt
-        (`'foo'\\''bar'` for an embedded single quote), then wraps the
-        result in `'…'`. Shell metacharacters inside the prompt are
-        neutralised by the single-quoted argument and never reach the
-        shell interpreter.
+        The prompt crosses the shell-only SSM boundary as base64 data. The
+        fixed wrapper decodes it and passes it to Claude as one argv value.
         """
-        encoded = self.claude_prompt_resolved.replace("'", "'\\''")
-        return (
-            "claude --dangerously-skip-permissions "
-            "--output-format stream-json "
-            f"-p '{encoded}' "
-            "2>&1 | tee /tmp/claude_output.json"
-        )
+        prompt = _encode_command_payload(self.claude_prompt_resolved or "")
+        return f"""python3 - <<'PY'
+import base64
+import subprocess
+import sys
+
+prompt = base64.urlsafe_b64decode("{prompt}").decode()
+output_path = "/tmp/claude_output.json"
+
+with open(output_path, "wb") as output:
+    process = subprocess.Popen(
+        [
+            "claude",
+            "--dangerously-skip-permissions",
+            "--output-format",
+            "stream-json",
+            "-p",
+            prompt,
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    assert process.stdout is not None
+    for chunk in iter(lambda: process.stdout.read(8192), b""):
+        sys.stdout.buffer.write(chunk)
+        sys.stdout.buffer.flush()
+        output.write(chunk)
+        output.flush()
+    raise SystemExit(process.wait())
+PY"""
 
     # ----- factories ------------------------------------------------------
 

--- a/shifter/cyberscript/tests/test_script_context.py
+++ b/shifter/cyberscript/tests/test_script_context.py
@@ -9,6 +9,8 @@ representation (path segment, S3 key, instance ID, IP, prompt text).
 
 from __future__ import annotations
 
+import base64
+
 import pytest
 from pydantic import ValidationError
 
@@ -255,9 +257,9 @@ class TestPromptText:
         [
             "Attack the box at 10.0.0.1",
             "Multi\nline\nprompt",
-            "Has 'quotes' and \"double\" and `backticks`",  # shell metas allowed inside the encoded arg
+            "Has 'quotes' and \"double\" and `backticks`",  # shell metas are allowed before encoding
             "Pipes | and semicolons ; and ampersands & — all fine pre-encoding",
-            "$(echo not-actually-executed-because-of-single-quote-wrap)",
+            "$(echo not-actually-executed-because-it-is-encoded)",
             "x" * 8192,                                       # exactly 8 KiB
         ],
     )
@@ -378,8 +380,12 @@ class TestScriptExecutionContextDiscriminator:
 
 
 # ---------------------------------------------------------------------------
-# Render methods — exact shell-string shape; nothing slips past the encoder
+# Render methods — fixed wrappers; user-controlled data crosses as encoded data
 # ---------------------------------------------------------------------------
+
+
+def _encoded(value: str) -> str:
+    return base64.urlsafe_b64encode(value.encode()).decode()
 
 
 class TestRenderPythonCommand:
@@ -396,8 +402,9 @@ class TestRenderPythonCommand:
         cmd = ctx.render_command()
 
         # Path segment is the instance_id, not the display name.
-        assert "/tmp/script_i-abc12345.py" in cmd
-        assert "/tmp/output_i-abc12345.log" in cmd
+        assert 'instance_id = "i-abc12345"' in cmd
+        assert 'script_path = f"/tmp/script_{instance_id}.py"' in cmd
+        assert 'output_path = f"/tmp/output_{instance_id}.log"' in cmd
         # The display name with its embedded space must NOT appear in the shell text.
         assert "Workstation 1" not in cmd
         assert "Workstation" not in cmd
@@ -410,31 +417,32 @@ class TestRenderPythonCommand:
             instance={"name": "Workstation", "instance_id": "i-abc12345"},
             script_s3_key="scripts/1/script.py",
         )
-        expected = (
-            "aws s3 cp s3://${BUCKET_NAME}/scripts/1/script.py /tmp/script_i-abc12345.py "
-            "&& python3 /tmp/script_i-abc12345.py "
-            "2>&1 | tee /tmp/output_i-abc12345.log"
-        )
-        assert ctx.render_command() == expected
+        cmd = ctx.render_command()
+
+        assert cmd.startswith("python3 - <<'PY'\n")
+        assert 'subprocess.run(\n    ["aws", "s3", "cp"' in cmd
+        assert '["python3", script_path]' in cmd
+        assert 'instance_id = "i-abc12345"' in cmd
+        assert f'script_s3_key = base64.urlsafe_b64decode("{_encoded("scripts/1/script.py")}").decode()' in cmd
+        assert "scripts/1/script.py" not in cmd
 
 
 class TestRenderClaudeCommand:
 
     @pytest.mark.parametrize(
-        "prompt, expected_arg",
+        "prompt",
         [
-            ("simple prompt", "'simple prompt'"),
-            ("with 'quote'", "'with '\\''quote'\\'''"),
-            ("two 'a' and 'b'", "'two '\\''a'\\'' and '\\''b'\\'''"),
-            ("no quotes here", "'no quotes here'"),
-            # Shell metas survive inside the single-quoted arg — that's correct,
-            # because `claude -p` receives the prompt as a literal string.
-            ("$(injected)", "'$(injected)'"),
-            ("`backticks`", "'`backticks`'"),
-            ("pipes | and ; semis", "'pipes | and ; semis'"),
+            "simple prompt",
+            "with 'quote'",
+            "two 'a' and 'b'",
+            "no quotes here",
+            "$(injected)",
+            "`backticks`",
+            "pipes | and ; semis",
+            "line one\nline two",
         ],
     )
-    def test_posix_single_quote_encoding(self, prompt: str, expected_arg: str) -> None:
+    def test_prompt_crosses_shell_boundary_encoded(self, prompt: str) -> None:
         from cyberscript.script_context import ScriptExecutionContext
 
         ctx = ScriptExecutionContext(
@@ -443,7 +451,9 @@ class TestRenderClaudeCommand:
             claude_prompt_resolved=prompt,
         )
         cmd = ctx.render_command()
-        assert f" -p {expected_arg} " in cmd
+        assert prompt not in cmd
+        assert f'prompt = base64.urlsafe_b64decode("{_encoded(prompt)}").decode()' in cmd
+        assert '"-p",\n            prompt,' in cmd
 
     def test_full_shape(self) -> None:
         from cyberscript.script_context import (
@@ -456,13 +466,14 @@ class TestRenderClaudeCommand:
             instance={"name": "Workstation", "instance_id": "i-abc12345"},
             claude_prompt_resolved="attack the box",
         )
-        expected = (
-            "claude --dangerously-skip-permissions "
-            "--output-format stream-json "
-            "-p 'attack the box' "
-            "2>&1 | tee /tmp/claude_output.json"
-        )
-        assert ctx.render_command() == expected
+        cmd = ctx.render_command()
+        assert cmd.startswith("python3 - <<'PY'\n")
+        assert '"claude",' in cmd
+        assert '"--dangerously-skip-permissions",' in cmd
+        assert '"--output-format",' in cmd
+        assert '"stream-json",' in cmd
+        assert 'output_path = "/tmp/claude_output.json"' in cmd
+        assert "attack the box" not in cmd
         assert AI_EXPERIMENT_EXECUTION_POLICY_VERSION == "ai-experiment-execution-v1"
 
     def test_policy_payload_pins_allowed_claude_boundary(self) -> None:
@@ -472,7 +483,7 @@ class TestRenderClaudeCommand:
         claude = policy["claude_code"]
 
         assert policy["version"] == "ai-experiment-execution-v1"
-        assert claude["prompt_delivery"] == "validated_single_argument"
+        assert claude["prompt_delivery"] == "encoded_shell_wrapper"
         assert claude["transcript_artifact_required"] is True
 
 
@@ -755,27 +766,41 @@ class TestInjectionBattery:
                 script_s3_key=s3_key,
             )
 
-    def test_injection_inside_quoted_prompt_does_not_escape(self) -> None:
-        """Even when the prompt contains `'` and shell metas, the rendered command
-        must keep them inside a single quoted argument — no break-out possible.
-        """
+    def test_prompt_metacharacters_do_not_reach_shell_text(self) -> None:
+        """Prompt shell metacharacters are encoded before the SSM shell string."""
         from cyberscript.script_context import ScriptExecutionContext
 
-        evil = "'; rm -rf / ; echo '"
+        evil = "'; rm -rf / ; echo ' $(id) `whoami`\nnext"
         ctx = ScriptExecutionContext(
             script_type="claude_code",
             instance={"name": "Workstation", "instance_id": "i-abc12345"},
             claude_prompt_resolved=evil,
         )
         cmd = ctx.render_command()
-        # The argument starts and ends with one literal single quote — every other
-        # quote in the rendered string is part of `'\''` escape sequences.
-        prefix = " -p '"
-        suffix = "' 2>&1 | tee "
-        assert prefix in cmd and suffix in cmd
-        # Count of bare-quote *boundaries*: exactly the opener and the closer.
-        between = cmd.split(prefix, 1)[1].rsplit(suffix, 1)[0]
-        # The argument body must not contain a raw "'" that isn't part of "'\''".
-        # Replace every "'\''" with sentinel, then no "'" should remain.
-        sanitized = between.replace("'\\''", "\x01")
-        assert "'" not in sanitized, f"unescaped single quote leaked: {between!r}"
+
+        assert evil not in cmd
+        assert "; rm -rf" not in cmd
+        assert "$(id)" not in cmd
+        assert "`whoami`" not in cmd
+        assert _encoded(evil) in cmd
+
+    def test_prompt_template_display_name_metacharacters_do_not_reach_shell_text(self) -> None:
+        from cyberscript.script_context import ScriptExecutionContext
+
+        prompt = "Use {{Target.name}}"
+        target_name = "Target One; $(id) `whoami`"
+        ctx = ScriptExecutionContext.for_claude(
+            instance_name="Workstation",
+            instance_id="i-abc12345",
+            private_ip=None,
+            claude_prompt_template=prompt,
+            instance_data={
+                "Target": {"ip": "10.0.0.5", "name": target_name, "instance_id": "i-def67890"},
+            },
+        )
+        cmd = ctx.render_command()
+
+        assert target_name not in cmd
+        assert "$(id)" not in cmd
+        assert "`whoami`" not in cmd
+        assert _encoded(f"Use {target_name}") in cmd

--- a/shifter/shifter_platform/tests/cms/experiments/test_orchestrator_command_safety.py
+++ b/shifter/shifter_platform/tests/cms/experiments/test_orchestrator_command_safety.py
@@ -9,12 +9,17 @@ shell text.
 
 from __future__ import annotations
 
+import base64
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from cms.experiments.exceptions import ExecutionPlanError
 from cms.experiments.orchestrator import ExperimentOrchestrator
+
+
+def _encoded(value: str) -> str:
+    return base64.urlsafe_b64encode(value.encode()).decode()
 
 
 def _make_experiment(**overrides):
@@ -79,10 +84,11 @@ class TestPythonCommandSafety:
         assert len(plan.victim_commands) == 1
         cmd = plan.victim_commands[0].command
         assert "Workstation 1" not in cmd, "display name must not reach shell text"
-        # S108 false positives: these are string assertions on generated shell
-        # text, not actual file operations from this test.
-        assert "/tmp/script_i-0abcdef12.py" in cmd  # noqa: S108
-        assert "/tmp/output_i-0abcdef12.log" in cmd  # noqa: S108
+        assert 'instance_id = "i-0abcdef12"' in cmd
+        assert 'script_path = f"/tmp/script_{instance_id}.py"' in cmd
+        assert 'output_path = f"/tmp/output_{instance_id}.log"' in cmd
+        assert "scripts/1/script.py" not in cmd
+        assert _encoded("scripts/1/script.py") in cmd
 
     def test_rejects_malformed_instance_id(self):
         exp = _make_experiment()
@@ -218,7 +224,9 @@ class TestClaudeCommandSafety:
             plan = orch._build_execution_plan(run, provisioned)
 
         cmd = plan.victim_commands[0].command
-        assert "-p 'Attack the box at 10.0.0.5'" in cmd
+        assert "Attack the box at 10.0.0.5" not in cmd
+        assert _encoded("Attack the box at 10.0.0.5") in cmd
+        assert '"-p",\n            prompt,' in cmd
 
     def test_validation_error_does_not_leak_raw_prompt(self):
         """Pydantic's default str() includes input_value; orchestrator must strip it."""
@@ -280,8 +288,8 @@ class TestClaudeCommandSafety:
                 orch._build_execution_plan(run, provisioned)
         assert "claude_prompt_template" in str(exc.value)
 
-    def test_quoted_metacharacters_survive_inside_single_quoted_arg(self):
-        """`'; rm -rf /; echo '` in the prompt must not break out of the `-p '…'` arg."""
+    def test_prompt_metacharacters_cross_shell_boundary_encoded(self):
+        """`'; rm -rf /; echo '` in the prompt must not reach shell syntax."""
         exp = _make_experiment()
         run = _make_run()
         sa = _make_script_assignment(
@@ -308,8 +316,7 @@ class TestClaudeCommandSafety:
             plan = orch._build_execution_plan(run, provisioned)
 
         cmd = plan.victim_commands[0].command
-        # The argument is wrapped: -p '<encoded>' …
-        between = cmd.split(" -p '", 1)[1].split("' 2>&1 ", 1)[0]
-        # Every bare `'` in the argument body must be part of a `'\''` sequence.
-        # Replace every `'\''` with a sentinel; no `'` should remain.
-        assert "'" not in between.replace("'\\''", "\x01")
+        assert "'; rm -rf /; echo '" not in cmd
+        assert "; rm -rf" not in cmd
+        assert _encoded("'; rm -rf /; echo '") in cmd
+        assert '"-p",\n            prompt,' in cmd


### PR DESCRIPTION
## Summary

- What changed: Replaced experiment script command rendering with fixed Python wrappers that decode validated base64 payloads and invoke `aws`, `python3`, and `claude` with structured argv.
- Why: Issue #1187 identified raw shell command interpolation for S3 keys and Claude prompts as a security hardening gap.

No formal Ground Control requirement UIDs are in scope for this issue.

## ADR Impact

- [x] No ADR impact
- [ ] Existing ADRs updated
- [ ] New ADR added
- [ ] Temporary exception added to `docs/adr/exceptions.yaml`

ADRs touched: None. Updated `docs/architecture/ai-experiment-execution-boundary.md` to document the existing AI execution boundary's encoded shell wrapper contract.

Exceptions added or renewed: None.

## Guardrail Changes

- [x] No guardrail files changed
- [ ] Guardrail files changed and matching docs were updated

Guardrail files changed: None.

## Traceability

- Implements: No formal requirements in scope.
- Tests: `shifter/cyberscript/tests/test_script_context.py`, `shifter/shifter_platform/tests/cms/experiments/test_orchestrator_dispatch.py`, `shifter/shifter_platform/tests/cms/experiments/test_orchestrator.py`

## Verification

- [x] `python3 scripts/adr_guard/adr_guard.py --all --level ci`
- [x] Relevant stack-native checks passed (`lint-imports`, `actionlint`, `tflint`, `gitleaks`) where applicable
- [x] Relevant tests
- [x] Docs updated where behavior or enforcement changed

Verification run:

- `cd shifter/shifter_platform && uv run pytest ../cyberscript/tests/test_script_context.py tests/cms/experiments/test_orchestrator_dispatch.py tests/cms/experiments/test_orchestrator.py` (162 passed)
- `cd shifter/shifter_platform && uv run ruff check .`
- `cd shifter/shifter_platform && uv run ruff format --check .`
- `python3 scripts/adr_guard/adr_guard.py --all --level ci`
