### PR TITLE
Review installation and backend docs

### DIFF
--- a/docs/architecture/root-configured-backend-bundles.md
+++ b/docs/architecture/root-configured-backend-bundles.md
@@ -1,627 +1,134 @@
 # Root-Configured Backend Bundles
 
-Status: planning, constrained by ADR-011
+Status: current architecture, constrained by ADR-011
 
 Tracking issue: <https://github.com/Brad-Edwards/shifter/issues/1109>
 
-Current-state inventory:
-[Branch Routing and Provider Coupling Inventory](branch-routing-provider-coupling-inventory.md)
+## Summary
 
-## Context
+Shifter uses one root installation config, `shifter.yaml`, to select the
+deployment backend and deployment profile.
 
-Shifter currently mixes runtime provider seams with branch-targeted deployment
-behavior. The application already has useful cloud adapter boundaries, but the
-public deployment model is still hard to explain: branch names imply provider
-and environment intent, while Terraform, Helm, generated env files, and Django
-settings each carry part of the final deployment shape.
+The implementation lives in `shifter/installation/`:
 
-That model is workable for a controlled internal deployment, but it is a poor
-fit for an OSS repository. Users should be able to choose the backend they want
-and validate that choice from a single installation contract.
+- `schema.py` validates root fields.
+- `loader.py` reads YAML, rejects duplicate keys and merge keys, and dispatches
+  backend checks.
+- `contract.py` defines the backend bundle contract.
+- `registry.py` contains the supported backend bundles.
+- `cli.py` exposes `shifter-config validate`.
+- `examples/` contains validated AWS and GCP examples.
 
-Pulumi is not part of the target architecture. Existing Pulumi-related names
-should be treated as legacy compatibility names unless an implementation issue
-explicitly migrates them.
+Published operator docs:
 
-## Recommendation
+- `shifter/installation/README.md`
+- `shifter/shifter_platform/documentation/docs/technical/dev/installation-config.md`
 
-Shifter OSS should use a root-configured backend bundle model:
+## Root Config Boundary
 
-```text
-root config -> selected backend bundle -> generated runtime, infra, validation, and deploy behavior
+`shifter.yaml` is user-authored installation intent. It is not a Terraform
+output file, Helm values file, generated runtime environment file, Kubernetes
+manifest, or CI branch selector.
+
+The root config owns:
+
+- schema version
+- selected backend
+- deployment name
+- deployment domain
+- deployment profile
+- logical secret references
+- backend-specific settings mapping
+
+The root schema validates root shape. Backend bundles validate backend-owned
+settings and secret reference grammar when they declare those validators.
+
+## Supported Backends
+
+| Backend | Profiles | Required secrets | Settings validation |
+| --- | --- | --- | --- |
+| `aws` | `prod`, `dev` | `django_secret_key`, `db_password` | Any mapping accepted by root-config validation. Deployment tooling validates consumed values. |
+| `gcp` | `prod`, `dev` | `django_secret_key` | Any mapping accepted by root-config validation. Deployment tooling validates consumed values. |
+
+## Validation
+
+Run from the repository root:
+
+```bash
+uv run --project shifter/installation shifter-config validate shifter.yaml
 ```
 
-The public model should be:
+Validation rejects:
 
-```yaml
-backend: aws
-deployment:
-  name: shifter
-  domain: shifter.example.com
-```
+- missing config files
+- invalid YAML
+- duplicate YAML mapping keys
+- YAML merge keys (`<<`)
+- non-mapping top-level YAML
+- unknown top-level fields
+- unknown `deployment` fields
+- missing required fields
+- unknown backend names
+- unsupported profile/backend combinations
+- malformed deployment names or domains
+- malformed secret names or references
+- missing required backend secrets
+- secret names not used by the selected backend
 
-Internally, a backend bundle may decompose into capability adapters for identity,
-storage, queueing, task execution, secrets, infrastructure, and range execution.
-That decomposition should remain an implementation detail unless an advanced
-configuration mode is deliberately introduced later.
+Validation errors are path-based and do not echo rejected input values.
 
-## Architecture Principles
+## Secret Handling
 
-- One root config is authoritative for backend selection and deployment-level
-  settings.
-- A backend is the OSS unit of choice. Users select `aws`, `gcp`, `local`, or a
-  future backend, not a mix of low-level capabilities.
-- Branch names must not be architectural deployment selectors.
-- Backend bundles own their required settings, generated outputs, validation
-  checks, infrastructure entrypoints, health checks, and setup docs.
-- Runtime code should select adapters from validated backend configuration, not
-  from branch routing or scattered environment assumptions.
-- Shared contracts remain under `shared`, and cross-layer access continues to go
-  through service boundaries.
-- Existing AWS and GCP behavior should migrate through compatibility paths that
-  preserve current security controls.
+`shifter.yaml` stores references, not secret values.
 
-## Root Config Schema Preflight
+Accepted reference forms are backend-described strings such as provider secret
+names, GitHub Actions secret names, environment variable names, or the literal
+`prompt`.
 
-Scope for `GEN-2001`, `PLAT-2001`, `GEN-2002`, and #1112: define the root
-installation config contract and its validation boundary only. Do not implement
-backend migration, workflow replacement, runtime adapter rewiring, cross-install
-orchestration, or a public capability-composition model as part of the schema
-definition.
+The schema rejects recognizable raw secret material, including PEM blocks,
+multi-line values, and implausibly long values. Short raw values can look like
+references, so `gitleaks` remains part of enforcement.
 
-The authoritative root file is **`shifter.yaml`** at the repository root, and the
-contract is implemented by the `installation` package
-([`shifter/installation/`](../../shifter/installation/README.md)): the typed schema,
-a fail-fast loader, worked examples, and the `shifter-config validate` CLI. The
-backend bundle contract and registry referenced below are #1113; the `local`
-backend is #1119.
+Generated backend outputs classify sensitive data as:
 
-### Contract Boundary
+- `public`
+- `secret-reference`
+- `secret-value`
 
-- The root config is user-authored installation intent. It selects one backend
-  bundle, deployment identity, public domain/hostname intent, and profile-level
-  settings. It is not a generated runtime env file, Terraform output file, Helm
-  values file, Kubernetes manifest, or CI branch selector.
-- The root config models exactly one standalone Shifter deployment. It must not
-  introduce fleet, install registry, tenant-to-install mapping, parent/child
-  deployment, remote cluster inventory, cross-install dependency, or centralized
-  rollout concepts in the OSS app model.
-- Secret material must stay out of the root config. The schema may accept secret
-  references, provider secret names, GitHub secret names, or bootstrap prompts,
-  but not raw secret values, access tokens, passwords, private keys, or service
-  account JSON.
-- Backend-specific settings must be namespaced behind the selected backend
-  bundle and validated by that bundle contract. The public root schema must not
-  expose low-level identity/storage/queue/task/secrets capability composition in
-  the default UX.
-- Unknown backends, unknown root keys, conflicting settings, unsupported
-  profile/backend combinations, missing required settings, and insecure public
-  posture must fail before Terraform, Helm, Django startup, worker startup, or
-  deployment scripts run.
-- Root config examples must be machine-validated by the same parser used by
-  setup, doctor, CI, and render commands. Documentation examples are not a
-  second schema.
+`secret-value` outputs may only be placed in a Kubernetes Secret or provider
+secret store.
 
-### Incumbents To Reuse
+## Runtime Binding
 
-| Concern | Canonical incumbent | Root config guardrail |
-| --- | --- | --- |
-| Shared contracts and layer boundaries | `shared/`, `.importlinter`, `scripts/check_layer_imports/layer_imports.yaml`, `ADR-001` | Put any cross-runtime contract behind `shared` or a repo-level script contract that does not import Django app layers directly. Do not create provider schemas separately inside each app. |
-| Schema validation | Existing Pydantic v2 schema style in `shared.schemas`, `cyberscript.schemas`, `cms.scenarios.schema`, and `cms.experiments.schemas`; script-local validators in `scripts/bootstrap/deploy.py` | Use one authoritative typed model/parser for the root config. If YAML is the UX format, use a structured parser and central validation instead of ad hoc regex/string parsing. |
-| Runtime env binding | `shifter/shifter_platform/config/settings.py`, `scripts/gcp/render_runtime_env.py`, `scripts/bootstrap/deploy.py::render_gcp_helm_values`, Helm `runtimeEnv` | Treat runtime env as derived output. Generate canonical keys first and keep AWS/Pulumi-era aliases as compatibility only while migration work requires them. Production `DJANGO_DEBUG`, `SESSION_COOKIE_SECURE`, and `CSRF_COOKIE_SECURE` are runtime-profile security settings, not edge-certificate readiness outputs; the GCP renderer always emits `SITE_URL=https://<public_hostname>` and fails closed (no HTTP/ingress-IP fallback) when a public hostname or managed TLS is missing. |
-| Cloud capability seams | `shifter/shifter_platform/shared/cloud/__init__.py`, `shared/cloud/types.py`, `shifter/engine/provisioner/cloud/__init__.py`, `ADR-005-R1` | Backend selection may feed the existing factories, but domain code must continue to call cloud-neutral factories/protocols instead of provider-specific modules. |
-| Identity/auth | `ADR-009`, `config/settings.py`, `config/oidc.py`, `config/identity_platform.py`, `scripts/bootstrap/deploy.py::ensure_gcp_identity_platform_operator` | Backend config may choose the identity stack through backend metadata; it must not move provider credential collection into Django or bypass domain/email/MFA/bootstrap controls. |
-| Secrets | `shared.cloud.*.secrets`, `engine/provisioner/cloud/*/secrets.py`, `scripts/bootstrap/deploy.py` Secret Manager/GitHub secret helpers, `.gitleaks.toml` | Store and pass secret identifiers, not values. Keep generated secret-bearing Helm values in temporary/staged outputs or provider secret stores, and never echo secret values in diagnostics. |
-| Logging and error text | `config.logging.ECSFormatter`, `shared.log_sanitize.safe_log`, existing CLI `error()`/`warn()` fail-fast style | Validation errors should name paths/keys and remediation, but must not include secret values, token payloads, or unescaped user-controlled strings. Do not add a parallel exception hierarchy unless a caller boundary needs it. |
-| Infrastructure validators | `terraform validate`, `.tflint.hcl`, `kubeconform`, `.kube-linter.yaml`, `ADR-006`, `ADR-008` | Backend doctor checks must invoke or front-run these validators instead of replacing them. Security posture checks such as managed TLS, public hostname, and authorized admin CIDRs stay fail-closed. |
-| Workflow/architecture gates | `.ground-control.yaml`, `.gc/plan-rules.md`, `scripts/adr_guard/adr_guard.py`, `.github/workflows/_quality.yml`, `ADR-002`, `ADR-003`, `ADR-011` | Root config work must preserve ADR guard, import boundaries, secret scanning, branch-independent deploy intent, and documented guardrail changes. |
+Backend metadata declares generated outputs consumed by runtime processes. The
+current registry declares `CLOUD_PROVIDER` for portal, worker, and provisioner
+roles. Django and provisioner code still select cloud adapters from
+`CLOUD_PROVIDER` at runtime through the existing cloud factory seams.
 
-### Security Layers The Design Must Pass
+Backend selection is not derived from branch names.
 
-- Auth surface: backend-derived config must satisfy the existing `AUTH_PROVIDER`
-  paths and `ADR-009` controls. AWS remains OIDC/Cognito-compatible; GCP remains
-  Identity Platform with provider-side credential collection, verified email,
-  MFA, and bootstrap-owned first-operator seeding.
-- Secret-handling surface: root config accepts references only. Provider secret
-  adapters and bootstrap helpers resolve values at runtime or deployment time.
-  Secret values must not be committed, logged, rendered into docs/examples, or
-  passed through command-line argv.
-- Env-binding shape: generated env must match `settings.py` canonical keys and
-  existing alias windows. Any new key must have one owner, one renderer, and one
-  validation source; generated ConfigMaps must not carry values that should be
-  Kubernetes Secrets or provider secrets. For #966, `DJANGO_DEBUG` and secure
-  cookie settings must be separated from managed TLS certificate activation,
-  DNS convergence, and identity-secret availability. Edge readiness may affect
-  ingress promotion or fail-closed deployment checks, but must not make a
-  production runtime debug-enabled or send session/CSRF cookies over plaintext.
-- Config validators: the root parser validates shape and cross-field conflicts;
-  backend bundles validate provider requirements; Terraform, Helm, Kubernetes,
-  actionlint, import-linter, and ADR guard keep their existing authority.
-- OS/process exposure: deployment and doctor commands should continue to use
-  argv-array subprocess calls, temporary credential files with cleanup, and
-  interactive secret prompts via `getpass` where values must be collected.
-- Error envelopes and logs: CLI failures should be deterministic nonzero exits
-  with sanitized messages. Django-facing validation should use existing
-  validation/error response patterns rather than a new global error envelope.
+## Backend Bundle Contract
 
-### Extensibility Seam
+A backend bundle declares:
 
-The schema needs an explicit version/profile/backend seam so the next backend
-or profile does not require redefining the root contract. The root parser owns
-root keys and dispatches selected-backend settings to backend bundle validation;
-backend bundles own provider-specific requirements, generated outputs,
-entrypoints, health checks, and docs. Runtime security profile and edge readiness
-must remain separate parameters: a production profile fixes debug and cookie
-security, while edge readiness controls hostname/TLS promotion or fail-closed
-gates. Future `local` or production variants should add backend/profile data
-behind that seam, not add another authoritative root file or branch convention.
+- backend identity and supported profiles
+- required command-line tools
+- required logical secrets and accepted reference grammar
+- generated outputs, destination, sensitivity, and consuming process roles
+- validation checks
+- health checks
+- cloud-neutral capabilities
+- backend-owned repository paths and docs
 
-### Anti-Patterns
+Validation command specs are argv arrays, not shell strings. The contract rejects
+shell metacharacters, absolute host paths, path traversal, and tokens with
+internal whitespace.
 
-- Treating branch names, Terraform environment directories, Helm values,
-  generated env files, or provider-local docs as additional authoritative config.
-- Duplicating root schema definitions across scripts, Django settings, Terraform
-  variables, Helm values, and examples.
-- Letting runtime code independently infer provider from `CLOUD_PROVIDER` while
-  setup/doctor uses a different root config interpretation.
-- Mixing public backend selection with low-level capability composition in the
-  default UX.
-- Recording secret values, bootstrap passwords, service-account JSON, access
-  tokens, or private keys in root config, argv, logs, examples, ConfigMaps, or
-  plan comments.
-- Weakening ADR, import, Terraform, Kubernetes, actionlint, gitleaks, or CI
-  enforcement to make the schema migration easier.
+## Source Of Truth
 
-### Non-Goals
+Do not create a second root-config parser in scripts, Django settings,
+Terraform, Helm, or examples. Import or execute the `shifter/installation`
+package instead.
 
-- Do not design a fleet manager, multi-install controller, hosted control plane,
-  marketplace, plugin runtime, or centralized upgrade service.
-- Do not move provider credential collection, secret value storage, identity
-  policy, deployment state, Terraform state, or Kubernetes runtime manifests
-  into the root config.
-- Do not rename legacy Pulumi-era or AWS/GCP compatibility surfaces as part of
-  schema definition unless a dedicated migration issue owns the state, workflow,
-  tests, and documentation impact.
-
-## Backend Bundle Contract And Registry Preflight
-
-Scope for `PLAT-2002`, `PLAT-2003`, `PLAT-2005`, and #1113: define the
-machine-readable backend bundle contract and the registry that replaces the
-provisional backend list in `shifter/installation/backends.py`. Do not migrate
-AWS, GCP, local, runtime adapter selection, CI branch routing, or setup/doctor
-orchestration as part of the contract definition. The contract should make those
-later changes lower-risk by naming the backend-owned inputs, outputs, checks, and
-adapter capabilities in one place.
-
-### Contract Boundary
-
-- A backend bundle is the default OSS unit of selection. Public setup chooses one
-  bundle such as `aws`, `gcp`, or `local`; it must not expose identity, storage,
-  queueing, task execution, secrets, infrastructure, or range execution as
-  independently user-composable capabilities.
-- The registry owns backend identity, display metadata, maturity, supported
-  profiles, required tools, required secret references, required root
-  `settings` shape, generated output descriptors, validation checks, health
-  checks, docs links, backend-owned file roots, and capability declarations.
-- The registry is not a deployment orchestrator, plugin runtime, Terraform
-  wrapper, Django settings module, workflow router, or provider credential
-  store. It should describe and dispatch to existing implementation entrypoints.
-- The registry is checked-in contract data/code, not a database-backed runtime
-  registry. Do not add persistence, migrations, tenant scoping, or dynamic
-  backend install state for #1113.
-- The contract belongs in the Django-free installation layer unless an ADR
-  records a different owner. Django, workflows, bootstrap scripts, and CI should
-  import or invoke that same contract instead of maintaining their own backend
-  tables.
-- Registry command/check entries must resolve to typed repo-owned entrypoints or
-  argv-array command specs. Do not store raw shell strings, user-controlled
-  Python import strings, or absolute host paths in backend metadata.
-- Backend-specific root `settings` validation belongs to the selected backend
-  bundle. The root schema continues to own root keys only: `version`, `backend`,
-  `deployment`, `secrets`, and that `settings` is a mapping.
-- Capability declarations may map to existing adapter protocols, but domain code
-  must continue to call `shared.cloud` and `engine/provisioner/cloud` service
-  seams. The bundle contract must not teach domain code to import provider
-  packages directly.
-- Generated runtime, infrastructure, Helm, Kubernetes, and CI values are derived
-  outputs. They are not alternate authoritative config files and must not accept
-  low-level capability overrides that disagree with the selected backend.
-
-### Contract Fields
-
-The initial registry should be small but structured enough that setup, doctor,
-CI, docs generation, and runtime derivation can share it:
-
-| Field | Owner | Guardrail |
-| --- | --- | --- |
-| `contract_version` | Registry | Version the backend contract shape independently of root `shifter.yaml` so future metadata fields can be added compatibly. Unknown major versions fail closed. |
-| `name`, `title`, `maturity`, `description` | Registry | Stable backend identity for selection and documentation. Do not infer backend from branch names, Terraform directories, or `CLOUD_PROVIDER`. |
-| `supported_profiles` | Registry | Replaces the hard-coded `ALLOWED_PROFILES` data in `installation.backends`; adding a profile is data, not a new root schema. |
-| `settings_schema` | Backend bundle | Validates `RootConfig.settings` for the selected backend only. Use typed Pydantic-style validation and aggregated sanitized errors. |
-| `required_tools` | Backend bundle | Feeds setup/doctor dependency checks; extend the command-specific model in `scripts/bootstrap/deploy.py::check_dependencies` instead of scattering `shutil.which`. |
-| `required_secrets` | Backend bundle | Declares logical secret references and provider reference grammar. Secret values remain in provider stores, GitHub secrets, Kubernetes Secrets, or interactive prompts, never in `shifter.yaml`. |
-| `generated_outputs` | Backend bundle | Names runtime env keys, Terraform variables/outputs, Helm values, Kubernetes artifacts, and compatibility aliases produced by backend renderers. Each output descriptor must declare owner, renderer/check source, destination, and sensitivity (`secret-reference`, `secret-value`, or `public/non-secret`) so generators cannot place secrets in ConfigMaps, docs, dry-runs, or plan comments. |
-| `validation_checks` | Backend bundle | References existing validators such as root config validation, Terraform validate/TFLint, Helm rendering, kubeconform, kube-linter, actionlint, import-linter, and ADR guard. |
-| `health_checks` | Backend bundle | Describes read-only post-render or post-deploy probes, their required credentials, expected timeout, and safe failure text without turning doctor into a mutating deploy command. |
-| `capabilities` | Backend bundle | Declares which existing cloud-neutral protocols the backend satisfies: storage, queue consumer/publisher, task runner, secrets, config store, event bus, database auth, and network inventory. |
-| `owned_files` and `docs` | Backend bundle | Points to backend-owned Terraform, Helm, Kubernetes, script, example, and docs roots so validation and docs generation can find them without branch routers. |
-
-### Incumbents To Reuse
-
-| Concern | Canonical incumbent | Backend contract guardrail |
-| --- | --- | --- |
-| Root config parser | `shifter/installation/schema.py`, `loader.py`, `errors.py`, `cli.py` | Build the registry beside this parser and replace `backends.py` data with registry data. Do not add another YAML parser or backend table in workflows, Django, or scripts. |
-| Validation error model | `installation.errors.ConfigIssue` and `InstallationConfigError` | Reuse aggregated path-based issues for backend settings validation. Messages must not carry rejected secret values. |
-| Schema style | Existing Pydantic v2 models in `installation.schema`, `cms.scenarios.schema`, and `cms.experiments.schemas` | Use typed models and model validators rather than ad hoc dict walking once data crosses the contract boundary. |
-| Portal cloud seams | `shifter/shifter_platform/shared/cloud/types.py` and `shared/cloud/__init__.py` | Backend capabilities point at these protocols/factories. Do not bypass them from CMS, CTF, engine views, or services. |
-| Provisioner cloud seams | `shifter/engine/provisioner/cloud/types.py` and `cloud/__init__.py` | Provisioner capability selection must receive the same backend identity as the portal, not infer a second provider from ambient env. |
-| Runtime env binding | `config/settings.py`, `scripts/gcp/render_runtime_env.py`, `scripts/bootstrap/deploy.py::render_gcp_helm_values`, Helm `runtimeEnv` | The bundle contract names canonical env keys and compatibility aliases. Renderers produce those keys; settings consume them. |
-| Identity/auth | `ADR-009`, `config/settings.py`, `config/oidc.py`, `config/identity_platform.py`, `ensure_gcp_identity_platform_operator` | Backend metadata may choose the auth mode, but provider credential collection and app-session gates stay in the existing auth seams. |
-| Secrets | `shared.cloud.*.secrets`, `engine/provisioner/cloud/*/secrets.py`, bootstrap secret helpers, `.gitleaks.toml` | Registry entries declare references and checks only. Do not log, commit, echo, or pass secret payloads through argv. |
-| Logging and redaction | `config.logging.ECSFormatter`, `shared.log_sanitize.safe_log`, installation errors | Contract/doctor diagnostics name backend, path, check, owner, and remediation while redacting provider messages and user-controlled values where needed. |
-| Infrastructure validation | Terraform validate/TFLint, Helm template rendering, kubeconform, kube-linter, `.importlinter`, ADR guard | Backend validation references these existing authorities. It may front-run or aggregate them, but must not replace or soften their failures. |
-
-### Security Layers
-
-- Auth surface: backend metadata may select `AUTH_PROVIDER`, but must satisfy the
-  existing OIDC/Cognito and Identity Platform boundaries. GCP continues to keep
-  browser credential collection in Identity Platform, enforce verified email and
-  MFA before app sessions, and seed the first operator through bootstrap-owned
-  logic.
-- Secret-handling surface: root config and backend settings hold references
-  only. The selected bundle validates the reference grammar; provider adapters
-  and bootstrap helpers resolve values. Secret payloads must not appear in
-  `shifter.yaml`, registry data, generated docs, logs, ConfigMaps, dry-run
-  output, GitHub comments, or process argv.
-- Env-binding shape: bundle outputs must match canonical `settings.py` keys and
-  document any AWS/Pulumi-era aliases as compatibility. ConfigMaps carry
-  non-secret runtime values; Kubernetes Secrets or provider stores carry secret
-  values.
-- Config validators: validation order is root schema, selected bundle settings,
-  backend prerequisite checks, renderer checks, infrastructure validators, and
-  runtime startup checks. Unknown backend, unsupported profile, unknown setting,
-  missing required tool/secret, insecure public posture, and conflicting outputs
-  fail before mutation.
-- OS/process exposure: checks and renderers use argv-array subprocess calls and
-  temporary credential files with cleanup. Passwords, private keys, service
-  account JSON, access tokens, and bootstrap secrets use existing prompt or
-  provider-secret paths, never shell snippets or command-line flags. Registry
-  metadata is data, not executable text: command specs are structured argv
-  arrays or stable repo-owned check IDs.
-- Error envelopes and logs: CLI/doctor paths return deterministic nonzero exits
-  with sanitized `ConfigIssue`-style messages. Django-facing callers keep using
-  existing Django validation and response patterns; do not add a global backend
-  exception hierarchy unless a caller boundary requires it.
-
-### Extensibility Seam
-
-The required seam is root `version` + backend `contract_version` + `backend` +
-`profile` + backend-owned `settings_schema`. Adding the initial `local` backend,
-a production GCP profile, or a future backend should add registry data,
-bundle-specific settings validation, and backend-owned render/check entries
-behind that seam. It should not require changing the root schema, adding a
-branch router, adding another authoritative config file, or teaching domain code
-about provider packages.
-
-### Anti-Patterns
-
-- Creating separate backend registries in `installation`, Django settings,
-  Terraform, Helm values, GitHub Actions, and docs.
-- Treating capability composition as the default OSS UX or allowing users to mix
-  AWS identity with GCP queues, local storage, or ad hoc task execution without a
-  later ADR-defined advanced mode.
-- Letting `CLOUD_PROVIDER`, `AUTH_PROVIDER`, branch names, generated env files,
-  Terraform directories, or Helm values override the selected backend bundle.
-- Forking provider-specific exception hierarchies, validators, CLI output
-  models, or secret-reference grammars when the installation error model and
-  cloud protocol exceptions already cover the boundary.
-- Putting arbitrary executable code, shell fragments, absolute local paths, or
-  network-fetched backend definitions in the registry.
-- Embedding GCP env allowlists, AWS network assumptions, image names, health
-  checks, or secret keys in portal code instead of backend-owned metadata and
-  renderers.
-- Weakening ADR guard, import boundaries, actionlint, TFLint, kubeconform,
-  kube-linter, gitleaks, Identity Platform checks, or network/TLS controls to
-  make backend migration easier.
-
-### Non-Goals
-
-- Do not implement AWS, GCP, or local bundle migration in #1113.
-- Do not introduce a public plugin marketplace, fleet manager, multi-install
-  controller, remote cluster inventory, or centralized rollout service.
-- Do not move Terraform state, provider credentials, identity policies, secret
-  values, or Kubernetes runtime manifests into the registry.
-- Do not persist backend bundles in the application database or introduce a
-  runtime plugin installation lifecycle.
-- Do not rename Pulumi-era compatibility names, database fields, image
-  repositories, task families, or Terraform moved blocks unless a dedicated
-  migration issue owns state and compatibility impact.
-
-## Backend-Derived Runtime Configuration Preflight
-
-Scope for `PLAT-2005` and #1114: make Django, workers, and provisioner
-processes derive provider and capability adapter selection from the validated
-root config plus selected backend bundle. Do not implement backend migration,
-new provider adapters, setup/doctor orchestration, or CI branch-routing
-replacement as part of this runtime derivation boundary.
-
-### Runtime Boundary
-
-- Runtime derivation starts from the same validated `RootConfig` and backend
-  registry contract used by setup, doctor, examples, and CI. Django settings,
-  worker startup, provisioner startup, and task-launch paths must not parse
-  `shifter.yaml` independently or maintain a second backend table.
-- The selected backend bundle owns the canonical runtime output schema:
-  backend identity, auth provider, cloud region/project/account identifiers,
-  queue identifiers, storage identifiers, task-runner settings, secret
-  references, network placement, health endpoints, and compatibility aliases.
-- Environment variables remain the process binding layer for Django, workers,
-  Kubernetes, ECS, and local subprocesses, but they are derived outputs, not an
-  authority that can override the selected backend. `CLOUD_PROVIDER` and
-  `AUTH_PROVIDER` become compatibility/runtime binding keys emitted by the
-  backend renderer, not ad hoc selectors set by workflows or branch names.
-- Portal code continues to use `shared.cloud` factories and protocols. Workers
-  continue to enter through `shared.management.commands.run_worker` and the
-  queue config from settings. Provisioner code continues to use its Django-free
-  `cloud` factory/protocol layer. Domain services must not import
-  provider-specific adapter packages directly.
-- The portal and provisioner must receive the same backend identity and
-  compatible capability map. A portal-derived task launch must not forward a
-  GCP runtime allowlist while the provisioner independently infers AWS from a
-  missing env var.
-- Runtime startup should fail closed on missing or conflicting derived keys
-  before processing requests, polling queues, launching tasks, or provisioning
-  infrastructure.
-
-### Incumbents To Reuse
-
-| Concern | Canonical incumbent | Runtime guardrail |
-| --- | --- | --- |
-| Root config and validation | `shifter/installation/schema.py`, `loader.py`, `errors.py`, `cli.py` | Runtime derivation consumes validated `RootConfig` and backend registry data. Do not add a Django-local YAML parser or a provisioner-local root schema. |
-| Django env binding | `shifter/shifter_platform/config/settings.py` | Keep one canonical settings surface for derived env keys and compatibility aliases. Backend renderers produce the keys settings already consumes or explicitly add one owner for any new key. |
-| Portal capability adapters | `shifter/shifter_platform/shared/cloud/__init__.py`, `shared/cloud/types.py`, `shared/cloud/exceptions.py` | Backend capabilities dispatch through existing factories/protocols and `CloudError` subclasses. Do not fork provider-specific exceptions or call adapters directly from app layers. |
-| Worker startup | `shared.management.commands.run_worker`, `settings.QUEUE_CONFIG`, `get_queue_consumer()` | Workers inherit the same derived runtime env as Django and resolve queue consumer IDs through the existing queue config shape. Do not create backend-specific worker commands. |
-| Task runner launch | `engine/ecs.py`, `cms/experiments/ecs.py`, `shared.cloud.types.TaskRunner` | Move provider-specific task settings and env propagation into backend-owned runtime descriptors. Preserve local provisioner mode as a compatibility path, but do not let it become a second backend selector. |
-| Provisioner capability adapters | `shifter/engine/provisioner/cloud/__init__.py`, `cloud/types.py`, `cloud/exceptions.py`, `config.py`, `range_terraform_runner.py` | Provisioner startup reads the derived backend identity and capability env emitted by the same backend bundle as the portal. GDC/AWS branching stays behind provisioner seams until replaced by registry dispatch. |
-| Runtime renderers | `scripts/gcp/render_runtime_env.py`, `scripts/bootstrap/deploy.py::render_gcp_helm_values`, Helm `runtimeEnv`, Kubernetes `platform-runtime` ConfigMap | Backend runtime renderers extend or wrap these existing render paths. They must label sensitivity and keep secret values out of ConfigMaps and dry-run output. |
-| Auth seams | `ADR-009`, `config/settings.py`, `config/oidc.py`, `config/identity_platform.py`, `ensure_gcp_identity_platform_operator` | Backend metadata selects the auth mode, but credential collection, verified email, MFA, operator bootstrap, and session creation stay in the existing provider auth boundaries. |
-| Logging and redaction | `config.logging.ECSFormatter`, `shared.log_sanitize.safe_log`, `installation.errors.ConfigIssue` | Startup and derivation diagnostics name backend, config path, generated key, and remediation while redacting provider errors, secret references where sensitive, and user-controlled strings. |
-
-### Security Layers
-
-- Auth surface: the derived `AUTH_PROVIDER` value must match the selected
-  backend's identity capability and `ADR-009`. AWS keeps the OIDC/Cognito path;
-  GCP keeps Identity Platform browser credential collection, verified email,
-  MFA, and bootstrap-owned first-operator seeding. Runtime derivation must reject
-  incompatible backend/auth pairs before Django URL/auth backends initialize.
-- Secret-handling surface: root config and backend settings contain secret
-  references only. Runtime renderers classify every output as
-  `public/non-secret`, `secret-reference`, or `secret-value`; only
-  `public/non-secret` and approved `secret-reference` keys may enter
-  ConfigMaps, logs, dry-runs, GitHub comments, or task env forwarding.
-  Secret-value outputs stay in provider secret stores, Kubernetes Secrets, or
-  temporary files with cleanup.
-- Env-binding shape: generated env must satisfy `settings.py`, worker
-  `QUEUE_CONFIG`, portal task-runner settings, provisioner cloud config, and the
-  Helm/Kubernetes `runtimeEnv` shape. Unknown keys, duplicate canonical owners,
-  conflicting compatibility aliases, and provider-specific required keys missing
-  for the selected backend fail before runtime startup.
-- Config validators: validation order is root schema, selected backend settings
-  schema, backend runtime output validation, renderer sensitivity checks, Helm
-  and Kubernetes shape validation, Django `check --deploy` where applicable, and
-  provisioner startup checks. Runtime derivation may aggregate these failures but
-  must not mask downstream validators.
-- OS/process exposure: local provisioner subprocesses, bootstrap renderers, and
-  task launchers use argv arrays. Do not pass passwords, private keys, service
-  account JSON, access tokens, or generated secret payloads in process argv,
-  command strings, shell snippets, or logged dry-run commands.
-- Error envelopes and logs: CLI/setup/doctor paths should report sanitized
-  `ConfigIssue`-style path failures. Django-facing failures should use existing
-  Django startup, validation, and response patterns. Provisioner failures should
-  use existing `CloudError`/runtime exceptions without adding a parallel backend
-  exception hierarchy.
-
-### Extensibility Seam
-
-The required seam is a typed runtime-output descriptor owned by each backend
-bundle and keyed by `contract_version`, backend, profile, process role, and
-capability. Process role must be explicit (`portal`, `worker`, `provisioner`,
-`experiment-task`, `range-task`) so a future `local` backend, a production GCP
-profile, or a different task runner adds data and render/check entries behind
-the registry rather than adding branch routers or widening low-level capability
-composition in the public config.
-
-### Runtime Gotchas
-
-- `settings.py` currently defaults `CLOUD_PROVIDER` to `aws`; derived runtime
-  work must remove the risk that a missing generated key silently selects AWS.
-- The provisioner has its own `CLOUD_PROVIDER` readers because it cannot import
-  Django settings. It needs an explicit generated binding from the same backend
-  bundle, not a second inference path.
-- `engine/ecs.py` contains a GCP provisioner env allowlist that is already a
-  backend runtime contract embedded in portal code. Move the ownership to
-  backend metadata/renderers before adding another provider or role.
-- `platform/k8s/gcp/overlays/gcp-dev/platform-runtime.env` is compatibility
-  input and currently includes guest-password-style defaults. Runtime derivation
-  must not preserve that pattern for new outputs; secret values belong in secret
-  stores or Kubernetes Secrets.
-- Pulumi-era names such as `pulumi-provisioner` and `PULUMI_*` aliases are
-  compatibility surfaces. Hide them behind canonical backend-neutral descriptors
-  unless a dedicated migration issue owns the rename.
-
-### Anti-Patterns
-
-- Adding a `get_backend()` helper in Django, another one in the provisioner, and
-  a third one in scripts that can disagree.
-- Letting `CLOUD_PROVIDER`, `AUTH_PROVIDER`, task image names, queue IDs,
-  Terraform outputs, Helm values, or branch names override the selected backend.
-- Passing a large inherited `os.environ` into task launches or local provisioner
-  subprocesses without a backend-owned allowlist and sensitivity classification.
-- Duplicating queue/storage/task/secrets protocols instead of extending
-  `shared.cloud.types` or `engine/provisioner/cloud/types` only when a real
-  capability requires it.
-- Emitting provider SDK errors, token payloads, secret names that reveal
-  sensitive tenancy, or unsanitized user-controlled config values into logs.
-
-### Non-Goals
-
-- Do not make runtime derivation a deployment orchestrator, plugin runtime,
-  fleet manager, or persistence-backed backend registry.
-- Do not change domain service ownership, import boundaries, model schemas,
-  queue handler contracts, or CTF/CMS/mission-control workflows as part of
-  deriving backend config.
-- Do not introduce public low-level capability composition. The runtime registry
-  may decompose a backend internally, but the OSS user still selects a backend
-  bundle.
-- Do not rename compatibility env vars, task families, image repositories,
-  database fields, or Terraform state keys without a dedicated migration issue
-  and state-compatibility plan.
-
-## Setup And Doctor UX Preflight
-
-Scope for `GEN-2002` and #1115: expose a backend-aware setup and validation
-experience that proves the selected backend is ready before Terraform, Helm,
-Django, workers, or provisioners mutate infrastructure or start runtime work.
-This is a UX and validation boundary, not a new deployment orchestrator.
-
-### Command Boundary
-
-- Setup may create or update the root config and guide secret/bootstrap
-  reference creation. It must not become a second source of backend truth.
-- Doctor is read-only by default. It may inspect local files, tool availability,
-  provider identity, secret existence, rendered outputs, Terraform/Helm/K8s
-  validity, and reachable health endpoints, but it must not run `apply`,
-  `upgrade --install`, `kubectl apply`, secret version writes, first-user
-  seeding, or destructive cleanup.
-- The public UX should reuse the existing CLI grammar, dry-run behavior,
-  non-interactive behavior, and `info`/`warn`/`error` fail-fast style from
-  `scripts/bootstrap/deploy.py`. If a new entrypoint is introduced, it should
-  call the same parser/check/render functions rather than fork bootstrap logic.
-- CI-facing validation should use the same root parser and backend doctor checks
-  as the local UX. Documentation examples and workflow examples must not carry a
-  parallel interpretation of valid config.
-
-### Checks To Reuse
-
-| Layer | Canonical incumbent | Doctor guardrail |
-| --- | --- | --- |
-| CLI dependency checks | `scripts/bootstrap/deploy.py::check_dependencies`, command-specific tool lists | Extend the command-specific dependency model for backends. Do not scatter `shutil.which` checks across backend scripts. |
-| Provider security preflight | `validate_gcp_control_plane_security_inputs`, GCP edge promotion checks, AWS Cognito/OIDC and Terraform input conventions | Preserve fail-closed checks for hostname, managed TLS, admin CIDRs, provider auth, and identity bootstrap prerequisites before deploy. |
-| Render validation | `scripts/gcp/render_runtime_env.py`, `scripts/gcp/render_edge_manifest.py`, `render_gcp_helm_values`, Helm `runtimeEnv` | Doctor should render to memory or temp paths and compare against the backend contract. Do not hand-build env files in a separate path. |
-| Infrastructure validation | `terraform init -backend=false`, `terraform validate`, `.tflint.hcl`, Helm template rendering, `kubeconform`, `.kube-linter.yaml`, `ADR-006`, `ADR-008` | Doctor may front-run these checks and summarize them, but it must not replace their authority or mask their exact failures. |
-| Runtime validation | `config/settings.py`, `/health/`, Django `check --deploy`, cloud factories in `shared.cloud` and `engine/provisioner/cloud` | Validate generated runtime keys against canonical settings and factories before startup. Runtime provider selection must still flow from validated backend config. |
-| Tests | `scripts/bootstrap/tests/test_deploy.py`, `scripts/gcp/tests/*`, shared cloud factory tests, `tests/config/*` | Add contract tests around setup/doctor parsing, read-only behavior, redaction, and backend dispatch rather than only snapshotting terminal output. |
-
-### Security Layers
-
-- Auth surface: setup/doctor may verify the selected backend's auth mode and
-  required references, but provider credential collection stays in existing
-  provider flows. GCP first-operator handling continues through
-  `ensure_gcp_identity_platform_operator`; AWS remains Cognito/OIDC-compatible.
-- Secret-handling surface: checks must verify secret references, names, access,
-  or freshness without printing or storing secret payloads. If a payload must be
-  read for an existing backend check, use existing provider secret helpers,
-  temporary files with cleanup, and redacted diagnostics.
-- Env-binding shape: generated runtime values must keep secret identifiers in
-  ConfigMaps and secret values in Kubernetes Secrets or provider stores.
-  Doctor should fail when a value crosses that boundary.
-- OS/process exposure: subprocess calls use argv arrays. Do not pass passwords,
-  service-account JSON, private keys, access tokens, or bootstrap secrets in
-  argv, dry-run output, plan comments, shell snippets, or log messages.
-- Error envelopes and logs: CLI output should identify the failing check,
-  config path, canonical owner, and remediation. User-provided paths, hostnames,
-  and provider messages should be sanitized before logging.
-
-### Extensibility Seam
-
-Backend bundles should contribute setup and doctor metadata behind the same
-version/profile/backend seam as the root config schema: required tools, required
-secret references, provider prerequisites, renderers, validators, health checks,
-and whether a check is read-only. Adding a `local` backend or a production
-profile should add backend/profile check data, not a new setup command family or
-branch-derived validation path.
-
-### Anti-Patterns
-
-- A doctor command that mutates infrastructure, writes provider secrets, applies
-  Kubernetes manifests, seeds users, or silently repairs state.
-- Separate root config parsers for setup, doctor, render, CI, Terraform docs, or
-  Django settings.
-- Treating `CLOUD_PROVIDER`, branch names, Terraform directories, Helm values,
-  or generated env files as the source of truth when the root config exists.
-- Printing provider credentials, secret payloads, env dumps, Terraform outputs
-  with sensitive values, or command lines containing tokens.
-- Marking doctor green when Terraform, Helm, Kubernetes, ADR guard, import
-  boundaries, or security posture checks failed downstream.
-
-## Draft Requirements
-
-These requirements have been created in Ground Control as `DRAFT` requirements.
-They should remain `DRAFT` while the architecture is reviewed and transition to
-`ACTIVE` only when implementation starts.
-
-| UID | Title | Type | Priority | Statement |
-| --- | --- | --- | --- | --- |
-| `PLAT-2001` | Root installation configuration | Functional | MUST | Shifter must have one authoritative root installation configuration that selects the backend bundle and supplies deployment-level settings used to derive runtime, infrastructure, and validation behavior. |
-| `PLAT-2002` | Backend bundles are the OSS backend selection unit | Constraint | MUST | OSS users must choose a complete backend bundle rather than composing low-level provider capabilities in the default setup path. |
-| `PLAT-2003` | Backend bundle contract | Interface | MUST | Each backend bundle must expose a stable machine-readable contract for required settings, generated outputs, infrastructure entrypoints, validation checks, health checks, and documentation. |
-| `PLAT-2004` | Branch-independent deployment targeting | Constraint | MUST | Deployment target selection must come from explicit configuration or invocation, not from repository branch names. |
-| `PLAT-2005` | Backend-derived runtime configuration | Functional | MUST | Django, workers, and provisioner processes must derive provider and capability adapter selection from validated backend configuration. |
-| `PLAT-2006` | AWS/GCP compatibility and security preservation | Non-functional | MUST | Migration of existing AWS and GCP support must preserve current security controls, guardrails, and operational safety unless an ADR records an intentional change. |
-| `GEN-2001` | Standalone OSS deployment scope | Constraint | MUST | This repository must model one standalone Shifter deployment and avoid cross-install orchestration concepts in the OSS app model. |
-| `GEN-2002` | Backend-aware setup and validation UX | Functional | SHOULD | Users should be able to initialize, configure, and validate their selected backend before applying infrastructure or starting the application. |
-
-## ADR Status
-
-`ADR-011` accepts the root-configured backend bundle direction and supersedes
-the branch-routing portions of `ADR-005`.
-
-Follow-on implementation should preserve the adapter seam rule in `ADR-005-R1`,
-keep identity provider details behind the `ADR-009` auth seam, and update ADR
-evidence only when corresponding files change.
-
-## Issue Map
-
-- #1110 Draft requirements and ADR for root-configured backend bundles.
-- #1111 Inventory branch routing and provider coupling. See
-  [Branch Routing and Provider Coupling Inventory](branch-routing-provider-coupling-inventory.md).
-- #1112 Define root installation config schema.
-- #1113 Define backend bundle contract and registry.
-- #1114 Derive runtime configuration from selected backend bundle.
-- #1115 Add backend-aware setup and doctor validation UX.
-- #1116 Migrate AWS support into a backend bundle.
-- #1117 Migrate GCP support into a backend bundle.
-- #1118 Replace branch-targeted deployment docs and CI routing.
-- #1119 Define initial local backend scope.
-
-## Suggested Sequence
-
-1. Use the current-state inventory to define the root config schema and backend
-   bundle contract.
-2. Implement config loading, backend registry, and doctor validation.
-3. Migrate AWS and GCP through compatibility paths.
-4. Replace branch-targeted docs and CI routing with backend validation and
-   explicit deployment invocation.
-
-## Open Questions
-
-- Should the local backend be Docker Compose first, Kubernetes first, or staged?
-- Which commands should form the public setup UX: `make`, a Python CLI, Django
-  management commands, or a small standalone tool? (#1112 ships `shifter-config
-  validate`; the broader setup/doctor UX is #1115.)
-- Which existing Pulumi-related names are harmless compatibility aliases, and
-  which require migration to avoid confusing users?
-
-## Resolved
-
-- The first-class root config file is `shifter.yaml` at the repository root; the
-  contract is the `installation` package (`shifter/installation/`). (#1112)
-- The backend bundle contract and registry are the `installation.contract` and
-  `installation.registry` modules; they supersede the provisional
-  `installation.backends` list. The root schema derives backend/profile
-  validation from the registry, and the loader runs the selected backend
-  bundle's per-backend `settings` and secret-reference checks. The shipped
-  `aws`/`gcp` registry entries are provisional (no `settings_model` or
-  `reference_pattern` yet); the AWS/GCP migration issues (#1116/#1117) fill in
-  the per-backend settings schema, secret-reference patterns, and renderer /
-  validation-check wiring. (#1113)
+Do not treat CI branch names, Terraform environment directories, Helm values, or
+generated env files as additional authoritative backend selectors.

--- a/docs/dev/deploy-secrets.md
+++ b/docs/dev/deploy-secrets.md
@@ -8,9 +8,8 @@ the deploy workflows write them into a gitignored `local.auto.tfvars`
 that Terraform auto-loads alongside the baseline (the `.local`/`.auto`
 overrides win).
 
-This file is the canonical inventory of what needs to be configured before
-a fresh deploy. Set values under **Settings → Secrets and variables →
-Actions**, separated by:
+This file lists values that must be configured before a fresh deploy. Set values
+under **Settings → Secrets and variables → Actions**, separated by:
 
 - **Secrets** — sensitive (project IDs, public keys with identifying
   comments, alarm email addresses, allow-list domains for self-signup,
@@ -18,9 +17,7 @@ Actions**, separated by:
 - **Variables** — non-sensitive deployment parameters (region selection,
   feature flags).
 
-Required values are flagged as required by the workflow's own preflight
-step; missing-secret runs fail loud with a pointer to this doc rather
-than silently deploying the placeholder baseline.
+Required values are enforced by the workflow preflight step.
 
 ## GCP (gcp-dev)
 
@@ -40,6 +37,11 @@ Consumed by `.github/workflows/_gcp-dev.yml`.
 | `PLATFORM_BOOTSTRAP_STAFF_EMAILS` | secret | no | Comma-separated list of emails elevated to Django `is_staff` on first sign-in. |
 | `PLATFORM_BOOTSTRAP_SUPERUSER_EMAILS` | secret | no | Comma-separated list of emails elevated to `is_superuser`. |
 
+For local GCP bootstrap, `scripts/bootstrap/deploy.py` validates the bootstrap
+operator email against the Terraform output `identity_allowed_email_domain`.
+When Terraform outputs are not available yet, it uses
+`SHIFTER_GCP_OPERATOR_EMAIL_DOMAIN` from the process environment.
+
 ## AWS portal (`dev` / `prod`)
 
 Consumed by `.github/workflows/_shifter-platform.yml`. The portal stack
@@ -53,11 +55,11 @@ thresholds, etc.).
 | `AWS_ROLE_ARN_DEV` / `AWS_ROLE_ARN` | secret | yes | OIDC role assumed by the deploy job. |
 | `AWS_PORTAL_ENABLE_AUTOSCALING` | variable | no | Default `false`. Enables ASG scaling steps in the deploy job. |
 
-Additional values currently live in the committed `terraform.tfvars`
-baseline. To override them per-deployment, drop a `local.auto.tfvars`
-next to the corresponding `terraform.tfvars` and Terraform will merge
-the two automatically (the `.local`/`.auto` file is in `.gitignore`).
-The minimum set to override before a real deploy:
+Additional values live in the committed `terraform.tfvars` baseline. To
+override them per deployment, add a `local.auto.tfvars` next to the
+corresponding `terraform.tfvars`; Terraform merges it automatically. The
+`.local`/`.auto` file is gitignored. The minimum set to override before a real
+deploy:
 
 - `domain_name`, `ses_domain`, `ctfd_domain`, `ctf_from_email`
 - `alarm_email`
@@ -68,10 +70,8 @@ The minimum set to override before a real deploy:
 - `user_storage_bucket`
 - AWS-account-suffixed bucket names that vary per environment
 
-Future iterations of this workflow will move these into GitHub secrets
-the same way the GCP path does; for now, contributors run a local
-`terraform apply` (with their own `local.auto.tfvars`) from a workstation
-that has the right role.
+For AWS local deploys, run `terraform apply` with a gitignored
+`local.auto.tfvars` from a workstation that has the target role.
 
 ## Local development
 

--- a/shifter/installation/README.md
+++ b/shifter/installation/README.md
@@ -1,149 +1,115 @@
-# installation — root installation config + backend bundle contract
+# installation
 
-A Shifter OSS deployment is configured by **one** root file, `shifter.yaml`, at the
-repository root, and that file selects a **backend bundle**. This package owns both
-contracts: the typed root schema, a loader that fails fast with aggregated errors, the
-`shifter-config` CLI, the machine-readable backend bundle contract every backend
-exposes, and the registry of known backends. It is the single authoritative parser —
-setup, doctor, CI, and (later) runtime derivation validate against it rather than
-re-parsing the YAML by hand or maintaining a parallel backend table. Constrained by
-[ADR-011](../../docs/adr/index.yaml) and the
-[Root-Configured Backend Bundles](../../docs/architecture/root-configured-backend-bundles.md)
-architecture note.
+This package validates the root Shifter installation config, `shifter.yaml`.
 
-This package is Django-free (pydantic v2 + PyYAML only) so scripts, CI, and the
-Django app can all use it.
+`shifter.yaml` is a user-authored file at the repository root. It selects one
+backend bundle and provides deployment-level settings. The installation package
+is the authoritative parser for that file.
 
-## `shifter.yaml`
+## Supported Backends
 
-```yaml
-version: 1                       # optional, default 1; only schema version 1 is supported
-backend: aws                     # required; one of the known backends (currently: aws, gcp)
-deployment:                      # required
-  name: shifter                  # required; DNS-label-safe (lowercase letters, digits, internal hyphens, 1-40 chars)
-  domain: shifter.example.com    # required; a real public DNS hostname (>= 2 labels, not an IP, not bare localhost)
-  profile: prod                  # optional, default prod; one of {prod, dev}; must be allowed by the selected backend
-secrets:                         # logical name -> reference; the selected backend requires an entry for each
-  django_secret_key: shifter/prod/django-secret-key   #   secret it declares (value may be `prompt` to collect at
-  db_password: prompt                                 #   deploy time); typo'd / unknown keys are rejected
-settings:                        # optional; backend-specific settings, validated by the selected backend bundle
-  region: us-east-2
-```
+| Backend | Profiles | Required secrets |
+| --- | --- | --- |
+| `aws` | `prod`, `dev` | `django_secret_key`, `db_password` |
+| `gcp` | `prod`, `dev` | `django_secret_key` |
 
-### Field reference
+Both backend entries currently accept any `settings` mapping. Backend-specific
+setting keys are still enforced by the deployment path that consumes them.
 
-| Key | Required | Type | Notes |
-| --- | --- | --- | --- |
-| `version` | no (default `1`) | int | Schema version. Only `1` is supported today. |
-| `backend` | yes | string | The backend bundle to use. Must be a name in the [backend bundle registry](#backend-bundle-contract) (`aws`, `gcp`); the `local` backend is #1119. |
-| `deployment.name` | yes | string | DNS-label-safe identifier for this installation: lowercase letters, digits, and internal hyphens; 1-40 characters. |
-| `deployment.domain` | yes | string | Public hostname users reach this deployment at. Must be a fully-qualified DNS name (at least two labels), lowercase, with no scheme, no IP literal, and no trailing dot. |
-| `deployment.profile` | no (default `prod`) | string | Deployment tier: `prod` or `dev`. Must also be a profile the selected backend supports. |
-| `secrets` | no (default `{}`) | mapping | Logical secret name → reference identifier. Keys match `^[a-z][a-z0-9_]*$`. Values are *references* — a provider secret name, a GitHub Actions secret name, an environment variable, or the literal `prompt` (collect at deploy time) — never the secret value itself. The selected backend bundle requires an entry here for each secret *it* declares (value may be `prompt`) and rejects entries for secrets it does not use, so a missing or typo'd secret key fails before deploy. |
-| `settings` | no (default `{}`) | mapping | Backend-specific settings. The root schema only checks it is a mapping; the selected backend bundle's `settings_model` validates the contents. |
+## Config File
 
-`validate` checks the *shape* of the root config — the backend selector, deployment
-identity, secret references, and that `settings` is a mapping — then runs the selected
-backend bundle's checks: its `settings_model` validates the `settings` contents, and
-its `RequiredSecret.reference_pattern`s validate the supplied secret references. Unknown
-top-level keys, unknown keys under `deployment`, missing required keys, an unknown
-backend, an unsupported profile/backend combination, a malformed name or domain, a
-`secrets` value that is clearly raw key material (multi-line, PEM-headered, or
-implausibly long), and any backend-specific `settings` or secret-reference problem the
-bundle reports are all rejected — and all problems are reported together — *before*
-Terraform, Helm, Django, workers, or deployment scripts run. The shipped `aws`/`gcp`
-bundles accept any `settings` mapping and reference format today (`settings_model` and
-`reference_pattern` unset); the full per-backend validation lands with the AWS/GCP
-migration issues (#1116/#1117).
-
-> The root config holds references, not secret values. Storing a raw password,
-> token, private key, or service-account JSON in `shifter.yaml` is rejected by the
-> schema where it is recognizable and caught independently by `gitleaks`. The schema
-> cannot tell a short secret value from a secret *name*, so the precise per-provider
-> reference grammar is the backend bundle's responsibility
-> (`RequiredSecret.reference_grammar` for humans, `reference_pattern` for machines).
-
-## Backend bundle contract
-
-A **backend bundle** is the public OSS unit of backend selection: a deployment picks
-one bundle (`aws`, `gcp`, `local`, ...) and that bundle owns everything the backend
-needs. [`contract.py`](contract.py) defines the typed, machine-readable contract every
-bundle exposes; [`registry.py`](registry.py) is the single registry of known bundles
-that the root schema, setup, doctor, CI, and docs generation all consume.
-
-A `BackendBundle` carries:
-
-| Field | What it is |
-| --- | --- |
-| `contract_version` | The contract-shape version (independent of `shifter.yaml`'s `version`); an unknown version fails closed. |
-| `name`, `title`, `maturity`, `description` | Stable backend identity for selection and documentation. |
-| `supported_profiles` | The deployment profiles this backend supports (replaces the old hard-coded `ALLOWED_PROFILES` data). |
-| `settings_model` | A Pydantic model (which must set `extra="forbid"`) validating this backend's `RootConfig.settings`; `None` means "any mapping" until the backend supplies one. |
-| `required_tools` | Command-line tools the backend's setup/deploy/doctor flow needs (bare executable names; every `validation_checks` executable must appear here). |
-| `required_secrets` | Logical secret names, the human-readable reference grammar each accepts, and an optional `reference_pattern` (anchored regex) for machine validation (the root config holds references, never values). |
-| `generated_outputs` | The runtime/infra/CI values the backend renders, each tagged with owner, source, an `OutputDestination` (where it lands — `runtime-env`, `kubernetes-secret`, `provider-secret-store`, `terraform-variables`, `helm-values`, `generated-file`), sensitivity (`public` / `secret-reference` / `secret-value`), and the process roles that consume it. A `secret-value` output may only be placed in a Kubernetes Secret or a provider secret store — the contract rejects, e.g., a secret value destined for a ConfigMap. |
-| `validation_checks` | Checks the backend runs (or front-runs) before mutating infrastructure — each an argv command spec (PATH-resolved executable name, repo-relative path args, no internal whitespace or shell metacharacters), never a shell string. |
-| `health_checks` | Read-only post-render / post-deploy probes. |
-| `capabilities` | Which cloud-neutral protocols (storage, queue, task runner, secrets, ...) the backend satisfies through the existing `shared.cloud` / `engine/provisioner/cloud` seams. |
-| `owned_files`, `docs` | Repository-relative path roots the backend owns, so validation and docs generation can find them without a branch router. |
-
-Within a bundle, the `name` / `logical_name` of every `RequiredTool`, `RequiredSecret`,
-`GeneratedOutput`, `ValidationCheck`, and `HealthCheck` must be unique (consumers build
-maps keyed by them).
-
-```python
-from installation import BACKEND_BUNDLES, get_backend_bundle
-
-bundle = get_backend_bundle("aws")               # -> BackendBundle | None
-list(BACKEND_BUNDLES)                            # -> ["aws", "gcp"]
-bundle.supports_profile("dev")                   # -> True
-bundle.validate_settings({"region": "us-east-2"})    # -> normalized dict; raises InstallationConfigError on failure
-bundle.settings_issues({"region": "us-east-2"})      # -> [ConfigIssue, ...] anchored under "settings"; [] if valid
-bundle.secret_reference_issues({"django_secret_key": "..."})  # -> [ConfigIssue, ...] anchored under "secrets.<name>"
-```
-
-Adding a backend is a new entry in `BACKEND_BUNDLES` (plus its worked example under
-`examples/`) — not a schema change and not a branch router.
-
-## Usage
-
-This package is its own [uv](https://docs.astral.sh/uv/) project, so run the CLI
-through `uv run --project shifter/installation` from the repo root (paths are
-relative to the directory you run from):
+Start from one of the checked examples:
 
 ```bash
-# After copying an example to ./shifter.yaml at the repo root:
-uv run --project shifter/installation shifter-config validate            # validates ./shifter.yaml
-uv run --project shifter/installation shifter-config validate path/to/shifter.yaml
-# equivalently:  uv run --project shifter/installation python -m installation validate [PATH]
+cp shifter/installation/examples/aws.yaml shifter.yaml
+uv run --project shifter/installation shifter-config validate shifter.yaml
 ```
 
-`validate` prints `OK — root config shape is valid (backend=…, profile=…)` and exits
-`0` when the config is valid, or prints each problem to stderr and exits `1`.
+Use `examples/gcp.yaml` for GCP.
 
-```python
-from installation import load_root_config, validate_root_config_file, InstallationConfigError
+## Root Fields
 
-config = load_root_config("shifter.yaml")   # raises InstallationConfigError with aggregated .issues
-issues = validate_root_config_file("shifter.yaml")  # returns a list of ConfigIssue; never raises
+| Key | Required | Notes |
+| --- | --- | --- |
+| `version` | no | Defaults to `1`. Only `1` is accepted. |
+| `backend` | yes | Must be `aws` or `gcp`. |
+| `deployment.name` | yes | Lowercase letters, digits, and internal hyphens. Length: 1-40 characters. |
+| `deployment.domain` | yes | Lowercase DNS hostname with at least two labels. IP literals, schemes, trailing dots, and bare hostnames are rejected. |
+| `deployment.profile` | no | Defaults to `prod`. Must be allowed by the selected backend. |
+| `secrets` | no | Mapping of logical secret name to a reference. Values must be references, not secret values. |
+| `settings` | no | Backend-specific mapping. The root schema only checks that this is a mapping. |
+
+Secret names must match `^[a-z][a-z0-9_]*$`.
+
+Secret references must be single-line strings with no surrounding whitespace.
+The root schema rejects recognizable raw secret material, including PEM blocks,
+multi-line values, and implausibly long values. It cannot distinguish every short
+secret value from a reference; `gitleaks` remains part of the enforcement path.
+
+The literal value `prompt` is accepted for any required secret. It records that
+the value must be supplied during deployment.
+
+## Validation
+
+Run validation from the repository root:
+
+```bash
+uv run --project shifter/installation shifter-config validate shifter.yaml
 ```
 
-## Examples
+The command exits `0` when the config is valid. It exits `1` and prints all
+detected issues when validation fails.
 
-Worked, machine-validated configs for the supported backends live in
-[`examples/`](examples/) (`aws.yaml`, `gcp.yaml`). The package test suite loads
-every file in that directory through the same parser, so an example can never drift
-from the schema. Copy one to `./shifter.yaml` at the repo root and edit it for your
-deployment.
+Validation rejects:
 
-## Layout
+- missing config files
+- invalid YAML
+- duplicate YAML mapping keys
+- YAML merge keys (`<<`)
+- non-mapping top-level YAML
+- unknown top-level fields
+- unknown `deployment` fields
+- missing required fields
+- unknown backend names
+- unsupported profile/backend combinations
+- malformed deployment names or domains
+- malformed secret names or references
+- missing required backend secrets
+- secret names not used by the selected backend
+
+Validation messages are path-based and do not echo rejected input values.
+
+## Backend Bundle Contract
+
+`contract.py` defines the machine-readable backend bundle contract.
+`registry.py` contains the backend entries consumed by the schema and loader.
+
+A backend bundle declares:
+
+- backend identity and supported profiles
+- required command-line tools
+- required logical secrets and accepted reference grammar
+- generated outputs, including destination and sensitivity
+- validation checks and health checks
+- cloud-neutral capabilities
+- owned repository paths and docs
+
+Generated outputs are classified as `public`, `secret-reference`, or
+`secret-value`. A `secret-value` output may only be placed in a Kubernetes Secret
+or provider secret store.
+
+Validation commands are stored as argv arrays, not shell strings. Command specs
+reject shell metacharacters, absolute paths, path traversal, and tokens with
+internal whitespace.
+
+## Package Layout
 
 | File | Purpose |
 | --- | --- |
-| `schema.py` | Pydantic v2 models for the root config (`RootConfig`, `DeploymentConfig`) — the root-key *shape*, including that `settings` is a mapping; the contents of `settings` and the secret reference grammar belong to the selected backend bundle. |
-| `contract.py` | The machine-readable backend bundle contract: `BackendBundle` and its `GeneratedOutput` / `ValidationCheck` / `HealthCheck` / `RequiredTool` / `RequiredSecret` / `OwnedFiles` / `CommandSpec` parts, plus the `BackendMaturity` / `OutputSensitivity` / `ProcessRole` / `BackendCapability` / `OutputKind` enums. |
-| `registry.py` | The single registry of known backend bundles (`BACKEND_BUNDLES`, `get_backend_bundle`) and the derived `KNOWN_BACKENDS` / `KNOWN_PROFILES` / `ALLOWED_PROFILES` the root schema uses. |
-| `loader.py` | `load_root_config` / `validate_root_config_file` — read YAML, validate the root shape, then run the selected backend bundle's `settings` and secret-reference checks; aggregate every problem. |
-| `errors.py` | `ConfigIssue` and `InstallationConfigError` — the error model (never carries the rejected input, so it cannot leak a mistyped secret). |
-| `cli.py` / `__main__.py` | The `shifter-config` CLI. |
-| `examples/` | Worked example configs, validated by the test suite. |
+| `schema.py` | Root config model and root-field validators. |
+| `loader.py` | YAML loading, duplicate-key checks, root validation, and backend validation dispatch. |
+| `contract.py` | Backend bundle contract types and invariants. |
+| `registry.py` | Supported backend bundle registry. |
+| `cli.py` | `shifter-config validate`. |
+| `errors.py` | Sanitized validation issue model. |
+| `examples/` | Valid AWS and GCP example configs. |

--- a/shifter/installation/examples/aws.yaml
+++ b/shifter/installation/examples/aws.yaml
@@ -26,7 +26,7 @@ secrets:
   django_secret_key: shifter/prod/django-secret-key
   db_password: shifter/prod/db-password
 
-# Backend-specific settings. Validated by the AWS backend bundle, not by the root
-# schema — see issue #1113 for the backend bundle contract.
+# Backend-specific settings. The root schema checks that this is a mapping.
+# Deployment tooling validates the values it consumes.
 settings:
   region: us-east-2

--- a/shifter/installation/examples/gcp.yaml
+++ b/shifter/installation/examples/gcp.yaml
@@ -25,8 +25,8 @@ deployment:
 secrets:
   django_secret_key: projects/your-gcp-project/secrets/shifter-django-secret-key/versions/latest
 
-# Backend-specific settings. Validated by the GCP backend bundle, not by the root
-# schema — see issue #1113 for the backend bundle contract.
+# Backend-specific settings. The root schema checks that this is a mapping.
+# Deployment tooling validates the values it consumes.
 settings:
   region: us-central1
   project_id: your-gcp-project

--- a/shifter/shifter_platform/documentation/docs/getting-started/quickstart.md
+++ b/shifter/shifter_platform/documentation/docs/getting-started/quickstart.md
@@ -1,6 +1,6 @@
 # Quickstart
 
-Launch your first range in 5 minutes.
+Launch your first range.
 
 ## Prerequisites
 
@@ -26,7 +26,8 @@ Launch your first range in 5 minutes.
 
 ### 3. Wait for Provisioning
 
-Takes 10 minutes. You'll see status updates:
+Provisioning time depends on the selected scenario and cloud backend. You'll see
+status updates:
 
 - **Pending** - Queued for provisioning
 - **Provisioning** - Infrastructure spinning up

--- a/shifter/shifter_platform/documentation/docs/index.md
+++ b/shifter/shifter_platform/documentation/docs/index.md
@@ -4,7 +4,7 @@ Run XDR/XSIAM demos without installing tools on your laptop.
 
 ## Get Started
 
-- [Quickstart](getting-started/quickstart) - Launch your first range in 5 minutes
+- [Quickstart](getting-started/quickstart) - Launch your first range
 - [Key Concepts](getting-started/concepts) - Agents, ranges, scenarios, terminals
 
 ## How-To Guides

--- a/shifter/shifter_platform/documentation/docs/technical/architecture.md
+++ b/shifter/shifter_platform/documentation/docs/technical/architecture.md
@@ -1,22 +1,13 @@
 # Shifter Architecture
 
-Enterprise, multi-user, extensible cyber range platform. Deploys to AWS or GCP.
+Shifter is a Django application for managing cyber ranges. It deploys to AWS or
+GCP.
 
 ## Platform Infrastructure
 
-Infrastructure is defined per cloud provider. A `CLOUD_PROVIDER` environment variable selects the active provider at runtime.
-
-```mermaid
-graph TB
-    subgraph Platform["Platform Infrastructure"]
-        Global["Global<br/>(IAM, identity federation)"]
-        Core["Core<br/>(Container registry, base resources)"]
-        Range["Range<br/>(Networking, guest isolation)"]
-    end
-
-    Global --> Core
-    Core --> Range
-```
+Infrastructure is defined per cloud provider. `shifter.yaml` selects the backend
+bundle for installation. The backend emits runtime configuration, including
+`CLOUD_PROVIDER`, for Django, workers, and the provisioner.
 
 | Component | Purpose |
 |-----------|---------|
@@ -57,28 +48,13 @@ Common operator requirements:
 
 ### Hosting
 
-CI/CD via GitHub Actions with self-hosted runners. Separate workflow per cloud target.
+CI/CD runs through GitHub Actions on self-hosted runners. AWS and GCP have
+separate deployment paths.
 
 ## Shifter (Django)
 
-Django monorepo. Users interact via Mission Control; backend apps expose service interfaces.
-
-```mermaid
-graph TB
-    subgraph Shifter["Shifter Platform"]
-        MC["Mission Control<br/>(Presentation)"]
-        SE["Shifter Engine<br/>(Range Management)"]
-        CMS["Shifter CMS<br/>(Content Management)"]
-        SA["Shifter Admin<br/>(Platform Management)"]
-    end
-
-    Users((Users)) --> MC
-
-    MC -->|service calls| SE
-    MC -->|service calls| CMS
-    MC -->|service calls| SA
-    SE -.->|references models| CMS
-```
+Django monorepo. Users interact through Mission Control. Backend apps expose
+service interfaces.
 
 | Element | App | Purpose |
 |---------|-----|---------|
@@ -89,7 +65,8 @@ graph TB
 
 ### Event-Driven Communication
 
-Provisioner publishes status events to a message topic. All domains subscribe via per-domain queues and process events through domain-specific handlers.
+The provisioner publishes status events to a message topic. Domains subscribe
+through per-domain queues and process events through domain-specific handlers.
 
 On AWS this is SNS → SQS. On GCP this is Pub/Sub topic → subscriptions. The application code uses cloud adapter interfaces (see [Cloud Adapters](dev/cloud-adapters)) and does not reference provider APIs directly.
 
@@ -121,7 +98,14 @@ sequenceDiagram
 
 ## Cloud Adapters
 
-The platform and provisioner use protocol-based abstractions to isolate cloud-specific code. `CLOUD_PROVIDER` selects the implementation at runtime via factory functions.
+The platform and provisioner use protocol-based abstractions to isolate
+cloud-specific code. `CLOUD_PROVIDER` selects the implementation at runtime via
+factory functions.
+
+The installation backend registry declares the supported backends, required
+tools, required secrets, generated outputs, validation checks, health checks,
+owned files, and cloud-neutral capabilities. See
+[Installation Config](dev/installation-config).
 
 See [Cloud Adapters](dev/cloud-adapters) for the full interface reference.
 
@@ -130,7 +114,7 @@ See [Cloud Adapters](dev/cloud-adapters) for the full interface reference.
 | Decision | Choice | Rationale |
 |----------|--------|-----------|
 | UI separation | Mission Control is presentation only | Clean separation of presentation from domain logic. Views handle HTTP; services own business rules. |
-| API style | REST via Django REST Framework | Proven, simple, mature Django ecosystem support. |
+| API style | REST via Django REST Framework | Uses the existing Django application stack. |
 | Cloud abstraction | Protocol-based adapters per provider | Same Django app runs on AWS or GCP. Cloud-specific code isolated behind interfaces. |
 | Identity | Provider seam with per-cloud implementations | AWS keeps Cognito/OIDC. GCP uses Identity Platform with FirebaseUI/browser auth. Both require MFA, email-based usernames, and keep provider-specific auth details behind the app auth seam. |
-| Domains | example.com | Operator-owned domain. DNS may be hosted externally or in cloud-managed DNS. Current `gcp-dev` hostname is `shifter.example.com`. |
+| Domains | Operator-owned hostname | DNS may be hosted externally or in cloud-managed DNS. |

--- a/shifter/shifter_platform/documentation/docs/technical/dev/ci-cd.md
+++ b/shifter/shifter_platform/documentation/docs/technical/dev/ci-cd.md
@@ -1,16 +1,17 @@
-∏# CI/CD Pipeline
+# CI/CD Pipeline
 
-How code gets from your branch to production.
+How GitHub Actions validates and deploys Shifter.
 
 ## Overview
 
-All CI/CD runs through GitHub Actions. The main orchestrator is `deploy.yml`, which coordinates:
+All CI/CD runs through GitHub Actions. The main orchestrator is `deploy.yml`,
+which coordinates:
 
 1. **Quality** - Linting, tests, security scanning
 2. **Core** - ECR repositories (foundation)
 3. **Range** - Range VPC infrastructure
 4. **Shifter Engine** - Container build
-5. **Portal** - Infrastructure, container, deployment
+5. **Shifter Platform** - Application infrastructure, containers, deployment
 
 ## Trigger Rules
 
@@ -22,9 +23,14 @@ All CI/CD runs through GitHub Actions. The main orchestrator is `deploy.yml`, wh
 | Push to `gcp-dev` | Fast GCP validation + GCP deploy |
 | Push to `main` | Quality + Plan + Apply to prod |
 
-PRs get Terraform plan comments. `dev` is now the integration branch for cross-provider validation only. Actual dev deployments happen only from `aws-dev` and `gcp-dev`.
+PRs get Terraform plan comments. `dev` is the integration branch for
+cross-provider validation only. Dev deployments happen only from `aws-dev` and
+`gcp-dev`.
 
-`gcp-dev` pushes intentionally skip the global quality fan-out so GCP break/fix work can move faster. The fast path still runs the provider-local guardrails in `_gcp-dev.yml`: Terraform fmt/init/validate plus rendered-manifest schema validation before deploy. Broad lint/test/security coverage remains required on `dev`, on PRs, and on production.
+`gcp-dev` pushes skip the global quality fan-out. The fast path still runs the
+provider-local guardrails in `_gcp-dev.yml`: Terraform fmt/init/validate plus
+rendered-manifest schema validation before deploy. Broad lint/test/security
+coverage runs on PRs, `dev`, and `main`.
 
 ## Workflow Files
 
@@ -36,7 +42,7 @@ PRs get Terraform plan comments. `dev` is now the integration branch for cross-p
 ├── _range.yml              # Range VPC
 ├── _gcp-dev.yml            # GCP validate/deploy workflow
 ├── _shifter-engine.yml     # Shifter Engine container
-└── _portal.yml             # Portal infra + deploy
+└── _shifter-platform.yml   # Shifter Platform infra + deploy
 ```
 
 Underscore prefix (`_*.yml`) indicates reusable workflows called by `deploy.yml`.
@@ -65,9 +71,10 @@ The orchestrator uses path filters to run only relevant jobs:
 | Filter | Triggers When |
 |--------|--------------|
 | `core` | ECR module, environment root, deploy workflow |
-| `range` | Range Terraform, pulumi-state module |
+| `range` | Range Terraform, engine state module |
 | `shifter_engine` | Shifter Engine code, ECR module |
-| `portal` | Portal Django code, portal Terraform |
+| `shifter_platform` | Shifter Django code, portal/Guacamole Terraform |
+| `gcp` | GCP Terraform, GCP Kubernetes assets, GCP scripts, GCP cloud adapters |
 
 ## Quality Gate
 
@@ -91,10 +98,10 @@ Runs on every PR and push:
   via `.kube-linter.yaml`.
 - **K8s security scanning**: Checkov with the `kubernetes` framework (soft fail
   while manifests are being hardened).
-- **Tests**: `pytest` with PostgreSQL service container
+- **Tests**: `pytest` with PostgreSQL service container for `shifter_platform`
 - **IaC scanning**: Checkov for Terraform (soft fail - warnings only)
 - **Secret scanning**: gitleaks on newly introduced commits
-- **Coverage**: Shifter Engine requires 80% minimum
+- **Coverage**: `shifter_platform` emits terminal and XML coverage reports
 
 Architecture checks are not skipped by the normal test-skip path. `[skip tests]` may skip slow test jobs on `dev`, but it does not bypass ADR or architecture enforcement.
 
@@ -121,9 +128,9 @@ them into a gitignored `local.auto.tfvars` before `terraform apply`.
 See [`docs/dev/deploy-secrets.md`](../../../../../../docs/dev/deploy-secrets.md)
 for the required surface.
 
-## Portal Deployment
+## AWS Platform Deployment
 
-After Terraform apply, portal deployment:
+After Terraform apply, AWS platform deployment:
 
 1. Build Docker image
 2. Push to ECR with tags: `latest`, `{git-sha}`
@@ -150,7 +157,7 @@ Push to main      → AWS prod deploy
 
 ## Provider Routing
 
-`deploy.yml` now resolves branch intent explicitly:
+`deploy.yml` resolves branch intent explicitly:
 
 - `dev` is the shared integration branch. It must validate both provider paths when shared code changes, but it must not apply infrastructure or deploy workloads.
 - `aws-dev` is the only branch that deploys the AWS dev environment.
@@ -159,7 +166,7 @@ Push to main      → AWS prod deploy
 - Shared Shifter application changes trigger both the AWS validation chain and the GCP validation chain on `dev`, so provider overlaps are caught before promotion to either deploy branch.
 - The GCP control plane is deployed through the Helm chart in `platform/charts/shifter`, with generated values layered on top of environment defaults.
 - The GCP portal auth contract is FirebaseUI/browser-side Identity Platform auth plus server-side verified-token exchange. Do not add Django credential handling to recreate Cognito semantics.
-- New multi-cloud work should enter through the shared cloud adapter layers rather than adding provider-specific calls directly in domain services.
+- Multi-cloud work enters through the shared cloud adapter layers rather than provider-specific calls in domain services.
 
 ## Self-Hosted Runner
 
@@ -179,7 +186,7 @@ All workflows run on `self-hosted` runners (not GitHub-hosted). The runner has:
 3. Expand the job you want to inspect
 4. Each step shows its logs
 
-Terraform plans are also posted as PR comments for easy review.
+Terraform plans are also posted as PR comments.
 
 ## Common Issues
 

--- a/shifter/shifter_platform/documentation/docs/technical/dev/index.md
+++ b/shifter/shifter_platform/documentation/docs/technical/dev/index.md
@@ -6,12 +6,13 @@ Getting started as a Shifter developer.
 
 1. [Local Setup](local-setup) - Clone, dependencies, run locally
 2. [Setup](setup) - Deploy to AWS or GCP from scratch
-3. [CI/CD](ci-cd) - How deployments work
-4. [Secrets](secrets) - What secrets exist, where they live
-5. [Terraform](terraform) - Infrastructure patterns
-6. [Cloud Adapters](cloud-adapters) - Cloud abstraction layer
-7. [Principles](principles) - Engineering philosophy
-8. [ADR Enforcement](adr-enforcement) - Architecture guardrails and policy checks
+3. [Installation Config](installation-config) - `shifter.yaml` schema and validation
+4. [CI/CD](ci-cd) - How deployments work
+5. [Secrets](secrets) - What secrets exist, where they live
+6. [Terraform](terraform) - Infrastructure patterns
+7. [Cloud Adapters](cloud-adapters) - Cloud abstraction layer
+8. [Principles](principles) - Engineering philosophy
+9. [ADR Enforcement](adr-enforcement) - Architecture guardrails and policy checks
 
 ## Prerequisites
 
@@ -56,6 +57,7 @@ shifter/
 │   ├── charts/shifter/        # Helm chart for the GCP control plane
 │   └── k8s/gcp/               # GCP deployment assets and base manifests
 ├── scripts/                    # Bootstrap and utility scripts
+├── shifter/installation/        # shifter.yaml parser, validator, backend registry
 └── .github/workflows/          # CI/CD pipelines (AWS + GCP)
 ```
 

--- a/shifter/shifter_platform/documentation/docs/technical/dev/installation-config.md
+++ b/shifter/shifter_platform/documentation/docs/technical/dev/installation-config.md
@@ -1,0 +1,85 @@
+# Installation Config
+
+`shifter.yaml` is the root installation config. It lives at the repository root,
+selects one backend bundle, and provides deployment-level settings.
+
+The authoritative parser is `shifter/installation`.
+
+## Validate
+
+Run from the repository root:
+
+```bash
+uv run --project shifter/installation shifter-config validate shifter.yaml
+```
+
+The command exits `0` when the file is valid. It exits `1` and prints all
+detected issues when validation fails.
+
+## Start From An Example
+
+```bash
+cp shifter/installation/examples/aws.yaml shifter.yaml
+uv run --project shifter/installation shifter-config validate shifter.yaml
+```
+
+Use `shifter/installation/examples/gcp.yaml` for GCP.
+
+## Supported Backends
+
+| Backend | Profiles | Required secrets |
+| --- | --- | --- |
+| `aws` | `prod`, `dev` | `django_secret_key`, `db_password` |
+| `gcp` | `prod`, `dev` | `django_secret_key` |
+
+Both backends currently accept any `settings` mapping at root-config validation
+time. Deployment tooling still validates the values it consumes.
+
+## Fields
+
+| Key | Required | Notes |
+| --- | --- | --- |
+| `version` | no | Defaults to `1`. Only `1` is accepted. |
+| `backend` | yes | Must be `aws` or `gcp`. |
+| `deployment.name` | yes | Lowercase letters, digits, and internal hyphens. Length: 1-40 characters. |
+| `deployment.domain` | yes | Lowercase DNS hostname with at least two labels. IP literals, schemes, trailing dots, and bare hostnames are rejected. |
+| `deployment.profile` | no | Defaults to `prod`. Must be supported by the selected backend. |
+| `secrets` | no | Mapping of logical secret name to a reference. Values must be references, not secret values. |
+| `settings` | no | Backend-specific mapping. The root schema only checks that this is a mapping. |
+
+Secret names must match `^[a-z][a-z0-9_]*$`.
+
+The literal secret reference `prompt` is valid for every required secret. It
+records that the value must be supplied during deployment.
+
+## Validation Rules
+
+Validation rejects:
+
+- missing config files
+- invalid YAML
+- duplicate YAML mapping keys
+- YAML merge keys (`<<`)
+- non-mapping top-level YAML
+- unknown top-level fields
+- unknown `deployment` fields
+- missing required fields
+- unknown backend names
+- unsupported profile/backend combinations
+- malformed deployment names or domains
+- malformed secret names or references
+- missing required backend secrets
+- secret names not used by the selected backend
+
+Validation messages identify paths and do not echo rejected input values.
+
+## Secret Handling
+
+`shifter.yaml` stores secret references only.
+
+Do not put passwords, tokens, private keys, service-account JSON, or certificate
+material in `shifter.yaml`.
+
+The root schema rejects recognizable raw secret material, including PEM blocks,
+multi-line values, and implausibly long values. Short raw values can look like
+references, so `gitleaks` is still required.

--- a/shifter/shifter_platform/documentation/docs/technical/dev/setup.md
+++ b/shifter/shifter_platform/documentation/docs/technical/dev/setup.md
@@ -1,17 +1,30 @@
 # Setup
 
-Deploying Shifter from a bare cloud account to a running environment.
+Deploy Shifter from a cloud account to a running environment.
 
 ## Prerequisites
 
 - Python 3.12+
+- `uv`
 - Terraform 1.7+
 - GitHub CLI (`gh`) authenticated
 - Docker
 - **AWS**: AWS CLI v2 configured with SSO or IAM credentials
 - **GCP**: `gcloud` CLI authenticated with appropriate project
 
-## Cold-Start Deployment (New AWS Account)
+## Root Installation Config
+
+Create and validate `shifter.yaml` before deployment:
+
+```bash
+cp shifter/installation/examples/aws.yaml shifter.yaml
+uv run --project shifter/installation shifter-config validate shifter.yaml
+```
+
+Use `shifter/installation/examples/gcp.yaml` for GCP. See
+[Installation Config](installation-config) for the field reference.
+
+## AWS Deployment
 
 Use the deployment CLI which walks you through each step with confirmations:
 
@@ -26,7 +39,7 @@ Use the deployment CLI which walks you through each step with confirmations:
 Or run phases separately:
 
 ```bash
-# Phase 1: Bootstrap AWS account (S3, DynamoDB, IAM)
+# Phase 1: Bootstrap AWS account (S3 state backend, GitHub OIDC, IAM)
 ./scripts/bootstrap/deploy.py bootstrap --env prod --profile <your-prod-profile>
 
 # Or use standalone bash scripts:
@@ -39,8 +52,7 @@ Or run phases separately:
 ### 1. Bootstrap AWS Account
 
 The `bootstrap` command creates:
-- S3 bucket for Terraform state
-- DynamoDB table for state locking
+- S3 bucket for Terraform state with S3 native locking (`use_lockfile = true`)
 - GitHub OIDC provider (keyless CI/CD auth)
 - IAM role with all required permissions
 
@@ -125,7 +137,8 @@ The CLI walks through each component, shows the plan, and asks for confirmation 
 
 **Via CI/CD:**
 
-Push to `main` branch to trigger deployment (after bootstrap and backend.tf are configured).
+Push to `main` to deploy the AWS production environment after bootstrap and
+backend configuration are complete.
 
 **Manual deployment:**
 
@@ -288,17 +301,13 @@ aws ecr describe-images --repository-name shifter-prod-portal
 
 If empty, push a container first.
 
-## GCP Cold-Start Deployment
+## GCP Deployment
 
 GCP uses a single Terraform module (`platform/terraform/gcp/modules/platform-core/`) plus a Helm-packaged control plane (`platform/charts/shifter/`).
 
 ### 1. GCP Project Setup
 
-Create a GCP project and enable required APIs. The bootstrap script handles this:
-
-```bash
-# See scripts/gcp/ for bootstrap tooling
-```
+Create a GCP project and enable the APIs required by the bootstrap path.
 
 ### 2. Configure Workload Identity Federation
 
@@ -333,7 +342,7 @@ For CI deploys the equivalent values come from GitHub secrets — see
 
 ### 4. Deploy
 
-Normal GCP deployments happen through CI/CD on `gcp-dev`. The bootstrap entrypoint remains available for first-time setup and controlled recovery:
+GCP deployments run through CI/CD on `gcp-dev`. The bootstrap entrypoint is:
 
 ```bash
 ./scripts/bootstrap/deploy.py gdc-bootstrap --project-id <your-gcp-project-id> --cluster-id cluster1
@@ -349,4 +358,6 @@ That flow:
 
 ### 5. DNS and TLS
 
-The secure bootstrap path expects a real hostname and managed TLS from the start. Point `shifter.example.com` to the reserved global ingress IP so the Google-managed certificate can become active. The GCP path no longer uses the old debug-auth fallback as an acceptable first-boot mode.
+The GCP path requires a real hostname and managed TLS. Point the configured
+hostname to the reserved global ingress IP so the Google-managed certificate can
+become active.

--- a/shifter/shifter_platform/documentation/docs/technical/dev/terraform.md
+++ b/shifter/shifter_platform/documentation/docs/technical/dev/terraform.md
@@ -1,6 +1,6 @@
-# Terraform Patterns
+# Terraform
 
-How we manage infrastructure.
+Infrastructure layout and local Terraform commands.
 
 ## Directory Structure
 
@@ -34,8 +34,8 @@ platform/terraform/
 │   │   └── vpc/              # Portal VPC, subnets
 │   ├── range/
 │   │   └── vpc/              # Range VPC, Network Firewall
-│   ├── pulumi-provisioner/   # ECS task for Shifter Engine
-│   ├── pulumi-state/         # S3 + DynamoDB for Pulumi
+│   ├── engine-provisioner/   # ECS task for Shifter Engine
+│   ├── engine-state/         # Engine state bucket and DynamoDB runtime locks
 │   ├── guacamole/            # Browser-based RDP
 │   ├── log-aggregation/      # Centralized logging
 │   └── ecr/                  # Container registries
@@ -76,9 +76,13 @@ Each component has its own state file:
 | Range | `shifter/{env}/range/terraform.tfstate` |
 | Global | `global/{component}/terraform.tfstate` |
 
-State is stored in S3 with DynamoDB locking:
+AWS Terraform state is stored in S3 with S3 native locking
+(`use_lockfile = true`):
 - **Dev**: `shifter-dev-infra-*` bucket
 - **Prod**: `shifter-infra-*` bucket
+
+The `engine-state` module creates a DynamoDB table for provisioner runtime
+locks. It is not the Terraform backend lock.
 
 ## Working Locally
 
@@ -100,7 +104,7 @@ terraform validate
 CI bootstraps a GCS backend bucket named `${project_id}-terraform-state` for
 `gcp-dev` pushes before running `terraform init`.
 
-The `gcp-dev` tfvars file now carries the security-critical public edge and operator-access settings:
+The `gcp-dev` tfvars file carries the public edge and operator-access settings:
 
 ```hcl
 public_hostname             = "shifter.example.com"
@@ -112,7 +116,8 @@ dns_zone_dns_name       = ""
 dns_record_ttl          = 300
 ```
 
-`gdc-bootstrap` now fails before Terraform apply if those secure inputs are missing. The GCP path no longer treats a public IP/debug runtime as an acceptable bootstrap fallback, and normal applies happen through CI/CD on `gcp-dev` rather than ad hoc local deploys.
+`gdc-bootstrap` fails before Terraform apply if these inputs are missing.
+Routine GCP applies happen through CI/CD on `gcp-dev`.
 
 ### Plan
 

--- a/shifter/shifter_platform/documentation/docs/technical/platform_infrastructure/index.md
+++ b/shifter/shifter_platform/documentation/docs/technical/platform_infrastructure/index.md
@@ -1,6 +1,6 @@
 # Platform Infrastructure
 
-Cloud infrastructure and CI/CD for Shifter. Deploys to AWS or GCP.
+Cloud infrastructure and CI/CD for Shifter.
 
 ## AWS
 
@@ -16,8 +16,8 @@ platform/terraform/
 │   ├── ecr/              # Container registries
 │   ├── portal/           # Shifter app infrastructure
 │   ├── range/            # Range VPC and networking
-│   ├── pulumi-provisioner/   # ECS Fargate for Engine
-│   ├── pulumi-state/         # Pulumi backend (S3 + DynamoDB)
+│   ├── engine-provisioner/   # ECS Fargate for Engine
+│   ├── engine-state/         # Engine state bucket and DynamoDB locks
 │   ├── guacamole/            # Browser-based RDP (Guacamole)
 │   └── log-aggregation/      # Centralized logging
 ├── environments/
@@ -34,7 +34,7 @@ platform/terraform/
 | **Core** | `environments/{env}/` | ECR repositories, budget alerts |
 | **Range** | `modules/range/` | Range VPC, security groups, Network Firewall |
 | **Portal*** | `modules/portal/` | ALB, EC2 (configurable ASG), RDS, Redis, Cognito, S3 |
-| **Provisioner** | `modules/pulumi-provisioner/` | ECS Fargate task for range provisioning |
+| **Provisioner** | `modules/engine-provisioner/` | ECS Fargate task for range provisioning |
 | **Guacamole** | `modules/guacamole/` | Browser-based RDP access to range instances |
 | **CloudFormation** | `cloudformation/{env}/` | Cortex XDR connector IAM roles (manually deployed) |
 
@@ -42,7 +42,9 @@ platform/terraform/
 
 ### State Management
 
-Terraform state stored in S3 with DynamoDB locking per environment.
+Terraform state is stored in S3 with S3 native locking (`use_lockfile = true`).
+The engine state module also creates a DynamoDB table for provisioner runtime
+locks; that table is not the Terraform backend lock.
 
 ## GCP
 
@@ -74,7 +76,7 @@ platform/
 
 ### State Management
 
-Terraform state stored in GCS bucket per environment.
+Terraform state is stored in a GCS bucket per environment.
 
 ## Related Docs
 


### PR DESCRIPTION
## Summary

Review and update installation, backend bundle, setup, CI/CD, Terraform, and platform infrastructure docs against the current code and repo configuration.

Closes #1210

Requirement: `GEN-2002`

## Changes

- Rewrote the root-configured backend bundle architecture note as current-state documentation.
- Added in-app technical docs for `shifter.yaml` schema and validation.
- Updated the installation README and examples to match the actual schema, loader, backend registry, and secret-reference behavior.
- Corrected setup, CI/CD, Terraform, architecture, platform infrastructure, quickstart, and deploy-secrets docs for stale claims and unsupported wording.

## Validation

- `python3 scripts/adr_guard/adr_guard.py --all --level ci`
- `uv run pytest` from `shifter/installation` (`292 passed`)
- `git diff --check`
- Commit pre-commit hooks passed, including installation tests and shifter_platform tests.

## ADR Impact

- ADR-011 documentation updated through `docs/architecture/root-configured-backend-bundles.md`.

## Changelog

N/A, docs-only change.