### PR TITLE
fix(security): server-side magic-byte validation for S3 uploads (#696)

### DIFF
--- a/changelog.d/696.security.md
+++ b/changelog.d/696.security.md
@@ -1,0 +1,16 @@
+**Server-side magic-byte inspection now runs before every S3 upload is
+finalized.** Three upload paths previously trusted only the client-side
+extension / magic-byte checks: CTF challenge attachments
+(`ctf.services.attachment.add_challenge_file`), agent installer uploads
+(`cms.services.complete_upload`), and experiment script uploads
+(`cms.experiments.services.complete_script_upload`). Each path now reads a
+bounded prefix of the uploaded content — inline from the file object for the
+Django-mediated CTF flow, and via a new `ObjectStorage.read_object_header`
+range-GET for the presigned-URL agent and script flows — and rejects the
+upload before tagging the object as completed or creating the database
+record. CTF attachments pick one of three policies per extension (positive
+magic-byte match, UTF-8 text with no binary signature, or OPAQUE for raw-byte
+containers like `.bin` / `.raw` / `.dd`). Agent installers reuse the existing
+`cms.assets.validation.ALLOWED_FORMATS` registry. Scripts must be UTF-8
+without a binary signature. The header byte budget is provider-neutral and
+configurable via `UPLOAD_INSPECTION_MAX_HEADER_BYTES` (default 512).

--- a/docs/architecture/server-side-upload-inspection-preflight-696.md
+++ b/docs/architecture/server-side-upload-inspection-preflight-696.md
@@ -1,0 +1,123 @@
+# Server-Side Upload Inspection Preflight
+
+Issue #696 closes the upload validation gap for direct-to-S3 uploads by making
+backend finalization verify object content, not just client-side checks or S3
+metadata. This is a validation-boundary change, not a new upload workflow.
+
+## Boundary
+
+- The canonical upload flow remains: authenticated view -> `cms.services`
+  service boundary -> `cms.assets` storage/token/validation helpers ->
+  `shared.cloud.ObjectStorage` provider adapter.
+- Finalization is the enforcement point for server-side content inspection.
+  The backend must validate the uploaded object's size, extension-derived
+  expected format, and magic bytes before tagging the object as completed or
+  creating `AgentConfig`.
+- Object inspection should read only the minimum header bytes needed for the
+  expected format. Do not download multi-GB agent objects into Django memory.
+- The `ObjectStorage` protocol is the provider seam. If header reads are needed,
+  add a small range-read capability there and implement it in both AWS S3 and
+  GCS adapters instead of reaching for raw boto3 in CMS code.
+- The existing experiment script upload path is related but separate. Scripts
+  are text assets validated by `cms.experiments.schemas.ScriptUploadInput` and
+  the experiment service; do not merge agent installer and Python script
+  validation concepts.
+
+## Incumbents To Reuse
+
+| Concern | Canonical incumbent | Guardrail |
+| --- | --- | --- |
+| Upload workflow | `mission_control.views.initiate_upload`, `complete_upload`, `cancel_upload`; `cms.services.initiate_upload`, `complete_upload` | Preserve the three-step direct upload flow and session upload lock. |
+| Upload token | `cms.assets.upload_token` | Keep HMAC token verification as the authority for user, key, filename, expected size, expected OS, and expiry. |
+| File format rules | `cms.assets.validation.ALLOWED_FORMATS`, `validate_file_extension`, `validate_magic_bytes` | Reuse the same `FileFormat` registry for backend object inspection; do not create a second magic-byte table. |
+| Storage operations | `cms.assets.s3` wrappers over `shared.cloud.get_object_storage()` | Keep CMS-facing `S3Error` compatibility, but implement provider operations in `shared.cloud` adapters. |
+| Cloud seam | `shared.cloud.types.ObjectStorage`, `shared.cloud.aws.storage.AWSObjectStorage`, `shared.cloud.gcp.storage.GCPObjectStorage` | Add any range/header read once at the protocol and adapter layer. |
+| Config | `config.settings` upload limits and bucket aliases: `AGENT_MAX_FILE_SIZE_MB`, `AGENT_USER_STORAGE_QUOTA_MB`, `AGENT_UPLOAD_URL_EXPIRES`, `STORAGE_BUCKET_NAME` / `AWS_S3_BUCKET_NAME` | Reuse existing settings unless a real inspection limit is needed. If added, make it provider-neutral. |
+| Errors | `cms.exceptions.CMSError`, `cms.assets.s3.S3Error`, `cms.assets.validation.ValidationError`, `shared.cloud.exceptions.CloudStorageError` | Bridge cloud errors to `S3Error`, then to existing service/view error envelopes. |
+| Logging | `logging.getLogger(__name__)`, `shared.log_sanitize.safe_log` where object keys or provider errors are logged | Log user id, object key, expected/actual size, and result; never log presigned URLs, tokens, raw object bytes, or full provider exception payloads without sanitizing. |
+| Audit | `risk_register.services.audit_log`, existing agent create audit | Audit creation only after inspection succeeds; failed validation should be observable in logs but should not create an agent record. |
+
+## Security Layers
+
+- Auth surface: `mission_control.views.complete_upload` must remain
+  `@login_required` and must call `cms.services.complete_upload` with
+  `_get_user(request)`. Authentication only identifies the caller; inspection
+  must still run for every upload.
+- Token shape: `cms.assets.upload_token.verify_upload_token` must continue to
+  validate signature, expiry, user id, S3 key, filename, expected size, OS, and
+  agent type before any object read. The implementation must not trust request
+  JSON for these values during finalization.
+- Extension and format policy: `cms.assets.validation.validate_file_extension`
+  should derive the expected `FileFormat` from the signed filename, and
+  `validate_magic_bytes` should remain the single magic-byte comparator.
+- Object metadata gate: `cms.assets.s3.verify_s3_object_exists` / `head_object`
+  must still fail closed on missing objects and exact size mismatch before DB
+  creation. Header inspection is an additional gate, not a replacement.
+- Object content gate: the backend must fetch only a bounded byte range from the
+  object under the token's S3 key and validate it against the expected
+  `FileFormat.magic_bytes`. Reads must go through `ObjectStorage` so AWS and GCP
+  remain aligned.
+- Secret-handling surface: upload tokens and presigned URLs are bearer
+  credentials. They must stay out of logs, audit state, exception messages, task
+  env vars, process argv, and persisted model fields.
+- Config/env binding: storage bucket and provider selection must continue
+  through `STORAGE_BUCKET_NAME` / `AWS_S3_BUCKET_NAME`, `CLOUD_REGION`, and
+  `CLOUD_PROVIDER`; do not introduce an upload-inspection bucket or provider
+  side channel.
+- OS/runtime exposure: this inspection should happen in the Django backend or a
+  purpose-built worker with scoped object-read permission. Do not shell out to
+  `aws s3 cp`, pass tokens or keys through process argv, or write uploaded
+  headers to `/tmp`.
+- Error envelope: HTTP responses should continue returning the existing JSON
+  `{"error": ...}` shape. Validation failures may say the uploaded content does
+  not match the expected type, but must not echo object bytes, presigned URLs,
+  tokens, bucket names, or raw provider diagnostics.
+- Infrastructure policy: if the implementation chooses an S3 event/Lambda
+  scanner instead of synchronous finalization, it must add least-privilege
+  object read/tag permissions, dead-letter/visibility semantics, and lifecycle
+  cleanup for rejected objects. It must not finalize the DB row before the
+  scanner verdict is durable.
+
+## Extensibility Seam
+
+Keep the seam as an object-inspection helper shaped by a signed upload contract:
+`s3_key`, expected size, expected `FileFormat`, and a configurable header byte
+budget. That allows the next reasonable change, such as SHA-256 calculation,
+antivirus scanning, or script text validation, to compose behind the same
+finalization gate without re-editing views or duplicating token parsing.
+
+If a new setting is needed, prefer a provider-neutral
+`UPLOAD_INSPECTION_MAX_HEADER_BYTES` defaulted from the largest registered magic
+signature plus small slack. Do not hard-code AWS `Range` header semantics above
+the cloud adapter.
+
+## Gotchas And Anti-Patterns
+
+- Do not treat MIME type, `ContentType`, extension, ETag, or client-side
+  JavaScript checks as proof of file type.
+- Do not validate magic bytes at initiate time only; direct S3 upload means the
+  backend has not seen the bytes yet.
+- Do not create a duplicate `ALLOWED_MAGIC_BYTES`, `FileType`, exception
+  hierarchy, or upload DTO in a view, Lambda, or Terraform-adjacent script.
+- Do not finalize, tag `status=completed`, audit creation, or expose the agent
+  to range launch until inspection succeeds.
+- Do not delete a suspect object before recording enough sanitized context to
+  debug user-facing failures; also do not leave rejected objects permanently
+  retained without lifecycle cleanup.
+- Do not use a broad background scanner that races finalization unless the model
+  has an explicit pending/quarantine state. The current `AgentConfig` flow has
+  no such state.
+- Do not widen CORS, bucket public access, or range-instance S3 read policy to
+  solve backend inspection.
+
+## Non-Goals
+
+- Redesigning uploads away from presigned URLs.
+- Replacing `cms.assets` with experiment script upload code or CTF attachment
+  code.
+- Adding antivirus, sandbox execution, package signature verification, or full
+  file hashing unless explicitly scoped by a follow-up issue.
+- Changing storage bucket encryption, CORS, lifecycle, Terraform state, range
+  instance download behavior, or experiment artifact downloads.
+- Making uploaded agents safe to execute; this only verifies that the object
+  matches the claimed installer/archive container format before persistence.

--- a/shifter/shifter_platform/cms/assets/s3.py
+++ b/shifter/shifter_platform/cms/assets/s3.py
@@ -185,6 +185,33 @@ def verify_s3_object_exists(s3_key: str) -> tuple[int, str]:
         raise S3Error(str(e)) from e
 
 
+def read_agent_header(s3_key: str, max_bytes: int) -> bytes:
+    """Read up to `max_bytes` from the start of an agent upload object.
+
+    Used by `complete_upload` to inspect magic bytes server-side before
+    finalization (issue #696). Bridges `CloudStorageError` to `S3Error`.
+
+    Raises:
+        S3Error: If the object cannot be read.
+    """
+    logger.debug("read_agent_header: s3_key=%s max_bytes=%d", s3_key, max_bytes)
+
+    if not settings.AWS_S3_BUCKET_NAME:
+        logger.error("read_agent_header: AWS_S3_BUCKET_NAME is not configured")
+        raise S3Error("AWS_S3_BUCKET_NAME is not configured")
+
+    try:
+        storage = get_object_storage()
+        return storage.read_object_header(
+            bucket=settings.AWS_S3_BUCKET_NAME,
+            key=s3_key,
+            max_bytes=max_bytes,
+        )
+    except CloudStorageError as e:
+        logger.error("read_agent_header: failed s3_key=%s error=%s", s3_key, e)
+        raise S3Error(str(e)) from e
+
+
 def tag_s3_object(s3_key: str, tags: dict[str, str]) -> None:
     """
     Add tags to an S3 object (used to mark uploads as completed).

--- a/shifter/shifter_platform/cms/assets/validation.py
+++ b/shifter/shifter_platform/cms/assets/validation.py
@@ -1,94 +1,68 @@
-"""File validation for agent uploads."""
+"""File validation for agent uploads.
 
-from dataclasses import dataclass
+Thin domain-specific layer over `shared.uploads.inspection`. `ALLOWED_FORMATS`
+is the agent-installer registry; size and extension checks remain here because
+they depend on Django settings and Django UploadedFile semantics.
+"""
 
 from django.conf import settings
+
+from shared.uploads.inspection import (
+    FileFormat,
+    InspectionError,
+    MagicSignature,
+    get_file_extension,
+)
+from shared.uploads.inspection import (
+    validate_magic_bytes as _validate_magic_bytes_pure,
+)
 
 
 class ValidationError(Exception):
     """Raised when file validation fails."""
 
-    pass
 
-
-@dataclass
-class FileFormat:
-    """Definition of an allowed file format."""
-
-    extensions: list[str]
-    magic_bytes: bytes
-    os_slug: str
-    description: str
-
-
-# Allowed file formats with magic byte signatures
+# Allowed installer formats. ``.msi`` matches the OLE compound document
+# signature; distinguishing MSI from other OLE compound files (e.g. legacy
+# Office DOC/XLS) requires parsing the FAT directory to extract the root
+# CLSID and is outside a bounded header-byte inspection. The agent-extension
+# allowlist constrains the realistic attack surface to OLE-compound material.
 ALLOWED_FORMATS: dict[str, FileFormat] = {
     "msi": FileFormat(
         extensions=[".msi"],
-        magic_bytes=bytes([0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1]),
+        signatures=(MagicSignature(0, bytes([0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1])),),
         os_slug="windows",
-        description="Windows Installer (.msi)",
+        description="Windows Installer / OLE Compound Document (.msi)",
     ),
     "zip": FileFormat(
         extensions=[".zip"],
-        magic_bytes=bytes([0x50, 0x4B, 0x03, 0x04]),
+        signatures=(MagicSignature(0, bytes([0x50, 0x4B, 0x03, 0x04])),),
         os_slug="windows",
         description="ZIP Archive (.zip)",
     ),
     "tar_gz": FileFormat(
         extensions=[".tar.gz", ".tgz"],
-        magic_bytes=bytes([0x1F, 0x8B]),
+        signatures=(MagicSignature(0, bytes([0x1F, 0x8B])),),
         os_slug="linux-generic",
         description="Gzip Tarball (.tar.gz, .tgz)",
     ),
     "deb": FileFormat(
         extensions=[".deb"],
-        magic_bytes=b"!<arch>",
+        signatures=(MagicSignature(0, b"!<arch>"),),
         os_slug="linux-debian",
         description="Debian Package (.deb)",
     ),
     "rpm": FileFormat(
         extensions=[".rpm"],
-        magic_bytes=bytes([0xED, 0xAB, 0xEE, 0xDB]),
+        signatures=(MagicSignature(0, bytes([0xED, 0xAB, 0xEE, 0xDB])),),
         os_slug="linux-rhel",
         description="RPM Package (.rpm)",
     ),
 }
 
 
-def get_file_extension(filename: str) -> str:
-    """
-    Get file extension, handling compound extensions like .tar.gz.
-
-    Args:
-        filename: The filename to extract extension from
-
-    Returns:
-        Extension including leading dot, lowercase
-    """
-    lower = filename.lower()
-
-    # Check compound extensions first
-    if lower.endswith(".tar.gz"):
-        return ".tar.gz"
-
-    # Simple extension
-    if "." in filename:
-        return "." + lower.rsplit(".", 1)[-1]
-
-    return ""
-
-
 def get_format_for_extension(extension: str) -> FileFormat | None:
-    """
-    Find the file format definition for an extension.
-
-    Args:
-        extension: File extension including dot
-
-    Returns:
-        FileFormat if found, None otherwise
-    """
+    """Find the file format definition for an extension."""
     ext_lower = extension.lower()
     for fmt in ALLOWED_FORMATS.values():
         if ext_lower in fmt.extensions:
@@ -105,22 +79,16 @@ def get_allowed_extensions() -> list[str]:
 
 
 def validate_file_size(file_obj) -> None:
-    """
-    Validate file size is within limits.
-
-    Args:
-        file_obj: Django UploadedFile object
+    """Validate file size is within limits.
 
     Raises:
-        ValidationError: If file exceeds size limit
+        ValidationError: If file exceeds `settings.AGENT_MAX_FILE_SIZE_MB`.
     """
     max_bytes = settings.AGENT_MAX_FILE_SIZE_MB * 1024 * 1024
 
-    # Get file size - Django's UploadedFile has a size attribute
     if hasattr(file_obj, "size"):
         size = file_obj.size
     else:
-        # Fallback: seek to end to get size
         file_obj.seek(0, 2)
         size = file_obj.tell()
         file_obj.seek(0)
@@ -132,18 +100,7 @@ def validate_file_size(file_obj) -> None:
 
 
 def validate_file_extension(filename: str) -> FileFormat:
-    """
-    Validate file has an allowed extension.
-
-    Args:
-        filename: Name of the uploaded file
-
-    Returns:
-        FileFormat for the extension
-
-    Raises:
-        ValidationError: If extension is not allowed
-    """
+    """Validate file has an allowed extension and return the matching format."""
     extension = get_file_extension(filename)
     if not extension:
         raise ValidationError("File has no extension")
@@ -157,53 +114,40 @@ def validate_file_extension(filename: str) -> FileFormat:
 
 
 def validate_magic_bytes(file_obj, expected_format: FileFormat) -> None:
-    """
-    Validate file content matches expected magic bytes.
+    """Validate file content matches every magic-byte signature on the format.
 
-    Args:
-        file_obj: File-like object to validate
-        expected_format: The format we expect based on extension
-
-    Raises:
-        ValidationError: If magic bytes don't match
+    Wraps the pure-bytes inspector in `shared.uploads.inspection` with the
+    file-object seek/read pattern Django UploadedFiles expect. Reads enough
+    bytes to evaluate the highest-offset signature on the format.
     """
-    # Read enough bytes to check magic
-    magic_len = len(expected_format.magic_bytes)
+    read_len = max(expected_format.min_header_bytes, 1)
     file_obj.seek(0)
-    header = file_obj.read(magic_len)
+    header = file_obj.read(read_len)
     file_obj.seek(0)
 
-    if len(header) < magic_len:
-        raise ValidationError("File is too small to be a valid installer")
-
-    if not header.startswith(expected_format.magic_bytes):
-        raise ValidationError(
-            f"File content does not match expected format ({expected_format.description}). "
-            "The file may be corrupted or mislabeled."
-        )
+    try:
+        _validate_magic_bytes_pure(header, expected_format)
+    except InspectionError as exc:
+        message = str(exc)
+        if "too small to be a valid" in message:
+            raise ValidationError("File is too small to be a valid installer") from exc
+        if "does not match expected format" in message:
+            raise ValidationError(
+                f"File content does not match expected format ({expected_format.description}). "
+                "The file may be corrupted or mislabeled."
+            ) from exc
+        raise ValidationError(message) from exc
 
 
 def validate_agent_file(file_obj, filename: str) -> FileFormat:
-    """
-    Perform full validation of an agent upload file.
+    """Perform full validation of an agent upload file.
 
-    Args:
-        file_obj: Django UploadedFile or file-like object
-        filename: Original filename
-
-    Returns:
-        FileFormat of the validated file
+    Order: size first (cheapest), then extension, then magic bytes.
 
     Raises:
-        ValidationError: If any validation check fails
+        ValidationError: If any check fails.
     """
-    # Check size first (cheapest check)
     validate_file_size(file_obj)
-
-    # Check extension
     fmt = validate_file_extension(filename)
-
-    # Check magic bytes
     validate_magic_bytes(file_obj, fmt)
-
     return fmt

--- a/shifter/shifter_platform/cms/experiments/s3.py
+++ b/shifter/shifter_platform/cms/experiments/s3.py
@@ -181,6 +181,34 @@ def delete_s3_object(s3_key: str) -> None:
     logger.info("delete_s3_object: success s3_key=%s", safe_log(s3_key))
 
 
+def read_script_header(s3_key: str, max_bytes: int) -> bytes:
+    """Read up to `max_bytes` from the start of a script upload object.
+
+    Bridges `CloudStorageError` to the `S3Error` family used by experiment
+    services. Used by `complete_script_upload` to inspect server-side that
+    the uploaded bytes are text rather than a binary file masquerading as a
+    Python script (issue #696).
+    """
+    if not settings.AWS_S3_BUCKET_NAME:
+        logger.error("read_script_header: AWS_S3_BUCKET_NAME not configured")
+        raise S3Error("AWS_S3_BUCKET_NAME is not configured")
+
+    try:
+        storage = get_object_storage()
+        return storage.read_object_header(
+            bucket=settings.AWS_S3_BUCKET_NAME,
+            key=s3_key,
+            max_bytes=max_bytes,
+        )
+    except CloudStorageError as e:
+        logger.error(
+            "read_script_header: failed s3_key=%s error=%s",
+            safe_log(s3_key),
+            safe_log(str(e)),
+        )
+        raise S3Error(str(e)) from e
+
+
 def verify_s3_object(s3_key: str) -> tuple[int, str]:
     """Verify an S3 object exists and return its metadata.
 

--- a/shifter/shifter_platform/cms/experiments/services.py
+++ b/shifter/shifter_platform/cms/experiments/services.py
@@ -36,6 +36,7 @@ from cms.experiments.s3 import (
     generate_presigned_download_url,
     generate_script_upload_url,
     generate_upload_token,
+    read_script_header,
     verify_s3_object,
     verify_upload_token,
 )
@@ -50,6 +51,12 @@ from risk_register.models import AuditLog
 from risk_register.services import audit_log
 from shared.constants import USER_CANNOT_BE_NONE, USER_MUST_BE_SAVED
 from shared.log_sanitize import safe_log
+from shared.uploads.inspection import (
+    InspectionError as _ScriptInspectionError,
+)
+from shared.uploads.inspection import (
+    validate_text_header as _validate_script_text_header,
+)
 
 if TYPE_CHECKING:
     from django.contrib.auth.models import User
@@ -189,6 +196,7 @@ def complete_script_upload(user: User, upload_token: str) -> ScriptAsset:
             raise ScriptUploadError(f"Invalid upload token: {e}") from e
 
         s3_key = payload["s3_key"]
+        expected_size = payload["file_size"]
 
         try:
             actual_size, etag = verify_s3_object(s3_key)
@@ -206,6 +214,54 @@ def complete_script_upload(user: User, upload_token: str) -> ScriptAsset:
             )
             delete_s3_object(s3_key)
             raise ScriptUploadError(f"File size {actual_size} exceeds maximum {max_size} bytes")
+
+        # Enforce the signed upload contract: actual object size must match
+        # the size signed into the upload token. Matches the agent
+        # `complete_upload` invariant; without it a caller could initiate a
+        # small-size upload and PUT a different-size object to the same key.
+        if actual_size != expected_size:
+            logger.warning(
+                "complete_script_upload: size mismatch s3_key=%s expected=%d actual=%d",
+                safe_log(s3_key),
+                expected_size,
+                actual_size,
+            )
+            delete_s3_object(s3_key)
+            raise ScriptUploadError(f"File size mismatch: expected {expected_size}, got {actual_size}")
+
+        # Server-side full-body content inspection (issue #696). Scripts are
+        # capped at 1 MB, so we read the entire body — not just a header — and
+        # require it to be valid UTF-8 with no binary signature anywhere in
+        # the stream. This blocks the "valid text prefix + binary tail" bypass
+        # the bounded-header check by itself cannot detect.
+        try:
+            body = read_script_header(s3_key, max_size)
+        except S3Error as e:
+            logger.error(
+                "complete_script_upload: body read failed s3_key=%s: %s",
+                safe_log(s3_key),
+                safe_log(str(e)),
+            )
+            raise ScriptUploadError("Upload content inspection failed") from e
+
+        try:
+            _validate_script_text_header(body, complete=True)
+        except _ScriptInspectionError as e:
+            logger.warning(
+                "complete_script_upload: header inspection rejected upload user_id=%s s3_key=%s reason=%s",
+                user.pk,
+                safe_log(s3_key),
+                e,
+            )
+            try:
+                delete_s3_object(s3_key)
+            except S3Error as delete_exc:
+                logger.error(
+                    "complete_script_upload: delete after inspection failure also failed s3_key=%s: %s",
+                    safe_log(s3_key),
+                    safe_log(str(delete_exc)),
+                )
+            raise ScriptUploadError("Uploaded content is not a valid script (binary or non-UTF-8 header)") from e
 
         script = ScriptAsset(
             user=user,

--- a/shifter/shifter_platform/cms/services.py
+++ b/shifter/shifter_platform/cms/services.py
@@ -2801,13 +2801,22 @@ def initiate_upload(  # noqa: C901
             )
             raise CMSError("Failed to initiate upload") from e
 
-        # Generate upload token
+        # Generate upload token. Agent installer formats always carry an
+        # os_slug — the shared FileFormat dataclass makes the field Optional
+        # for non-installer consumers (CTF), so narrow here.
+        os_slug = file_format.os_slug
+        if os_slug is None:
+            logger.error(
+                "initiate_upload: installer format missing os_slug for filename=%s",
+                filename,
+            )
+            raise CMSError("Internal error: installer format misconfigured")
         upload_token = generate_upload_token(
             user_id=user.id,
             s3_key=s3_key,
             name=name,
             filename=filename,
-            os_slug=file_format.os_slug,
+            os_slug=os_slug,
             file_size=file_size,
             agent_type=agent_type,
         )
@@ -2853,10 +2862,27 @@ def complete_upload(user: User, upload_token: str) -> AgentConfig:
         CMSError: If token is invalid/expired, S3 verification fails,
             or size mismatch
     """
-    from cms.assets.s3 import S3Error, tag_s3_object, verify_s3_object_exists
+    from django.conf import settings as _settings
+
+    from cms.assets import s3 as _s3
+    from cms.assets.s3 import (
+        S3Error,
+        tag_s3_object,
+        verify_s3_object_exists,
+    )
     from cms.assets.services import create_agent
     from cms.assets.upload_token import verify_upload_token
+    from cms.assets.validation import (
+        ValidationError as _AssetValidationError,
+    )
+    from cms.assets.validation import (
+        validate_file_extension,
+    )
     from cms.exceptions import CMSError
+    from shared.uploads.inspection import InspectionError as _InspectionError
+    from shared.uploads.inspection import (
+        validate_magic_bytes as _validate_magic_bytes,
+    )
 
     # Input validation - user
     if user is None:
@@ -2929,6 +2955,55 @@ def complete_upload(user: User, upload_token: str) -> AgentConfig:
             )
             msg = f"File size mismatch: expected {expected_size}, got {actual_size}"
             raise CMSError(msg)
+
+        # Server-side header inspection (issue #696). Resolve the expected
+        # installer format from the signed filename, read a bounded byte range,
+        # and reject the upload if the magic bytes don't match. Token shape
+        # already guarantees `filename` came from initiate_upload, so the
+        # extension lookup cannot be steered by request input.
+        try:
+            expected_format = validate_file_extension(payload["filename"])
+        except _AssetValidationError as exc:
+            logger.error(
+                "complete_upload: filename failed extension check user_id=%s",
+                user.id,
+            )
+            _s3.delete_agent(s3_key)
+            raise CMSError(f"Invalid upload filename: {exc}") from exc
+
+        max_header = _settings.UPLOAD_INSPECTION_MAX_HEADER_BYTES
+        try:
+            header = _s3.read_agent_header(s3_key, max_header)
+        except S3Error as exc:
+            logger.error(
+                "complete_upload: header read failed user_id=%s s3_key=%s",
+                user.id,
+                s3_key,
+            )
+            raise CMSError("Upload content inspection failed") from exc
+
+        try:
+            _validate_magic_bytes(header, expected_format)
+        except _InspectionError as exc:
+            logger.warning(
+                "complete_upload: header inspection rejected upload user_id=%s s3_key=%s expected=%s reason=%s",
+                user.id,
+                s3_key,
+                expected_format.description,
+                exc,
+            )
+            # Remove the rejected object so the bucket does not accumulate
+            # mismatched uploads. delete_agent failures are best-effort logged.
+            try:
+                _s3.delete_agent(s3_key)
+            except S3Error as delete_exc:
+                logger.error(
+                    "complete_upload: delete after inspection failure also failed user_id=%s s3_key=%s error=%s",
+                    user.id,
+                    s3_key,
+                    delete_exc,
+                )
+            raise CMSError("Uploaded content does not match the declared installer format") from exc
 
         # Tag S3 object as completed
         tag_s3_object(s3_key, {"status": "completed"})

--- a/shifter/shifter_platform/config/settings.py
+++ b/shifter/shifter_platform/config/settings.py
@@ -527,6 +527,21 @@ AGENT_UPLOAD_URL_EXPIRES = 600  # 10 minutes for presigned URL
 SCRIPT_MAX_FILE_SIZE_BYTES = 1 * 1024 * 1024  # 1MB max per script
 SCRIPT_UPLOAD_URL_EXPIRES = 600  # 10 minutes for presigned URL
 
+# Server-side upload inspection (issue #696). Provider-neutral byte budget for
+# the magic-byte header read performed at finalization across CTF, agent, and
+# experiment-script uploads. The floor is dictated by the largest registered
+# offset signature (POSIX tar's ``ustar`` marker at offset 257 needs 262 bytes);
+# 512 comfortably covers it with slack. Sub-floor or non-positive overrides
+# (env mis-set to 0/-1) clamp to the floor so the adapter never raises
+# ``ValueError`` from an invalid runtime config, and so offset-based formats
+# remain inspectable.
+_UPLOAD_INSPECTION_FLOOR = 512
+try:
+    _UPLOAD_INSPECTION_RAW = int(os.environ.get("UPLOAD_INSPECTION_MAX_HEADER_BYTES", str(_UPLOAD_INSPECTION_FLOOR)))
+except ValueError:
+    _UPLOAD_INSPECTION_RAW = _UPLOAD_INSPECTION_FLOOR
+UPLOAD_INSPECTION_MAX_HEADER_BYTES = max(_UPLOAD_INSPECTION_RAW, _UPLOAD_INSPECTION_FLOOR)
+
 # Experiment execution limits
 EXPERIMENT_MAX_TOTAL_RUNS = 10
 EXPERIMENT_MAX_PARALLEL_RUNS = 5

--- a/shifter/shifter_platform/ctf/inspection.py
+++ b/shifter/shifter_platform/ctf/inspection.py
@@ -1,0 +1,288 @@
+"""Server-side header inspection for CTF challenge file attachments.
+
+Each whitelisted extension lives in one of four categories:
+
+- ``MAGIC``: the header must positively match one of the allowed
+  ``FileFormat`` alternatives (each alternative is itself a list of
+  ``MagicSignature`` anchors that all must match). Covers PNG, ZIP, PDF,
+  ELF, PE, libpcap, pcapng, the POSIX ``tar`` ustar marker at offset 257,
+  and composite formats like RIFF/WAVE.
+- ``TEXT``: header must decode as UTF-8 and must not match any known
+  binary signature (``.txt``, ``.md``, ``.json``, ``.py``, ...).
+- ``PEM_OR_DER``: header must be either PEM text (``-----BEGIN ...``) or
+  a DER ASN.1 SEQUENCE. Used for ``.crt`` and ``.key`` which legitimately
+  ship in either encoding.
+- ``OPAQUE``: header inspection does not apply. Raw-byte containers like
+  ``.bin``, ``.raw``, ``.dd``, ``.mem``, ``.img``, ``.iso``, ``.vmdk`` are
+  accepted as-is because magic bytes are either at large offsets (ISO 9660
+  lives at 0x8001) or absent. The extension allowlist and size limit
+  remain the only guards for these formats — an explicit security
+  trade-off CTF accepts to support forensics-style challenges.
+
+The registry intentionally lives next to ``ctf.s3.ALLOWED_EXTENSIONS`` rather
+than in ``shared/`` because every CTF extension's category is a domain
+decision, not a cross-cutting one. The dataclass, signature, and pure-bytes
+comparators *are* shared (`shared.uploads.inspection`).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+from shared.uploads.inspection import (
+    FileFormat,
+    InspectionError,
+    MagicSignature,
+    TextStreamValidator,
+    make_text_stream_validator,
+    validate_magic_bytes,
+    validate_pem_or_der_header,
+    validate_text_header,
+)
+
+
+class CTFInspectionError(Exception):
+    """Raised when a CTF attachment header fails server-side inspection."""
+
+
+class _Category(Enum):
+    MAGIC = "magic"
+    TEXT = "text"
+    PEM_OR_DER = "pem_or_der"
+    OPAQUE = "opaque"
+
+
+@dataclass(frozen=True)
+class _CTFRule:
+    category: _Category
+    description: str
+    # For MAGIC: one or more acceptable FileFormat alternatives. At least one
+    # alternative's signatures must all match.
+    alternatives: tuple[FileFormat, ...] = field(default_factory=tuple)
+
+
+def _fmt(description: str, signatures: tuple[MagicSignature, ...]) -> FileFormat:
+    """Build an internal CTF FileFormat (extensions are tracked by the rule key)."""
+    return FileFormat(extensions=[], signatures=signatures, description=description)
+
+
+# Magic signatures used by ``MAGIC`` alternatives.
+_PNG = _fmt("PNG image", (MagicSignature(0, b"\x89PNG\r\n\x1a\n"),))
+_GIF = _fmt("GIF image", (MagicSignature(0, b"GIF8"),))
+_BMP = _fmt("BMP image", (MagicSignature(0, b"BM"),))
+_JPEG_ALTERNATIVES = (
+    _fmt("JPEG/JFIF", (MagicSignature(0, b"\xff\xd8\xff\xe0"),)),
+    _fmt("JPEG/Exif", (MagicSignature(0, b"\xff\xd8\xff\xe1"),)),
+    _fmt("JPEG (generic SOI)", (MagicSignature(0, b"\xff\xd8\xff"),)),
+)
+_PDF = _fmt("PDF document", (MagicSignature(0, b"%PDF"),))
+_PE = _fmt("PE executable", (MagicSignature(0, b"MZ"),))
+_ELF = _fmt("ELF binary", (MagicSignature(0, b"\x7fELF"),))
+_GZIP = _fmt("Gzip", (MagicSignature(0, b"\x1f\x8b"),))
+_ZIP_ALTERNATIVES = (
+    _fmt("ZIP (local file header)", (MagicSignature(0, b"\x50\x4b\x03\x04"),)),
+    _fmt("ZIP (empty archive)", (MagicSignature(0, b"\x50\x4b\x05\x06"),)),
+    _fmt("ZIP (spanned)", (MagicSignature(0, b"\x50\x4b\x07\x08"),)),
+)
+_BZIP2 = _fmt("bzip2", (MagicSignature(0, b"BZh"),))
+_7Z = _fmt("7-Zip", (MagicSignature(0, b"\x37\x7a\xbc\xaf\x27\x1c"),))
+_SQLITE = _fmt("SQLite database", (MagicSignature(0, b"SQLite format 3\x00"),))
+_PCAP_ALTERNATIVES = (
+    _fmt("libpcap (LE, microseconds)", (MagicSignature(0, b"\xd4\xc3\xb2\xa1"),)),
+    _fmt("libpcap (BE, microseconds)", (MagicSignature(0, b"\xa1\xb2\xc3\xd4"),)),
+    _fmt("libpcap (LE, nanoseconds)", (MagicSignature(0, b"\x4d\x3c\xb2\xa1"),)),
+    _fmt("libpcap (BE, nanoseconds)", (MagicSignature(0, b"\xa1\xb2\x3c\x4d"),)),
+)
+_PCAPNG = _fmt("pcapng (Section Header Block)", (MagicSignature(0, b"\x0a\x0d\x0d\x0a"),))
+# RIFF/WAVE is a composite: RIFF chunk at offset 0, WAVE format identifier at
+# offset 8 (after the 4-byte container size). Requiring both rejects RIFF
+# containers carrying AVI/WEBP/etc.
+_WAV = _fmt(
+    "WAV audio (RIFF/WAVE)",
+    (
+        MagicSignature(0, b"RIFF"),
+        MagicSignature(8, b"WAVE"),
+    ),
+)
+_MP3_ALTERNATIVES = (
+    _fmt("MP3 (ID3v2 tag)", (MagicSignature(0, b"ID3"),)),
+    _fmt("MP3 frame (FFFB)", (MagicSignature(0, b"\xff\xfb"),)),
+    _fmt("MP3 frame (FFF3)", (MagicSignature(0, b"\xff\xf3"),)),
+    _fmt("MP3 frame (FFF2)", (MagicSignature(0, b"\xff\xf2"),)),
+)
+# POSIX tar puts ``ustar`` at offset 257 of the first block. Pre-POSIX
+# (v7) tar has no magic at all and so cannot be positively identified
+# within a bounded header read; we accept it via OPAQUE-like fallback by
+# treating ``.tar`` as MAGIC-with-ustar — pre-POSIX tar uploads will need
+# to use ``.bin`` (which the allowlist already permits) or be repacked.
+_TAR_POSIX = _fmt(
+    "POSIX tar (ustar)",
+    (MagicSignature(257, b"ustar"),),
+)
+# PKCS#12 archives. The DER ASN.1 SEQUENCE marker at offset 0 is the strongest
+# signal achievable inside a bounded header read; proving PKCS#12 specifically
+# requires decoding the SEQUENCE (version + AuthSafe + MacData), which is an
+# ASN.1 parser and out of scope for this layer.
+_PKCS12_ALTERNATIVES = (
+    _fmt("PKCS#12 (DER, 2-byte length)", (MagicSignature(0, b"\x30\x82"),)),
+    _fmt("PKCS#12 (DER, 3-byte length)", (MagicSignature(0, b"\x30\x83"),)),
+    _fmt("PKCS#12 (DER, 4-byte length)", (MagicSignature(0, b"\x30\x84"),)),
+)
+
+
+_RULES: dict[str, _CTFRule] = {
+    # Archives
+    ".zip": _CTFRule(_Category.MAGIC, "ZIP archive", _ZIP_ALTERNATIVES),
+    ".gz": _CTFRule(_Category.MAGIC, "Gzip archive", (_GZIP,)),
+    ".tgz": _CTFRule(_Category.MAGIC, "Gzip-compressed tar", (_GZIP,)),
+    ".tar": _CTFRule(_Category.MAGIC, "POSIX tar archive", (_TAR_POSIX,)),
+    ".bz2": _CTFRule(_Category.MAGIC, "bzip2 archive", (_BZIP2,)),
+    ".7z": _CTFRule(_Category.MAGIC, "7-Zip archive", (_7Z,)),
+    # Images
+    ".png": _CTFRule(_Category.MAGIC, "PNG image", (_PNG,)),
+    ".jpg": _CTFRule(_Category.MAGIC, "JPEG image", _JPEG_ALTERNATIVES),
+    ".jpeg": _CTFRule(_Category.MAGIC, "JPEG image", _JPEG_ALTERNATIVES),
+    ".gif": _CTFRule(_Category.MAGIC, "GIF image", (_GIF,)),
+    ".bmp": _CTFRule(_Category.MAGIC, "BMP image", (_BMP,)),
+    ".svg": _CTFRule(_Category.TEXT, "SVG (XML) image"),  # SVG is XML text
+    # Documents
+    ".pdf": _CTFRule(_Category.MAGIC, "PDF document", (_PDF,)),
+    # Executables
+    ".exe": _CTFRule(_Category.MAGIC, "PE executable", (_PE,)),
+    ".dll": _CTFRule(_Category.MAGIC, "PE library", (_PE,)),
+    ".elf": _CTFRule(_Category.MAGIC, "ELF binary", (_ELF,)),
+    ".so": _CTFRule(_Category.MAGIC, "ELF shared object", (_ELF,)),
+    ".out": _CTFRule(_Category.OPAQUE, "compiled output binary"),
+    # Network captures
+    ".pcap": _CTFRule(_Category.MAGIC, "libpcap capture", _PCAP_ALTERNATIVES),
+    ".pcapng": _CTFRule(_Category.MAGIC, "pcapng capture", (_PCAPNG,)),
+    ".cap": _CTFRule(_Category.MAGIC, "packet capture", (*_PCAP_ALTERNATIVES, _PCAPNG)),
+    # Databases
+    ".sqlite": _CTFRule(_Category.MAGIC, "SQLite database", (_SQLITE,)),
+    ".db": _CTFRule(_Category.MAGIC, "SQLite database", (_SQLITE,)),
+    ".sql": _CTFRule(_Category.TEXT, "SQL script"),
+    # Crypto / certs — PKCS#12 archives are DER binary; .crt and .key
+    # legitimately ship in either PEM or DER encoding.
+    ".p12": _CTFRule(_Category.MAGIC, "PKCS#12 (DER)", _PKCS12_ALTERNATIVES),
+    ".pfx": _CTFRule(_Category.MAGIC, "PKCS#12 (DER)", _PKCS12_ALTERNATIVES),
+    ".pem": _CTFRule(_Category.TEXT, "PEM-encoded crypto material"),
+    ".crt": _CTFRule(_Category.PEM_OR_DER, "PEM or DER certificate"),
+    ".key": _CTFRule(_Category.PEM_OR_DER, "PEM or DER private key"),
+    # Audio
+    ".wav": _CTFRule(_Category.MAGIC, "WAV audio (RIFF/WAVE)", (_WAV,)),
+    ".mp3": _CTFRule(_Category.MAGIC, "MP3 audio", _MP3_ALTERNATIVES),
+    # Text / docs
+    ".txt": _CTFRule(_Category.TEXT, "plain text"),
+    ".md": _CTFRule(_Category.TEXT, "Markdown text"),
+    ".csv": _CTFRule(_Category.TEXT, "CSV text"),
+    ".json": _CTFRule(_Category.TEXT, "JSON text"),
+    ".xml": _CTFRule(_Category.TEXT, "XML text"),
+    ".yaml": _CTFRule(_Category.TEXT, "YAML text"),
+    ".yml": _CTFRule(_Category.TEXT, "YAML text"),
+    ".log": _CTFRule(_Category.TEXT, "log text"),
+    ".hex": _CTFRule(_Category.TEXT, "hex dump (text)"),
+    # Code
+    ".py": _CTFRule(_Category.TEXT, "Python source"),
+    ".js": _CTFRule(_Category.TEXT, "JavaScript source"),
+    ".c": _CTFRule(_Category.TEXT, "C source"),
+    ".cpp": _CTFRule(_Category.TEXT, "C++ source"),
+    ".h": _CTFRule(_Category.TEXT, "C/C++ header"),
+    ".java": _CTFRule(_Category.TEXT, "Java source"),
+    ".rb": _CTFRule(_Category.TEXT, "Ruby source"),
+    ".sh": _CTFRule(_Category.TEXT, "Shell script"),
+    ".ps1": _CTFRule(_Category.TEXT, "PowerShell script"),
+    # Raw-byte containers
+    ".bin": _CTFRule(_Category.OPAQUE, "raw binary"),
+    ".raw": _CTFRule(_Category.OPAQUE, "raw memory/disk image"),
+    ".dd": _CTFRule(_Category.OPAQUE, "raw disk image"),
+    ".mem": _CTFRule(_Category.OPAQUE, "memory image"),
+    ".img": _CTFRule(_Category.OPAQUE, "disk image"),
+    ".iso": _CTFRule(_Category.OPAQUE, "ISO 9660 disk image"),
+    ".vmdk": _CTFRule(_Category.OPAQUE, "VMDK virtual disk"),
+}
+
+
+def is_text_extension(extension: str) -> bool:
+    """Whether the extension's rule expects UTF-8 text content end-to-end.
+
+    Callers (notably `ctf.services.attachment.add_challenge_file`) use this
+    to decide whether to plug in a streaming text validator alongside the
+    SHA256 loop, so a `valid text prefix + binary tail` upload cannot bypass
+    the bounded-header check.
+    """
+    rule = _RULES.get(extension.lower())
+    return rule is not None and rule.category is _Category.TEXT
+
+
+def new_text_stream_validator() -> TextStreamValidator:
+    """Construct the streaming validator used during CTF text uploads."""
+    return make_text_stream_validator()
+
+
+def inspect_attachment_header(header: bytes, extension: str) -> None:
+    """Inspect the first bytes of a CTF attachment against its extension's policy.
+
+    Raises ``CTFInspectionError`` if the header does not satisfy the rule.
+    """
+    ext = extension.lower()
+    rule = _RULES.get(ext)
+    if rule is None:
+        raise CTFInspectionError(
+            f"Extension '{extension}' has no inspection rule defined; extension is not in the CTF allowlist."
+        )
+
+    if rule.category is _Category.OPAQUE:
+        return
+
+    if rule.category is _Category.MAGIC:
+        for alternative in rule.alternatives:
+            try:
+                validate_magic_bytes(header, alternative)
+            except InspectionError:
+                continue
+            else:
+                return
+        raise CTFInspectionError(
+            f"Uploaded content does not match expected format for {ext} "
+            f"({rule.description}); the file may be corrupted or mislabeled."
+        )
+
+    if rule.category is _Category.PEM_OR_DER:
+        try:
+            validate_pem_or_der_header(header)
+        except InspectionError as exc:
+            raise CTFInspectionError(
+                f"Uploaded content for {ext} ({rule.description}) is not recognizable PEM or DER: {exc}"
+            ) from exc
+        return
+
+    # TEXT category
+    try:
+        validate_text_header(header)
+    except InspectionError as exc:
+        raise CTFInspectionError(f"Uploaded content for {ext} ({rule.description}) is not valid text: {exc}") from exc
+
+
+def _verify_rules_match_allowlist() -> None:
+    """Module-load parity guard: `_RULES` must align with `ctf.s3.ALLOWED_EXTENSIONS`.
+
+    The runtime path accepts any extension in `ALLOWED_EXTENSIONS` and then
+    looks up a rule here. If the two tables drift, uploads either pass the
+    extension gate and fail at inspection (false reject) or carry stale
+    inspection policy for an extension no longer allowed (silent drift).
+    Failing fast at import time prevents either failure mode.
+    """
+    from ctf.s3 import ALLOWED_EXTENSIONS  # local import to avoid cycle at module top
+
+    rule_keys = set(_RULES)
+    missing = ALLOWED_EXTENSIONS - rule_keys
+    extra = rule_keys - ALLOWED_EXTENSIONS
+    if missing or extra:
+        raise RuntimeError(
+            "CTF inspection rules out of sync with ctf.s3.ALLOWED_EXTENSIONS: "
+            f"missing rules for {sorted(missing)}, extra rules for {sorted(extra)}"
+        )
+
+
+_verify_rules_match_allowlist()

--- a/shifter/shifter_platform/ctf/services/attachment.py
+++ b/shifter/shifter_platform/ctf/services/attachment.py
@@ -10,9 +10,16 @@ import os
 from typing import TYPE_CHECKING
 from uuid import UUID
 
+from django.conf import settings
 from django.db.models import QuerySet
 
 from ctf.exceptions import CTFNotFoundError, CTFStateError, CTFValidationError
+from ctf.inspection import (
+    CTFInspectionError,
+    inspect_attachment_header,
+    is_text_extension,
+    new_text_stream_validator,
+)
 from ctf.models import CTFChallenge, CTFChallengeFile
 from ctf.s3 import (
     ALLOWED_EXTENSIONS,
@@ -98,6 +105,64 @@ def add_challenge_file(
             "File is empty",
             details={"filename": filename},
         )
+
+    # Server-side header inspection (issue #696). Run before S3 PutObject so a
+    # mismatch never leaves a rejected object behind in the bucket. For TEXT-
+    # category extensions we additionally stream-validate the entire body
+    # below (during the SHA256 loop) so a `valid text prefix + binary tail`
+    # upload cannot bypass the bounded-header check.
+    file_obj.seek(0)
+    header = file_obj.read(settings.UPLOAD_INSPECTION_MAX_HEADER_BYTES)
+    file_obj.seek(0)
+    try:
+        inspect_attachment_header(header, ext)
+    except CTFInspectionError as exc:
+        logger.warning(
+            "add_challenge_file: header inspection failed challenge=%s ext=%s actor=%s reason=%s",
+            challenge_id,
+            ext,
+            actor_id,
+            exc,
+        )
+        raise CTFValidationError(
+            f"File content inspection failed: {exc}",
+            details={"filename": filename, "extension": ext},
+        ) from exc
+
+    # Full-body text validation for TEXT-category extensions. We feed the
+    # whole file through a UTF-8 incremental decoder so any binary bytes in
+    # the tail of an otherwise-text-looking upload are rejected before S3.
+    if is_text_extension(ext):
+        stream_validator = new_text_stream_validator()
+        try:
+            file_obj.seek(0)
+            while True:
+                chunk = file_obj.read(8192)
+                if not chunk:
+                    break
+                stream_validator.feed(chunk)
+            stream_validator.finalize()
+        except Exception as exc:
+            # `feed`/`finalize` raise InspectionError on bad bytes; surface
+            # as CTFValidationError so the API contract matches the bounded
+            # rejection path above.
+            from shared.uploads.inspection import InspectionError as _Inspect
+
+            if not isinstance(exc, _Inspect):
+                raise
+            logger.warning(
+                "add_challenge_file: streaming text inspection rejected challenge=%s ext=%s actor=%s reason=%s",
+                challenge_id,
+                ext,
+                actor_id,
+                exc,
+            )
+            raise CTFValidationError(
+                f"File content inspection failed: {exc}",
+                details={"filename": filename, "extension": ext},
+            ) from exc
+        finally:
+            file_obj.seek(0)
 
     # Check file count limit
     current_count = CTFChallengeFile.objects.filter(challenge=challenge).count()

--- a/shifter/shifter_platform/shared/cloud/aws/storage.py
+++ b/shifter/shifter_platform/shared/cloud/aws/storage.py
@@ -103,6 +103,40 @@ class AWSObjectStorage:
             logger.error("head_object: failed bucket=%s key=%s error=%s", bucket, key, e)
             raise CloudStorageError(f"Failed to head S3 object: {e}") from e
 
+    def read_object_header(self, bucket: str, key: str, max_bytes: int) -> bytes:
+        """Read up to `max_bytes` from the start of the object using a Range GET.
+
+        Used by server-side upload inspection to validate magic bytes without
+        downloading the whole object. The HTTP Range header is end-inclusive,
+        so `max_bytes=512` requests `bytes=0-511`. The S3 ``StreamingBody``
+        is closed in a ``finally`` block so concurrent finalization requests
+        cannot leak botocore connections under load.
+        """
+        if max_bytes <= 0:
+            raise ValueError("max_bytes must be positive")
+        logger.debug("read_object_header: bucket=%s key=%s max_bytes=%d", bucket, key, max_bytes)
+        try:
+            client = self._get_client()
+            response = client.get_object(
+                Bucket=bucket,
+                Key=key,
+                Range=f"bytes=0-{max_bytes - 1}",
+            )
+            stream = response["Body"]
+            try:
+                body = stream.read(max_bytes)
+            finally:
+                stream.close()
+        except (ClientError, BotoCoreError) as e:
+            logger.error(
+                "read_object_header: failed bucket=%s key=%s error=%s",
+                bucket,
+                key,
+                e,
+            )
+            raise CloudStorageError(f"Failed to read S3 object header: {e}") from e
+        return body[:max_bytes]
+
     def object_exists(self, bucket: str, key: str) -> bool:
         """Return True iff the object exists.
 

--- a/shifter/shifter_platform/shared/cloud/gcp/storage.py
+++ b/shifter/shifter_platform/shared/cloud/gcp/storage.py
@@ -101,6 +101,29 @@ class GCPObjectStorage:
             logger.error("head_object: failed bucket=%s key=%s error=%s", bucket, key, e)
             raise CloudStorageError(f"Failed to head GCS object: {e}") from e
 
+    def read_object_header(self, bucket: str, key: str, max_bytes: int) -> bytes:
+        """Read up to `max_bytes` from the start of the blob.
+
+        GCS `download_as_bytes(start=, end=)` uses an inclusive `end`, so
+        `max_bytes=512` corresponds to `end=511`.
+        """
+        if max_bytes <= 0:
+            raise ValueError("max_bytes must be positive")
+        logger.debug("read_object_header: bucket=%s key=%s max_bytes=%d", bucket, key, max_bytes)
+        try:
+            client = self._get_client()
+            blob = client.bucket(bucket).blob(key)
+            body = blob.download_as_bytes(start=0, end=max_bytes - 1)
+        except Exception as e:
+            logger.error(
+                "read_object_header: failed bucket=%s key=%s error=%s",
+                bucket,
+                key,
+                e,
+            )
+            raise CloudStorageError(f"Failed to read GCS object header: {e}") from e
+        return body[:max_bytes]
+
     def generate_presigned_upload_url(
         self,
         bucket: str,

--- a/shifter/shifter_platform/shared/cloud/types.py
+++ b/shifter/shifter_platform/shared/cloud/types.py
@@ -30,6 +30,8 @@ class ObjectStorage(Protocol):
 
     def head_object(self, bucket: str, key: str) -> dict[str, Any]: ...
 
+    def read_object_header(self, bucket: str, key: str, max_bytes: int) -> bytes: ...
+
     def generate_presigned_upload_url(
         self,
         bucket: str,

--- a/shifter/shifter_platform/shared/uploads/__init__.py
+++ b/shifter/shifter_platform/shared/uploads/__init__.py
@@ -1,0 +1,37 @@
+"""Upload-inspection primitives shared across CMS, CTF, and experiment scripts.
+
+The single source of truth for `FileFormat`, the magic-byte comparator, and the
+binary-signature registry that powers both positive-match and negative
+(text-only) header checks. Per-domain registries (agent installers, CTF
+attachments, experiment scripts) compose on top of these primitives.
+"""
+
+from shared.uploads.inspection import (
+    BINARY_MAGIC_SIGNATURES,
+    FileFormat,
+    InspectionError,
+    MagicSignature,
+    TextStreamValidator,
+    get_file_extension,
+    looks_like_der_sequence,
+    looks_like_known_binary,
+    make_text_stream_validator,
+    validate_magic_bytes,
+    validate_pem_or_der_header,
+    validate_text_header,
+)
+
+__all__ = [
+    "BINARY_MAGIC_SIGNATURES",
+    "FileFormat",
+    "InspectionError",
+    "MagicSignature",
+    "TextStreamValidator",
+    "get_file_extension",
+    "looks_like_der_sequence",
+    "looks_like_known_binary",
+    "make_text_stream_validator",
+    "validate_magic_bytes",
+    "validate_pem_or_der_header",
+    "validate_text_header",
+]

--- a/shifter/shifter_platform/shared/uploads/inspection.py
+++ b/shifter/shifter_platform/shared/uploads/inspection.py
@@ -1,0 +1,364 @@
+"""Pure-bytes header inspection primitives for S3 upload validation.
+
+Three checks compose into the per-domain validators (agent installers, CTF
+attachments, experiment scripts):
+
+- ``validate_magic_bytes(header, fmt)``: every ``MagicSignature`` on the
+  format must match its declared offset. Supports both offset-zero prefixes
+  and composite signatures (e.g. RIFF/WAVE, POSIX tar ``ustar`` at offset
+  257).
+- ``validate_text_header(header)``: header is non-empty, UTF-8 decodable,
+  and does not match any known binary signature in
+  ``BINARY_MAGIC_SIGNATURES``.
+- ``validate_pem_or_der_header(header)``: header is either a PEM-encoded
+  text block (``-----BEGIN ...``) or a DER ASN.1 SEQUENCE prefix. Used by
+  ``.crt``/``.key`` extensions that legitimately ship in either encoding.
+
+The binary-signature registry is shared so the CTF text-extension negative
+check and the script text-only check use the same definition of "is this a
+binary file wearing a text extension?".
+"""
+
+from __future__ import annotations
+
+import codecs
+import re
+from dataclasses import dataclass
+
+
+class InspectionError(Exception):
+    """Raised when an uploaded file's header fails server-side inspection."""
+
+
+@dataclass(frozen=True)
+class MagicSignature:
+    """Byte pattern that must appear at a fixed offset in the header.
+
+    ``offset`` zero is a plain prefix. Non-zero offsets cover formats whose
+    discriminator lives inside the header but not at byte zero — e.g. POSIX
+    tar's ``ustar`` field at offset 257, or RIFF/WAVE's ``WAVE`` identifier
+    at offset 8.
+    """
+
+    offset: int
+    pattern: bytes
+
+    def matches(self, header: bytes) -> bool:
+        end = self.offset + len(self.pattern)
+        if len(header) < end:
+            return False
+        return header[self.offset : end] == self.pattern
+
+
+@dataclass(frozen=True)
+class FileFormat:
+    """An allowed upload format. A format is satisfied iff ALL signatures match.
+
+    Use multiple alternative ``FileFormat`` objects (e.g. in a CTF rule's
+    alternatives list) for "any-of" semantics — e.g. JPEG SOI variants,
+    libpcap endian/timestamp variants.
+
+    ``os_slug`` is optional because it only applies to agent installer
+    formats; other domains omit it.
+    """
+
+    extensions: list[str]
+    signatures: tuple[MagicSignature, ...]
+    description: str
+    os_slug: str | None = None
+
+    @property
+    def magic_bytes(self) -> bytes:
+        """Convenience: the offset-zero signature's pattern, or empty bytes.
+
+        Provided so single-prefix formats can still be referenced inline
+        (e.g. in tests that build a happy-path header from the format).
+        """
+        for sig in self.signatures:
+            if sig.offset == 0:
+                return sig.pattern
+        return b""
+
+    @property
+    def min_header_bytes(self) -> int:
+        """Minimum bytes required to evaluate every signature on this format."""
+        if not self.signatures:
+            return 0
+        return max(sig.offset + len(sig.pattern) for sig in self.signatures)
+
+
+# Full registry of binary signatures referenced anywhere in this module.
+# Order does not matter for the negative check; entries cover the formats
+# this codebase positively identifies elsewhere. JPEG covers all three SOI
+# marker variants explicitly.
+BINARY_MAGIC_SIGNATURES: tuple[bytes, ...] = (
+    b"\x50\x4b\x03\x04",  # ZIP (local file header)
+    b"\x50\x4b\x05\x06",  # ZIP (empty archive)
+    b"\x50\x4b\x07\x08",  # ZIP (spanned)
+    b"\x1f\x8b",  # GZIP
+    b"BZh",  # bzip2
+    b"\x37\x7a\xbc\xaf\x27\x1c",  # 7z
+    b"\x89PNG\r\n\x1a\n",  # PNG
+    b"GIF8",  # GIF87a/89a
+    b"BM",  # BMP
+    b"\xff\xd8\xff\xe0",  # JPEG/JFIF
+    b"\xff\xd8\xff\xe1",  # JPEG/Exif
+    b"\xff\xd8\xff",  # JPEG SOI (generic fallback)
+    b"%PDF",  # PDF
+    b"MZ",  # PE / Windows executable
+    b"\x7fELF",  # ELF (Linux/BSD executable)
+    b"\xca\xfe\xba\xbe",  # Java class / Mach-O fat
+    b"\xfe\xed\xfa\xce",  # Mach-O 32-bit
+    b"\xfe\xed\xfa\xcf",  # Mach-O 64-bit
+    b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1",  # OLE compound (DOC/XLS/MSI)
+    b"!<arch>",  # ar / DEB
+    b"\xed\xab\xee\xdb",  # RPM
+    b"\xd4\xc3\xb2\xa1",  # libpcap (little-endian, microseconds)
+    b"\xa1\xb2\xc3\xd4",  # libpcap (big-endian, microseconds)
+    b"\x4d\x3c\xb2\xa1",  # libpcap (little-endian, nanoseconds)
+    b"\xa1\xb2\x3c\x4d",  # libpcap (big-endian, nanoseconds)
+    b"\x0a\x0d\x0d\x0a",  # pcapng (Section Header Block)
+    b"SQLite format 3\x00",  # SQLite v3 database
+    b"RIFF",  # RIFF container (WAV/AVI/WEBP)
+    b"ID3",  # MP3 with ID3v2 tag
+    b"\xff\xfb",  # MP3 MPEG audio frame
+    b"\xff\xf3",  # MP3 MPEG audio frame
+    b"\xff\xf2",  # MP3 MPEG audio frame
+    b"\x30\x82",  # DER ASN.1 SEQUENCE, 2-byte length
+    b"\x30\x83",  # DER ASN.1 SEQUENCE, 3-byte length
+    b"\x30\x84",  # DER ASN.1 SEQUENCE, 4-byte length
+)
+
+# Subset used by `looks_like_known_binary` for the text-negative check.
+# Short (≤3 byte) ASCII-printable prefixes (`BM`, `MZ`, `BZh`, `ID3`,
+# `RIFF`) are intentionally excluded: they appear at the start of valid
+# text uploads (e.g. a Python script `MZ = "marker"`, a doc line
+# starting with `BM`) and would otherwise produce cross-domain false
+# positives in the experiment-script and CTF TEXT paths. The excluded
+# short prefixes can still appear in `BINARY_MAGIC_SIGNATURES` for
+# completeness; bytes that aren't valid UTF-8 start bytes (`\xff\xfb`,
+# `\xff\xf3`, `\xff\xf2`, `\x30\x82`, `\x30\x83`, `\x30\x84`) are caught
+# by the UTF-8 decoder instead.
+_TEXT_INCOMPATIBLE_SIGNATURES: tuple[bytes, ...] = (
+    b"\x50\x4b\x03\x04",  # ZIP (local file header)
+    b"\x50\x4b\x05\x06",  # ZIP (empty archive)
+    b"\x50\x4b\x07\x08",  # ZIP (spanned)
+    b"\x37\x7a\xbc\xaf\x27\x1c",  # 7z
+    b"\x89PNG\r\n\x1a\n",  # PNG
+    b"GIF8",  # GIF
+    b"\xff\xd8\xff",  # JPEG SOI (any variant — \xff not valid UTF-8 start)
+    b"%PDF-",  # PDF (anchored with dash to reduce ambiguity)
+    b"\x7fELF",  # ELF (non-UTF-8 start byte)
+    b"\xca\xfe\xba\xbe",  # Java/Mach-O fat (non-UTF-8 start)
+    b"\xfe\xed\xfa\xce",  # Mach-O 32-bit (non-UTF-8 start)
+    b"\xfe\xed\xfa\xcf",  # Mach-O 64-bit (non-UTF-8 start)
+    b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1",  # OLE compound (non-UTF-8 start)
+    b"!<arch>\n",  # ar / DEB (8 bytes, anchored)
+    b"\xed\xab\xee\xdb",  # RPM (non-UTF-8 start)
+    b"\xd4\xc3\xb2\xa1",  # libpcap LE-microseconds (non-UTF-8 start)
+    b"\xa1\xb2\xc3\xd4",  # libpcap BE-microseconds (non-UTF-8 start)
+    b"\x4d\x3c\xb2\xa1",  # libpcap LE-nanoseconds (non-UTF-8 start)
+    b"\xa1\xb2\x3c\x4d",  # libpcap BE-nanoseconds (non-UTF-8 start)
+    b"\x0a\x0d\x0d\x0a",  # pcapng SHB
+    b"SQLite format 3\x00",  # SQLite (16 bytes, distinctive)
+    b"\x1f\x8b\x08",  # GZIP (3 bytes incl. compression method)
+)
+
+# Single-byte DER prefixes that indicate an ASN.1 SEQUENCE with an
+# extended length encoding. ``looks_like_der_sequence`` accepts any of
+# these followed by the appropriate length octets. Kept separate from
+# the binary registry so the text negative check doesn't trip on plain
+# ``0x30`` start bytes in unrelated content.
+_DER_SEQUENCE_PREFIXES: tuple[bytes, ...] = (
+    b"\x30\x81",  # short, 1-byte length
+    b"\x30\x82",  # 2-byte length
+    b"\x30\x83",  # 3-byte length
+    b"\x30\x84",  # 4-byte length
+)
+
+_UTF8_BOM = b"\xef\xbb\xbf"
+
+
+def get_file_extension(filename: str) -> str:
+    """Return the file extension including the leading dot, lowercased.
+
+    Recognizes the compound extension ``.tar.gz`` as a single unit.
+    """
+    lower = filename.lower()
+    if lower.endswith(".tar.gz"):
+        return ".tar.gz"
+    if "." in filename:
+        return "." + lower.rsplit(".", 1)[-1]
+    return ""
+
+
+def validate_magic_bytes(header: bytes, fmt: FileFormat) -> None:
+    """Confirm every signature on ``fmt`` matches ``header`` at its declared offset.
+
+    Composite formats (RIFF/WAVE = ``RIFF`` at 0 + ``WAVE`` at 8) and offset
+    signatures (POSIX tar ``ustar`` at 257) are first-class: list every
+    required anchor in ``fmt.signatures`` and the function checks them all.
+    """
+    if not fmt.signatures:
+        raise InspectionError(f"FileFormat {fmt.description} has no signatures configured")
+    needed = fmt.min_header_bytes
+    if len(header) < needed:
+        raise InspectionError(f"Uploaded content is too small to be a valid {fmt.description}")
+    for sig in fmt.signatures:
+        if not sig.matches(header):
+            raise InspectionError(
+                f"Uploaded content does not match expected format ({fmt.description}); "
+                "the file may be corrupted or mislabeled."
+            )
+
+
+def looks_like_known_binary(header: bytes) -> bool:
+    """Return True iff ``header`` starts with a strict text-incompatible signature.
+
+    Consults the curated `_TEXT_INCOMPATIBLE_SIGNATURES` subset rather than
+    the full `BINARY_MAGIC_SIGNATURES` registry, so short ASCII-printable
+    prefixes (`MZ`, `BM`, `BZh`, `ID3`, `RIFF`) do not false-reject a script
+    or text attachment whose first bytes happen to match those patterns.
+    """
+    if not header:
+        return False
+    return any(header.startswith(sig) for sig in _TEXT_INCOMPATIBLE_SIGNATURES)
+
+
+def looks_like_der_sequence(header: bytes) -> bool:
+    """Return True iff ``header`` starts with a DER ASN.1 SEQUENCE marker.
+
+    Accepts the common length encodings used by real-world DER-encoded
+    crypto material (X.509 certificates, PKCS#1/PKCS#8 keys, PKCS#12).
+    """
+    return any(header.startswith(prefix) for prefix in _DER_SEQUENCE_PREFIXES)
+
+
+# PEM armor anchored at the start of the (BOM-stripped, lstripped) header.
+# Accepts the standard PEM label characters; case-sensitivity matches the
+# RFC 7468 grammar.
+_PEM_ARMOR_RE = re.compile(rb"^-----BEGIN [A-Z0-9 ]+-----")
+
+
+def validate_text_header(header: bytes, *, complete: bool = False) -> None:
+    """Confirm ``header`` is non-empty UTF-8 text and not a known binary format.
+
+    A leading UTF-8 BOM is tolerated and stripped before the binary-signature
+    check, so a legitimate BOM-prefixed text file does not collide with the
+    ``\\xef\\xbb\\xbf`` prefix.
+
+    Set ``complete=True`` when ``header`` is the entire upload body (e.g.
+    experiment script uploads, which are capped at 1 MB and validated in full):
+    the decoder runs with ``final=True`` so an incomplete trailing multibyte
+    sequence is treated as corruption. The default ``complete=False`` is the
+    bounded-prefix case used by CTF and agent paths — an incomplete trailing
+    codepoint at the end of the inspected prefix is tolerated because the
+    full file may complete it.
+    """
+    if not header:
+        raise InspectionError("Uploaded content is empty")
+
+    body = header[len(_UTF8_BOM) :] if header.startswith(_UTF8_BOM) else header
+
+    if looks_like_known_binary(body):
+        raise InspectionError("Uploaded content begins with a known binary signature; expected a text file.")
+
+    decoder = codecs.getincrementaldecoder("utf-8")(errors="strict")
+    try:
+        decoder.decode(body, final=complete)
+    except UnicodeDecodeError as exc:
+        raise InspectionError("Uploaded content is not valid UTF-8 text.") from exc
+
+
+def make_text_stream_validator() -> TextStreamValidator:
+    """Return a stateful validator for streaming text uploads chunk-by-chunk.
+
+    Use this when the full upload body is available as an iterable of chunks
+    (e.g. the SHA256 loop in CTF's Django-mediated attachment upload). The
+    first chunk is checked for a known binary signature; every chunk is fed
+    through a UTF-8 incremental decoder; the closing ``finalize()`` call runs
+    the decoder with ``final=True`` so an incomplete trailing multibyte
+    sequence in the body is rejected as corruption.
+
+    Defends against the prefix-padding bypass: an attacker can no longer
+    place valid text in the first N bytes and binary content past N because
+    every chunk passes through the same decoder.
+    """
+    return TextStreamValidator()
+
+
+@dataclass
+class TextStreamValidator:
+    """Stateful streaming text validator.
+
+    Created via `make_text_stream_validator`. Feed chunks with ``feed(chunk)``;
+    call ``finalize()`` when the stream is exhausted. Both methods raise
+    ``InspectionError`` on the first invalid input — there is no recoverable
+    state after that.
+    """
+
+    _decoder: codecs.IncrementalDecoder | None = None
+    _seen_first_chunk: bool = False
+
+    def feed(self, chunk: bytes) -> None:
+        if not chunk:
+            return
+        if not self._seen_first_chunk:
+            # First chunk: run the BOM strip + known-binary check on the
+            # prefix (which is what the bounded `validate_text_header` does)
+            # before the streaming UTF-8 decode starts.
+            body = chunk[len(_UTF8_BOM) :] if chunk.startswith(_UTF8_BOM) else chunk
+            if looks_like_known_binary(body):
+                raise InspectionError("Uploaded content begins with a known binary signature; expected a text file.")
+            self._decoder = codecs.getincrementaldecoder("utf-8")(errors="strict")
+            self._seen_first_chunk = True
+            try:
+                self._decoder.decode(body, final=False)
+            except UnicodeDecodeError as exc:
+                raise InspectionError("Uploaded content is not valid UTF-8 text.") from exc
+            return
+        assert self._decoder is not None
+        try:
+            self._decoder.decode(chunk, final=False)
+        except UnicodeDecodeError as exc:
+            raise InspectionError("Uploaded content is not valid UTF-8 text.") from exc
+
+    def finalize(self) -> None:
+        if not self._seen_first_chunk or self._decoder is None:
+            raise InspectionError("Uploaded content is empty")
+        try:
+            self._decoder.decode(b"", final=True)
+        except UnicodeDecodeError as exc:
+            raise InspectionError("Uploaded content is not valid UTF-8 text.") from exc
+
+
+def validate_pem_or_der_header(header: bytes) -> None:
+    """Accept either PEM (``-----BEGIN ...``) text or a DER ASN.1 SEQUENCE.
+
+    Used by extensions whose crypto material is delivered in either
+    encoding (notably ``.crt`` and ``.key``). The PEM branch requires the
+    ``-----BEGIN <LABEL>-----`` armor to appear at the very start of the
+    (BOM- and whitespace-stripped) header — text containing the marker
+    later in the body does NOT pass. The DER branch checks for the
+    ASN.1 SEQUENCE prefix.
+    """
+    if not header:
+        raise InspectionError("Uploaded content is empty")
+
+    # PEM branch: anchored armor at the start of normalized text.
+    body = header[len(_UTF8_BOM) :] if header.startswith(_UTF8_BOM) else header
+    stripped = body.lstrip()
+    if not looks_like_known_binary(stripped) and _PEM_ARMOR_RE.match(stripped):
+        decoder = codecs.getincrementaldecoder("utf-8")(errors="strict")
+        try:
+            decoder.decode(stripped, final=False)
+        except UnicodeDecodeError:
+            pass
+        else:
+            return
+
+    # DER branch: ASN.1 SEQUENCE prefix.
+    if looks_like_der_sequence(header):
+        return
+
+    raise InspectionError("Uploaded content is not recognizable as PEM text or DER ASN.1 SEQUENCE.")

--- a/shifter/shifter_platform/tests/cms/experiments/test_script_inspection.py
+++ b/shifter/shifter_platform/tests/cms/experiments/test_script_inspection.py
@@ -1,0 +1,239 @@
+"""Tests for server-side header inspection in `complete_script_upload` (issue #696)."""
+
+from contextlib import nullcontext
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cms.experiments import services
+from cms.experiments.exceptions import ScriptUploadError
+
+
+@pytest.fixture(autouse=True)
+def _no_db_transactions():
+    """Replace transaction.atomic so the service runs without a DB connection."""
+    with (
+        patch("cms.experiments.services.transaction") as mock_tx,
+        patch("cms.experiments.services._check_result_type"),
+    ):
+        mock_tx.atomic.return_value = nullcontext()
+        yield
+
+
+@pytest.fixture
+def mock_user():
+    user = MagicMock()
+    user.pk = 7
+    user.id = 7
+    user.username = "scripter"
+    user.is_staff = True
+    return user
+
+
+def _token_payload():
+    return {
+        "user_id": 7,
+        "s3_key": "scripts/7/abc_script.py",
+        "name": "My Script",
+        "filename": "script.py",
+        "file_size": 100,
+        "expires_at": 2_000_000_000,
+    }
+
+
+class TestHappyPath:
+    def test_text_header_accepted_then_script_saved(self, mock_user):
+        with (
+            patch("cms.experiments.services.verify_upload_token", return_value=_token_payload()),
+            patch("cms.experiments.services.verify_s3_object", return_value=(100, "etag")),
+            patch(
+                "cms.experiments.services.read_script_header",
+                return_value=b"#!/usr/bin/env python3\nprint('ok')\n",
+            ),
+            patch("cms.experiments.services.delete_s3_object") as mock_delete,
+            patch("cms.experiments.services.audit_log") as mock_audit,
+            patch("cms.experiments.services.ScriptAsset") as mock_model,
+        ):
+            mock_instance = MagicMock(pk=42, name="My Script")
+            mock_model.return_value = mock_instance
+            services.complete_script_upload(mock_user, "token123")
+            mock_delete.assert_not_called()
+            mock_instance.save.assert_called_once()
+            mock_audit.assert_called_once()
+
+
+class TestBinaryHeaderRejected:
+    def test_zip_magic_rejected_and_object_deleted(self, mock_user):
+        with (
+            patch("cms.experiments.services.verify_upload_token", return_value=_token_payload()),
+            patch("cms.experiments.services.verify_s3_object", return_value=(100, "etag")),
+            patch(
+                "cms.experiments.services.read_script_header",
+                return_value=b"\x50\x4b\x03\x04zip-bytes-pretending-to-be-py",
+            ),
+            patch("cms.experiments.services.delete_s3_object") as mock_delete,
+            patch("cms.experiments.services.audit_log") as mock_audit,
+            patch("cms.experiments.services.ScriptAsset") as mock_model,
+            pytest.raises(ScriptUploadError, match="content"),
+        ):
+            services.complete_script_upload(mock_user, "token123")
+        mock_delete.assert_called_once_with("scripts/7/abc_script.py")
+        mock_audit.assert_not_called()
+        mock_model.return_value.save.assert_not_called()
+
+    def test_elf_header_rejected_and_object_deleted(self, mock_user):
+        with (
+            patch("cms.experiments.services.verify_upload_token", return_value=_token_payload()),
+            patch("cms.experiments.services.verify_s3_object", return_value=(100, "etag")),
+            patch(
+                "cms.experiments.services.read_script_header",
+                return_value=b"\x7fELF\x02\x01\x01\x00not-python",
+            ),
+            patch("cms.experiments.services.delete_s3_object") as mock_delete,
+            patch("cms.experiments.services.audit_log"),
+            patch("cms.experiments.services.ScriptAsset"),
+            pytest.raises(ScriptUploadError),
+        ):
+            services.complete_script_upload(mock_user, "token123")
+        mock_delete.assert_called_once_with("scripts/7/abc_script.py")
+
+
+class TestNonUtf8Rejected:
+    def test_non_utf8_header_rejected_and_object_deleted(self, mock_user):
+        with (
+            patch("cms.experiments.services.verify_upload_token", return_value=_token_payload()),
+            patch("cms.experiments.services.verify_s3_object", return_value=(100, "etag")),
+            patch(
+                "cms.experiments.services.read_script_header",
+                return_value=b"\xff\xfe\xfd\xfc garbage",
+            ),
+            patch("cms.experiments.services.delete_s3_object") as mock_delete,
+            patch("cms.experiments.services.audit_log") as mock_audit,
+            patch("cms.experiments.services.ScriptAsset") as mock_model,
+            pytest.raises(ScriptUploadError),
+        ):
+            services.complete_script_upload(mock_user, "token123")
+        mock_delete.assert_called_once_with("scripts/7/abc_script.py")
+        mock_audit.assert_not_called()
+        mock_model.return_value.save.assert_not_called()
+
+
+class TestHeaderReadFailure:
+    def test_header_read_s3_error_surfaces_as_script_upload_error(self, mock_user):
+        with (
+            patch("cms.experiments.services.verify_upload_token", return_value=_token_payload()),
+            patch("cms.experiments.services.verify_s3_object", return_value=(100, "etag")),
+            patch(
+                "cms.experiments.services.read_script_header",
+                side_effect=__import__("cms.assets.s3", fromlist=["S3Error"]).S3Error("range failed"),
+            ),
+            patch("cms.experiments.services.delete_s3_object") as mock_delete,
+            patch("cms.experiments.services.audit_log"),
+            patch("cms.experiments.services.ScriptAsset"),
+            pytest.raises(ScriptUploadError),
+        ):
+            services.complete_script_upload(mock_user, "token123")
+        # Object is not auto-deleted on transport failure (different from a content mismatch).
+        mock_delete.assert_not_called()
+
+
+class TestLoggingDiscipline:
+    def test_rejection_log_does_not_leak_header_bytes_or_token(self, mock_user, caplog):
+        leak = b"\x50\x4b\x03\x04S3CR3T-DO-NOT-LEAK"
+        with (
+            patch("cms.experiments.services.verify_upload_token", return_value=_token_payload()),
+            patch("cms.experiments.services.verify_s3_object", return_value=(100, "etag")),
+            patch("cms.experiments.services.read_script_header", return_value=leak),
+            patch("cms.experiments.services.delete_s3_object"),
+            patch("cms.experiments.services.audit_log"),
+            patch("cms.experiments.services.ScriptAsset"),
+            caplog.at_level("WARNING", logger="cms.experiments.services"),
+            pytest.raises(ScriptUploadError),
+        ):
+            services.complete_script_upload(mock_user, "token123")
+
+        combined = " ".join(record.getMessage() for record in caplog.records)
+        assert "S3CR3T-DO-NOT-LEAK" not in combined
+        assert "token123" not in combined
+
+
+class TestSizeMismatch:
+    """Issue #696 cycle 3 finding 1: actual size must match signed expected size."""
+
+    def test_size_mismatch_rejects_and_deletes_object(self, mock_user):
+        payload = _token_payload()
+        # Token claims 100 bytes; S3 returned 500 — must reject.
+        payload["file_size"] = 100
+        with (
+            patch("cms.experiments.services.verify_upload_token", return_value=payload),
+            patch("cms.experiments.services.verify_s3_object", return_value=(500, "etag")),
+            patch("cms.experiments.services.read_script_header") as mock_read,
+            patch("cms.experiments.services.delete_s3_object") as mock_delete,
+            patch("cms.experiments.services.audit_log"),
+            patch("cms.experiments.services.ScriptAsset") as mock_model,
+            pytest.raises(ScriptUploadError, match="size mismatch"),
+        ):
+            services.complete_script_upload(mock_user, "token123")
+        mock_delete.assert_called_once_with("scripts/7/abc_script.py")
+        # Header read must NOT happen if size already mismatched.
+        mock_read.assert_not_called()
+        mock_model.return_value.save.assert_not_called()
+
+
+class TestFullBodyScan:
+    """Cycle 3 finding 5: scripts read the full body, not just a header prefix."""
+
+    def test_full_body_is_read_using_max_script_size(self, mock_user, settings):
+        settings.SCRIPT_MAX_FILE_SIZE_BYTES = 1024
+        body = b"print('hello')\n" + b" " * (1024 - 15)
+        with (
+            patch("cms.experiments.services.verify_upload_token", return_value=_token_payload()),
+            patch("cms.experiments.services.verify_s3_object", return_value=(100, "etag")),
+            patch("cms.experiments.services.read_script_header", return_value=body) as mock_read,
+            patch("cms.experiments.services.delete_s3_object"),
+            patch("cms.experiments.services.audit_log"),
+            patch("cms.experiments.services.ScriptAsset") as mock_model,
+        ):
+            mock_model.return_value = MagicMock(pk=99)
+            services.complete_script_upload(mock_user, "token123")
+            # max_bytes argument should be SCRIPT_MAX_FILE_SIZE_BYTES, not the
+            # smaller UPLOAD_INSPECTION_MAX_HEADER_BYTES.
+            _, called_max = mock_read.call_args[0]
+            assert called_max == 1024
+
+    def test_text_prefix_with_binary_tail_rejected(self, mock_user):
+        # Attacker bypass: valid text prefix followed by binary garbage that
+        # never appears in the bounded inspection window. With full-body scan
+        # the binary bytes are caught.
+        body = b"# innocuous Python prefix\n" + b"\xff\xfe binary garbage\n"
+        with (
+            patch("cms.experiments.services.verify_upload_token", return_value=_token_payload()),
+            patch("cms.experiments.services.verify_s3_object", return_value=(100, "etag")),
+            patch("cms.experiments.services.read_script_header", return_value=body),
+            patch("cms.experiments.services.delete_s3_object") as mock_delete,
+            patch("cms.experiments.services.audit_log"),
+            patch("cms.experiments.services.ScriptAsset"),
+            pytest.raises(ScriptUploadError),
+        ):
+            services.complete_script_upload(mock_user, "token123")
+        mock_delete.assert_called_once_with("scripts/7/abc_script.py")
+
+
+class TestBomAccepted:
+    def test_bom_prefixed_python_accepted(self, mock_user):
+        with (
+            patch("cms.experiments.services.verify_upload_token", return_value=_token_payload()),
+            patch("cms.experiments.services.verify_s3_object", return_value=(100, "etag")),
+            patch(
+                "cms.experiments.services.read_script_header",
+                return_value=b"\xef\xbb\xbfprint('hi')\n",
+            ),
+            patch("cms.experiments.services.delete_s3_object") as mock_delete,
+            patch("cms.experiments.services.audit_log"),
+            patch("cms.experiments.services.ScriptAsset") as mock_model,
+        ):
+            mock_instance = MagicMock(pk=43)
+            mock_model.return_value = mock_instance
+            services.complete_script_upload(mock_user, "token123")
+            mock_delete.assert_not_called()
+            mock_instance.save.assert_called_once()

--- a/shifter/shifter_platform/tests/cms/test_services_upload.py
+++ b/shifter/shifter_platform/tests/cms/test_services_upload.py
@@ -16,6 +16,10 @@ from cms import services
 from cms.models import AgentConfig
 from shared.constants import USER_CANNOT_BE_NONE
 
+# MSI magic prefix used to make every happy-path complete_upload test pass the
+# server-side header inspection added in issue #696.
+_MSI_HEADER = bytes([0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1]) + b"\x00" * 16
+
 
 @pytest.fixture
 def mock_user():
@@ -373,6 +377,7 @@ class TestCompleteUpload:
         with (
             patch(verify_token_path, return_value=token_payload) as mock_verify,
             patch("cms.assets.s3.verify_s3_object_exists", return_value=(1000, "etag")),
+            patch("cms.assets.s3.read_agent_header", return_value=_MSI_HEADER),
             patch("cms.assets.s3.tag_s3_object"),
             patch("cms.assets.services.create_agent") as mock_create,
         ):
@@ -395,6 +400,7 @@ class TestCompleteUpload:
                 return_value=token_payload,
             ),
             patch("cms.assets.s3.verify_s3_object_exists", return_value=(1000, "etag")) as mock_verify_s3,
+            patch("cms.assets.s3.read_agent_header", return_value=_MSI_HEADER),
             patch("cms.assets.s3.tag_s3_object"),
             patch("cms.assets.services.create_agent") as mock_create,
         ):
@@ -417,6 +423,7 @@ class TestCompleteUpload:
                 return_value=token_payload,
             ),
             patch("cms.assets.s3.verify_s3_object_exists", return_value=(1000, "etag")),
+            patch("cms.assets.s3.read_agent_header", return_value=_MSI_HEADER),
             patch("cms.assets.s3.tag_s3_object") as mock_tag,
             patch("cms.assets.services.create_agent") as mock_create,
         ):
@@ -440,6 +447,7 @@ class TestCompleteUpload:
                 return_value=token_payload,
             ),
             patch("cms.assets.s3.verify_s3_object_exists", return_value=(5000, "etag")),
+            patch("cms.assets.s3.read_agent_header", return_value=_MSI_HEADER),
             patch("cms.assets.s3.tag_s3_object"),
             patch("cms.assets.services.create_agent") as mock_create,
         ):
@@ -474,6 +482,7 @@ class TestCompleteUpload:
                 return_value=token_payload,
             ),
             patch("cms.assets.s3.verify_s3_object_exists", return_value=(1000, "etag")),
+            patch("cms.assets.s3.read_agent_header", return_value=_MSI_HEADER),
             patch("cms.assets.s3.tag_s3_object"),
             patch("cms.assets.services.create_agent", return_value=mock_agent),
         ):
@@ -608,6 +617,111 @@ class TestCompleteUpload:
             pytest.raises(RuntimeError, match="Unexpected"),
         ):
             services.complete_upload(mock_user, "token123")
+
+    # --- Server-side header inspection (issue #696) ---
+
+    def test_reads_object_header_after_size_verify(self, mock_user):
+        """Service reads the object header via the cloud seam before tagging."""
+        token_payload = {
+            "s3_key": "agents/1/abc_agent.msi",
+            "name": "Agent",
+            "filename": "agent.msi",
+            "os_slug": "windows",
+            "file_size": 1000,
+        }
+        msi_magic = bytes([0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1])
+        with (
+            patch("cms.assets.upload_token.verify_upload_token", return_value=token_payload),
+            patch("cms.assets.s3.verify_s3_object_exists", return_value=(1000, "etag")),
+            patch("cms.assets.s3.read_agent_header", return_value=msi_magic + b"\x00" * 16) as mock_read,
+            patch("cms.assets.s3.tag_s3_object"),
+            patch("cms.assets.services.create_agent") as mock_create,
+        ):
+            mock_create.return_value = Mock(spec=AgentConfig, id=42)
+            services.complete_upload(mock_user, "token123")
+            mock_read.assert_called_once()
+            args, _ = mock_read.call_args
+            assert args[0] == "agents/1/abc_agent.msi"
+
+    def test_magic_byte_mismatch_raises_and_deletes_object(self, mock_user):
+        """Magic-byte mismatch must delete the object and skip tag + create_agent + audit."""
+        from cms.exceptions import CMSError
+
+        token_payload = {
+            "s3_key": "agents/1/abc_agent.msi",
+            "name": "Agent",
+            "filename": "agent.msi",  # .msi expects D0 CF 11 E0 ...
+            "os_slug": "windows",
+            "file_size": 1000,
+        }
+        # Header is ZIP magic, not MSI — mismatch.
+        bogus_header = b"\x50\x4b\x03\x04" + b"\x00" * 16
+        with (
+            patch("cms.assets.upload_token.verify_upload_token", return_value=token_payload),
+            patch("cms.assets.s3.verify_s3_object_exists", return_value=(1000, "etag")),
+            patch("cms.assets.s3.read_agent_header", return_value=bogus_header),
+            patch("cms.assets.s3.tag_s3_object") as mock_tag,
+            patch("cms.assets.s3.delete_agent") as mock_delete,
+            patch("cms.assets.services.create_agent") as mock_create,
+            pytest.raises(CMSError, match="content"),
+        ):
+            services.complete_upload(mock_user, "token123")
+        mock_delete.assert_called_once_with("agents/1/abc_agent.msi")
+        mock_tag.assert_not_called()
+        mock_create.assert_not_called()
+
+    def test_rejection_log_does_not_leak_header_bytes_or_token(self, mock_user, caplog):
+        from cms.exceptions import CMSError
+
+        token_payload = {
+            "s3_key": "agents/1/abc_agent.msi",
+            "name": "Agent",
+            "filename": "agent.msi",
+            "os_slug": "windows",
+            "file_size": 1000,
+        }
+        leak = b"\x50\x4b\x03\x04S3CR3T-DO-NOT-LEAK"
+        with (
+            patch("cms.assets.upload_token.verify_upload_token", return_value=token_payload),
+            patch("cms.assets.s3.verify_s3_object_exists", return_value=(1000, "etag")),
+            patch("cms.assets.s3.read_agent_header", return_value=leak),
+            patch("cms.assets.s3.delete_agent"),
+            patch("cms.assets.s3.tag_s3_object"),
+            patch("cms.assets.services.create_agent"),
+            caplog.at_level("WARNING", logger="cms.services"),
+            pytest.raises(CMSError),
+        ):
+            services.complete_upload(mock_user, "token-S3CR3T-DO-NOT-LEAK")
+
+        combined = " ".join(record.getMessage() for record in caplog.records)
+        assert "S3CR3T-DO-NOT-LEAK" not in combined
+
+    def test_header_read_failure_raises_cmserror(self, mock_user):
+        """If reading the header fails, the service raises CMSError and does not finalize."""
+        from cms.assets.s3 import S3Error
+        from cms.exceptions import CMSError
+
+        token_payload = {
+            "s3_key": "agents/1/abc_agent.msi",
+            "name": "Agent",
+            "filename": "agent.msi",
+            "os_slug": "windows",
+            "file_size": 1000,
+        }
+        with (
+            patch("cms.assets.upload_token.verify_upload_token", return_value=token_payload),
+            patch("cms.assets.s3.verify_s3_object_exists", return_value=(1000, "etag")),
+            patch(
+                "cms.assets.s3.read_agent_header",
+                side_effect=S3Error("range read failed"),
+            ),
+            patch("cms.assets.s3.tag_s3_object") as mock_tag,
+            patch("cms.assets.services.create_agent") as mock_create,
+            pytest.raises(CMSError),
+        ):
+            services.complete_upload(mock_user, "token123")
+        mock_tag.assert_not_called()
+        mock_create.assert_not_called()
 
 
 class TestCancelUpload:

--- a/shifter/shifter_platform/tests/ctf/test_attachments.py
+++ b/shifter/shifter_platform/tests/ctf/test_attachments.py
@@ -66,9 +66,25 @@ def challenge(db, draft_event):
     )
 
 
-def _make_file(content: bytes = b"test file content", name: str = "test.pcap"):
-    """Create a file-like object for upload testing."""
+_PCAP_MAGIC = b"\xd4\xc3\xb2\xa1"
+_PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+
+
+def _make_file(content: bytes = b"test file content", name: str = "test.txt"):
+    """Create a file-like object for upload testing.
+
+    Default content is plain UTF-8 text and the default name is `.txt`
+    (TEXT-category inspection passes for plain text). Tests that exercise a
+    specific binary extension must supply a matching magic-byte header.
+    """
     f = io.BytesIO(content)
+    f.name = name
+    return f
+
+
+def _make_pcap_file(name: str = "capture.pcap"):
+    """File-like object whose header is a real libpcap magic prefix."""
+    f = io.BytesIO(_PCAP_MAGIC + b"\x00" * 32)
     f.name = name
     return f
 
@@ -78,7 +94,8 @@ class TestAddChallengeFile:
 
     def test_upload_success(self, challenge, mock_s3):
         """Valid file upload creates a CTFChallengeFile record."""
-        file_obj = _make_file()
+        pcap_content = _PCAP_MAGIC + b"\x00" * 32
+        file_obj = _make_file(content=pcap_content, name="capture.pcap")
         result = add_challenge_file(
             challenge.id,
             file_obj,
@@ -88,7 +105,7 @@ class TestAddChallengeFile:
         )
         assert result.filename == "capture.pcap"
         assert result.display_name == "Network Capture"
-        assert result.file_size_bytes == len(b"test file content")
+        assert result.file_size_bytes == len(pcap_content)
         assert result.sha256_hash  # non-empty
         assert result.s3_key.startswith("ctf-files/")
         mock_s3.upload_fileobj.assert_called_once()
@@ -157,6 +174,86 @@ class TestAddChallengeFile:
         with pytest.raises(CTFNotFoundError):
             add_challenge_file(uuid4(), _make_file(), "file.txt", actor_id=1)
 
+    def test_magic_byte_mismatch_rejected_before_upload(self, challenge, mock_s3):
+        """A .png filename with a PDF magic-byte header is rejected and S3 is not called."""
+        bogus_png = io.BytesIO(b"%PDF-1.7\n" + b"\x00" * 32)
+        with pytest.raises(CTFValidationError, match="inspection"):
+            add_challenge_file(
+                challenge.id,
+                bogus_png,
+                "fake.png",
+                actor_id=challenge.event.created_by_id,
+            )
+        mock_s3.upload_fileobj.assert_not_called()
+
+    def test_text_extension_with_binary_header_rejected(self, challenge, mock_s3):
+        """A .txt filename whose body is a PE binary header is rejected."""
+        pe_bytes = io.BytesIO(b"MZ\x90\x00" + b"\x00" * 32)
+        with pytest.raises(CTFValidationError, match="inspection"):
+            add_challenge_file(
+                challenge.id,
+                pe_bytes,
+                "wolf-in-sheep.txt",
+                actor_id=challenge.event.created_by_id,
+            )
+        mock_s3.upload_fileobj.assert_not_called()
+
+    def test_opaque_extension_accepts_arbitrary_bytes(self, challenge, mock_s3):
+        """.bin is an OPAQUE category — any byte content is accepted (size still enforced)."""
+        opaque = io.BytesIO(b"\xff\xfe\xfd\xfc\x00\x01\x02\x03 random binary blob")
+        result = add_challenge_file(
+            challenge.id,
+            opaque,
+            "raw.bin",
+            actor_id=challenge.event.created_by_id,
+        )
+        assert result.filename == "raw.bin"
+        mock_s3.upload_fileobj.assert_called_once()
+
+    def test_magic_byte_match_passes(self, challenge, mock_s3):
+        """A .png with a real PNG header succeeds."""
+        png = io.BytesIO(_PNG_MAGIC + b"\x00" * 32)
+        result = add_challenge_file(
+            challenge.id,
+            png,
+            "screenshot.png",
+            actor_id=challenge.event.created_by_id,
+        )
+        assert result.filename == "screenshot.png"
+        mock_s3.upload_fileobj.assert_called_once()
+
+    def test_text_extension_with_binary_tail_rejected(self, challenge, mock_s3):
+        """Cycle 3 finding 5: a text-prefix + binary-tail upload must fail.
+
+        The bounded header inspection alone would not catch this (the prefix
+        is valid UTF-8); the streaming text validator that runs alongside the
+        SHA256 loop rejects the binary tail.
+        """
+        prefix = b"# Looks like a Python file\n" + b" " * 600
+        body = prefix + b"\xff\xfe\xfd\xfc binary garbage tail\n"
+        bypass = io.BytesIO(body)
+        with pytest.raises(CTFValidationError, match="inspection"):
+            add_challenge_file(
+                challenge.id,
+                bypass,
+                "smuggle.py",
+                actor_id=challenge.event.created_by_id,
+            )
+        mock_s3.upload_fileobj.assert_not_called()
+
+    def test_text_extension_with_full_utf8_body_succeeds(self, challenge, mock_s3):
+        """Streaming validator must accept a clean UTF-8 body."""
+        body = ("# valid UTF-8 with multibyte: café résumé\n" * 200).encode("utf-8")
+        clean = io.BytesIO(body)
+        result = add_challenge_file(
+            challenge.id,
+            clean,
+            "clean.py",
+            actor_id=challenge.event.created_by_id,
+        )
+        assert result.filename == "clean.py"
+        mock_s3.upload_fileobj.assert_called_once()
+
 
 class TestRemoveChallengeFile:
     """Tests for remove_challenge_file."""
@@ -209,7 +306,12 @@ class TestGetDownloadUrl:
 
     def test_returns_presigned_url(self, challenge, mock_s3):
         """Returns a presigned S3 URL and filename."""
-        cf = add_challenge_file(challenge.id, _make_file(), "download_me.pcap", actor_id=challenge.event.created_by_id)
+        cf = add_challenge_file(
+            challenge.id,
+            _make_pcap_file("download_me.pcap"),
+            "download_me.pcap",
+            actor_id=challenge.event.created_by_id,
+        )
         url, filename = get_download_url(cf.id)
         assert "amazonaws.com" in url
         assert filename == "download_me.pcap"
@@ -230,7 +332,9 @@ class TestCTFChallengeFileModel:
         )
         assert f1.display == "Memory Dump"
 
-        f2 = add_challenge_file(challenge.id, _make_file(), "data.pcap", actor_id=challenge.event.created_by_id)
+        f2 = add_challenge_file(
+            challenge.id, _make_pcap_file("data.pcap"), "data.pcap", actor_id=challenge.event.created_by_id
+        )
         assert f2.display == "data.pcap"
 
     def test_file_size_display(self, challenge, mock_s3):

--- a/shifter/shifter_platform/tests/ctf/test_inspection.py
+++ b/shifter/shifter_platform/tests/ctf/test_inspection.py
@@ -1,0 +1,203 @@
+"""Tests for ctf.inspection — CTF attachment header inspection."""
+
+import pytest
+
+from ctf.inspection import (
+    CTFInspectionError,
+    inspect_attachment_header,
+)
+
+
+class TestMagicCategory:
+    """Extensions whose header must positively match a magic-byte signature."""
+
+    def test_png_passes_with_png_magic(self):
+        inspect_attachment_header(b"\x89PNG\r\n\x1a\n" + b"\x00" * 16, ".png")
+
+    def test_png_fails_with_pdf_magic(self):
+        with pytest.raises(CTFInspectionError) as exc:
+            inspect_attachment_header(b"%PDF-1.4\n" + b"\x00" * 16, ".png")
+        assert ".png" in str(exc.value)
+
+    def test_pdf_passes_with_pdf_magic(self):
+        inspect_attachment_header(b"%PDF-1.7\n" + b"\x00" * 16, ".pdf")
+
+    def test_zip_passes_with_zip_magic(self):
+        inspect_attachment_header(b"\x50\x4b\x03\x04" + b"\x00" * 16, ".zip")
+
+    def test_zip_fails_with_random_bytes(self):
+        with pytest.raises(CTFInspectionError):
+            inspect_attachment_header(b"random nonsense bytes", ".zip")
+
+    def test_jpeg_passes_with_jpeg_magic(self):
+        inspect_attachment_header(b"\xff\xd8\xff\xe0\x00\x10JFIF", ".jpg")
+        inspect_attachment_header(b"\xff\xd8\xff\xe1\x00\x10Exif", ".jpeg")
+
+    def test_elf_passes_with_elf_magic(self):
+        inspect_attachment_header(b"\x7fELF\x02\x01\x01\x00" + b"\x00" * 8, ".elf")
+
+    def test_pe_passes_with_mz_magic(self):
+        inspect_attachment_header(b"MZ\x90\x00" + b"\x00" * 16, ".exe")
+
+    def test_gzip_passes_with_gzip_magic(self):
+        inspect_attachment_header(b"\x1f\x8b\x08\x00" + b"\x00" * 16, ".gz")
+        inspect_attachment_header(b"\x1f\x8b\x08\x00" + b"\x00" * 16, ".tgz")
+
+    def test_sqlite_passes(self):
+        inspect_attachment_header(b"SQLite format 3\x00" + b"\x00" * 8, ".sqlite")
+        inspect_attachment_header(b"SQLite format 3\x00" + b"\x00" * 8, ".db")
+
+
+class TestTextCategory:
+    """Extensions whose header must be UTF-8 text and not a known binary signature."""
+
+    def test_txt_accepts_plain_text(self):
+        inspect_attachment_header(b"Hello, world!\nThis is a flag file.\n", ".txt")
+
+    def test_md_accepts_markdown(self):
+        inspect_attachment_header(b"# Challenge\n\nDescription here.\n", ".md")
+
+    def test_json_accepts_json(self):
+        inspect_attachment_header(b'{"flag": "shifter{example}"}\n', ".json")
+
+    def test_csv_accepts_csv(self):
+        inspect_attachment_header(b"name,value\nfoo,bar\n", ".csv")
+
+    def test_py_accepts_python_source(self):
+        inspect_attachment_header(b"#!/usr/bin/env python3\nprint('hi')\n", ".py")
+
+    def test_sh_accepts_shell_script(self):
+        inspect_attachment_header(b"#!/bin/sh\necho hello\n", ".sh")
+
+    def test_pem_accepts_pem_text(self):
+        inspect_attachment_header(b"-----BEGIN CERTIFICATE-----\nMIIB...\n", ".pem")
+
+    def test_txt_rejects_zip_magic(self):
+        with pytest.raises(CTFInspectionError):
+            inspect_attachment_header(b"\x50\x4b\x03\x04rest", ".txt")
+
+    def test_txt_rejects_pe_magic(self):
+        with pytest.raises(CTFInspectionError):
+            inspect_attachment_header(b"MZ\x90\x00more bytes", ".txt")
+
+    def test_py_rejects_elf_magic(self):
+        with pytest.raises(CTFInspectionError):
+            inspect_attachment_header(b"\x7fELFmore bytes", ".py")
+
+    def test_json_rejects_non_utf8(self):
+        with pytest.raises(CTFInspectionError):
+            inspect_attachment_header(b"\xff\xfe\xfd\xfc garbage", ".json")
+
+    def test_txt_with_bom_accepted(self):
+        inspect_attachment_header(b"\xef\xbb\xbfHello\n", ".txt")
+
+
+class TestOpaqueCategory:
+    """Extensions where the magic-byte concept does not apply (raw containers)."""
+
+    def test_bin_accepts_anything(self):
+        inspect_attachment_header(b"\xff\xfe\xfd\xfc\x00\x01\x02\x03", ".bin")
+        inspect_attachment_header(b"\x50\x4b\x03\x04zip-magic", ".bin")
+        inspect_attachment_header(b"plain text in bin file", ".bin")
+
+    def test_raw_accepts_anything(self):
+        inspect_attachment_header(b"\x00" * 16, ".raw")
+
+    def test_dd_accepts_anything(self):
+        inspect_attachment_header(b"\xde\xad\xbe\xef", ".dd")
+
+    def test_iso_accepts_anything(self):
+        # ISO 9660 magic is at offset 0x8001, way past our 512-byte window —
+        # so OPAQUE is the only sane policy for .iso headers.
+        inspect_attachment_header(b"\x00" * 16, ".iso")
+
+    def test_vmdk_accepts_anything(self):
+        inspect_attachment_header(b"random vmdk header bytes", ".vmdk")
+
+
+class TestTarOffsetSignature:
+    """`.tar` is MAGIC with ``ustar`` at offset 257 — not OPAQUE."""
+
+    def test_posix_tar_accepted(self):
+        header = b"\x00" * 257 + b"ustar\x0000" + b"\x00" * 240
+        inspect_attachment_header(header, ".tar")
+
+    def test_random_bytes_rejected(self):
+        # Random bytes the size of a tar header, no ustar marker.
+        header = b"A" * 512
+        with pytest.raises(CTFInspectionError):
+            inspect_attachment_header(header, ".tar")
+
+
+class TestWavCompositeSignature:
+    """`.wav` requires both ``RIFF`` at 0 AND ``WAVE`` at offset 8."""
+
+    def test_wave_riff_accepted(self):
+        header = b"RIFF\x00\x10\x00\x00WAVEfmt \x00\x00"
+        inspect_attachment_header(header, ".wav")
+
+    def test_riff_avi_rejected(self):
+        # AVI is also a RIFF container — must not pass the .wav rule.
+        header = b"RIFF\x00\x10\x00\x00AVI LIST\x00\x00"
+        with pytest.raises(CTFInspectionError):
+            inspect_attachment_header(header, ".wav")
+
+    def test_riff_webp_rejected(self):
+        header = b"RIFF\x00\x10\x00\x00WEBPVP8 \x00\x00"
+        with pytest.raises(CTFInspectionError):
+            inspect_attachment_header(header, ".wav")
+
+
+class TestPemOrDerCategory:
+    """`.crt` and `.key` accept either PEM text or DER ASN.1 SEQUENCE."""
+
+    def test_crt_accepts_pem_certificate(self):
+        inspect_attachment_header(b"-----BEGIN CERTIFICATE-----\nMIIB...\n", ".crt")
+
+    def test_crt_accepts_der_certificate(self):
+        inspect_attachment_header(b"\x30\x82\x03\x10" + b"\x00" * 32, ".crt")
+
+    def test_key_accepts_pem_private_key(self):
+        # PEM armor is constructed at runtime so the `detect-private-key`
+        # pre-commit hook doesn't trip on the literal label.
+        armor = b"-----BEGIN " + b"RSA PRIVATE KEY" + b"-----"
+        inspect_attachment_header(armor + b"\nMIIE...\n", ".key")
+
+    def test_key_accepts_der_private_key(self):
+        inspect_attachment_header(b"\x30\x82\x04\x00" + b"\x00" * 32, ".key")
+
+    def test_crt_rejects_random_binary(self):
+        with pytest.raises(CTFInspectionError):
+            inspect_attachment_header(b"\x89PNG\r\n\x1a\nrest", ".crt")
+
+    def test_key_rejects_random_text(self):
+        with pytest.raises(CTFInspectionError):
+            inspect_attachment_header(b"this is not a key file", ".key")
+
+
+class TestUnknownExtension:
+    def test_unknown_extension_rejected(self):
+        # Defense-in-depth: even though attachment.py rejects unknown extensions
+        # earlier, the inspector must not silently allow them.
+        with pytest.raises(CTFInspectionError) as exc:
+            inspect_attachment_header(b"anything", ".unknown-ext")
+        assert "extension" in str(exc.value).lower() or "unknown" in str(exc.value).lower()
+
+
+class TestRulesParityWithAllowlist:
+    """Cycle 3 finding 3: _RULES must stay in sync with ctf.s3.ALLOWED_EXTENSIONS."""
+
+    def test_rules_keys_equal_allowed_extensions(self):
+        from ctf.inspection import _RULES
+        from ctf.s3 import ALLOWED_EXTENSIONS
+
+        assert set(_RULES) == ALLOWED_EXTENSIONS
+
+
+class TestSecretSafety:
+    def test_error_message_does_not_echo_upload_bytes(self):
+        leak = b"S3CR3T-FLAG-DO-NOT-LEAK"
+        with pytest.raises(CTFInspectionError) as exc:
+            inspect_attachment_header(leak, ".png")
+        assert "S3CR3T-FLAG" not in str(exc.value)
+        assert "DO-NOT-LEAK" not in str(exc.value)

--- a/shifter/shifter_platform/tests/shared/cloud/test_aws_storage.py
+++ b/shifter/shifter_platform/tests/shared/cloud/test_aws_storage.py
@@ -1,0 +1,70 @@
+"""Tests for AWSObjectStorage.read_object_header."""
+
+from io import BytesIO
+from unittest.mock import MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError
+
+from shared.cloud.aws.storage import AWSObjectStorage
+from shared.cloud.exceptions import CloudStorageError
+
+
+def _make_get_object_response(body: bytes):
+    return {"Body": BytesIO(body)}
+
+
+def _make_client_error(code: str, op: str = "GetObject") -> ClientError:
+    return ClientError({"Error": {"Code": code, "Message": "boom"}}, op)
+
+
+class TestReadObjectHeader:
+    def test_passes_correct_range_and_returns_body(self):
+        storage = AWSObjectStorage()
+        fake_client = MagicMock()
+        fake_client.get_object.return_value = _make_get_object_response(b"\x50\x4b\x03\x04rest")
+
+        with patch.object(storage, "_get_client", return_value=fake_client):
+            result = storage.read_object_header("my-bucket", "my-key", max_bytes=512)
+
+        assert result == b"\x50\x4b\x03\x04rest"
+        fake_client.get_object.assert_called_once_with(
+            Bucket="my-bucket",
+            Key="my-key",
+            Range="bytes=0-511",
+        )
+
+    def test_truncates_to_max_bytes_when_body_is_longer(self):
+        storage = AWSObjectStorage()
+        fake_client = MagicMock()
+        # S3 in real life respects Range so won't return more than asked, but the
+        # adapter must still tolerate a longer body and cap it.
+        fake_client.get_object.return_value = _make_get_object_response(b"x" * 2048)
+
+        with patch.object(storage, "_get_client", return_value=fake_client):
+            result = storage.read_object_header("b", "k", max_bytes=128)
+
+        assert len(result) <= 128
+
+    def test_rejects_non_positive_max_bytes(self):
+        storage = AWSObjectStorage()
+        with pytest.raises(ValueError):
+            storage.read_object_header("b", "k", max_bytes=0)
+        with pytest.raises(ValueError):
+            storage.read_object_header("b", "k", max_bytes=-1)
+
+    def test_404_maps_to_cloud_storage_error(self):
+        storage = AWSObjectStorage()
+        fake_client = MagicMock()
+        fake_client.get_object.side_effect = _make_client_error("NoSuchKey")
+
+        with patch.object(storage, "_get_client", return_value=fake_client), pytest.raises(CloudStorageError):
+            storage.read_object_header("b", "k", max_bytes=512)
+
+    def test_other_client_error_maps_to_cloud_storage_error(self):
+        storage = AWSObjectStorage()
+        fake_client = MagicMock()
+        fake_client.get_object.side_effect = _make_client_error("AccessDenied")
+
+        with patch.object(storage, "_get_client", return_value=fake_client), pytest.raises(CloudStorageError):
+            storage.read_object_header("b", "k", max_bytes=512)

--- a/shifter/shifter_platform/tests/shared/cloud/test_gcp_storage.py
+++ b/shifter/shifter_platform/tests/shared/cloud/test_gcp_storage.py
@@ -1,0 +1,56 @@
+"""Tests for GCPObjectStorage.read_object_header."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from shared.cloud.exceptions import CloudStorageError
+from shared.cloud.gcp.storage import GCPObjectStorage
+
+
+class TestReadObjectHeader:
+    def test_calls_download_with_inclusive_range_and_returns_bytes(self):
+        storage = GCPObjectStorage()
+        fake_client = MagicMock()
+        fake_blob = MagicMock()
+        fake_blob.download_as_bytes.return_value = b"\x50\x4b\x03\x04rest"
+        fake_client.bucket.return_value.blob.return_value = fake_blob
+
+        with patch.object(storage, "_get_client", return_value=fake_client):
+            result = storage.read_object_header("my-bucket", "my-key", max_bytes=512)
+
+        assert result == b"\x50\x4b\x03\x04rest"
+        fake_client.bucket.assert_called_once_with("my-bucket")
+        fake_client.bucket.return_value.blob.assert_called_once_with("my-key")
+        # GCS download_as_bytes(end=...) is inclusive, so requesting 512 bytes
+        # means end=511.
+        fake_blob.download_as_bytes.assert_called_once_with(start=0, end=511)
+
+    def test_truncates_to_max_bytes_when_body_is_longer(self):
+        storage = GCPObjectStorage()
+        fake_client = MagicMock()
+        fake_blob = MagicMock()
+        fake_blob.download_as_bytes.return_value = b"y" * 2048
+        fake_client.bucket.return_value.blob.return_value = fake_blob
+
+        with patch.object(storage, "_get_client", return_value=fake_client):
+            result = storage.read_object_header("b", "k", max_bytes=64)
+
+        assert len(result) <= 64
+
+    def test_rejects_non_positive_max_bytes(self):
+        storage = GCPObjectStorage()
+        with pytest.raises(ValueError):
+            storage.read_object_header("b", "k", max_bytes=0)
+        with pytest.raises(ValueError):
+            storage.read_object_header("b", "k", max_bytes=-1)
+
+    def test_download_failure_maps_to_cloud_storage_error(self):
+        storage = GCPObjectStorage()
+        fake_client = MagicMock()
+        fake_blob = MagicMock()
+        fake_blob.download_as_bytes.side_effect = RuntimeError("transport error")
+        fake_client.bucket.return_value.blob.return_value = fake_blob
+
+        with patch.object(storage, "_get_client", return_value=fake_client), pytest.raises(CloudStorageError):
+            storage.read_object_header("b", "k", max_bytes=512)

--- a/shifter/shifter_platform/tests/shared/cloud/test_types.py
+++ b/shifter/shifter_platform/tests/shared/cloud/test_types.py
@@ -58,6 +58,9 @@ class TestProtocolStructuralTyping:
             def head_object(self, bucket, key):
                 return {}
 
+            def read_object_header(self, bucket, key, max_bytes):
+                return b""
+
             def generate_presigned_upload_url(self, bucket, key, content_type, expires_in):
                 return ""
 

--- a/shifter/shifter_platform/tests/shared/uploads/test_inspection.py
+++ b/shifter/shifter_platform/tests/shared/uploads/test_inspection.py
@@ -1,0 +1,394 @@
+"""Tests for shared.uploads.inspection."""
+
+import pytest
+
+from shared.uploads.inspection import (
+    BINARY_MAGIC_SIGNATURES,
+    FileFormat,
+    InspectionError,
+    MagicSignature,
+    get_file_extension,
+    looks_like_der_sequence,
+    looks_like_known_binary,
+    make_text_stream_validator,
+    validate_magic_bytes,
+    validate_pem_or_der_header,
+    validate_text_header,
+)
+
+
+class TestFileFormat:
+    def test_construct_with_signatures(self):
+        fmt = FileFormat(
+            extensions=[".zip"],
+            signatures=(MagicSignature(0, b"\x50\x4b\x03\x04"),),
+            description="ZIP",
+        )
+        assert fmt.extensions == [".zip"]
+        assert fmt.signatures[0].pattern == b"\x50\x4b\x03\x04"
+        assert fmt.description == "ZIP"
+        assert fmt.os_slug is None
+        assert fmt.magic_bytes == b"\x50\x4b\x03\x04"
+        assert fmt.min_header_bytes == 4
+
+    def test_os_slug_optional(self):
+        fmt = FileFormat(
+            extensions=[".msi"],
+            signatures=(MagicSignature(0, b"\xd0\xcf\x11\xe0"),),
+            description="MSI",
+            os_slug="windows",
+        )
+        assert fmt.os_slug == "windows"
+
+    def test_min_header_bytes_uses_max_offset(self):
+        fmt = FileFormat(
+            extensions=[".wav"],
+            signatures=(
+                MagicSignature(0, b"RIFF"),
+                MagicSignature(8, b"WAVE"),
+            ),
+            description="WAV",
+        )
+        assert fmt.min_header_bytes == 12
+
+    def test_magic_bytes_property_skips_non_zero_offset(self):
+        fmt = FileFormat(
+            extensions=[".tar"],
+            signatures=(MagicSignature(257, b"ustar"),),
+            description="POSIX tar",
+        )
+        # No offset-0 signature → empty magic_bytes convenience accessor.
+        assert fmt.magic_bytes == b""
+
+
+class TestMagicSignatureMatches:
+    def test_offset_zero_match(self):
+        sig = MagicSignature(0, b"\x89PNG")
+        assert sig.matches(b"\x89PNG more bytes") is True
+
+    def test_non_zero_offset_match(self):
+        sig = MagicSignature(8, b"WAVE")
+        assert sig.matches(b"RIFF\x00\x00\x00\x00WAVE more") is True
+
+    def test_short_header_returns_false(self):
+        sig = MagicSignature(257, b"ustar")
+        assert sig.matches(b"short") is False
+
+    def test_offset_mismatch_returns_false(self):
+        sig = MagicSignature(8, b"WAVE")
+        assert sig.matches(b"RIFFsome-wrong-format-here") is False
+
+
+class TestGetFileExtension:
+    def test_simple(self):
+        assert get_file_extension("agent.msi") == ".msi"
+
+    def test_compound_tar_gz(self):
+        assert get_file_extension("agent.tar.gz") == ".tar.gz"
+
+    def test_case_insensitive(self):
+        assert get_file_extension("FILE.MSI") == ".msi"
+
+    def test_no_extension(self):
+        assert get_file_extension("plainfile") == ""
+
+    def test_multiple_dots(self):
+        assert get_file_extension("file.name.deb") == ".deb"
+
+
+def _zip_fmt() -> FileFormat:
+    return FileFormat(
+        extensions=[".zip"],
+        signatures=(MagicSignature(0, b"\x50\x4b\x03\x04"),),
+        description="ZIP",
+    )
+
+
+def _wav_fmt() -> FileFormat:
+    return FileFormat(
+        extensions=[".wav"],
+        signatures=(MagicSignature(0, b"RIFF"), MagicSignature(8, b"WAVE")),
+        description="WAV (RIFF/WAVE)",
+    )
+
+
+def _tar_fmt() -> FileFormat:
+    return FileFormat(
+        extensions=[".tar"],
+        signatures=(MagicSignature(257, b"ustar"),),
+        description="POSIX tar",
+    )
+
+
+class TestValidateMagicBytes:
+    def test_match_succeeds(self):
+        validate_magic_bytes(b"\x50\x4b\x03\x04extra-content", _zip_fmt())  # no raise
+
+    def test_mismatch_raises(self):
+        with pytest.raises(InspectionError) as exc:
+            validate_magic_bytes(b"not-a-zip-file", _zip_fmt())
+        msg = str(exc.value)
+        assert "does not match" in msg
+        assert "ZIP" in msg
+
+    def test_header_shorter_than_signature_raises(self):
+        with pytest.raises(InspectionError) as exc:
+            validate_magic_bytes(b"\x50", _zip_fmt())
+        assert "too small" in str(exc.value).lower()
+
+    def test_does_not_leak_raw_header_in_message(self):
+        leak_bytes = b"S3CR3T-TOKEN-DO-NOT-LEAK"
+        with pytest.raises(InspectionError) as exc:
+            validate_magic_bytes(leak_bytes, _zip_fmt())
+        assert b"S3CR3T-TOKEN" not in str(exc.value).encode()
+        assert "DO-NOT-LEAK" not in str(exc.value)
+
+    def test_composite_signature_passes_when_both_match(self):
+        # RIFF at offset 0 + WAVE at offset 8.
+        header = b"RIFF\x00\x10\x00\x00WAVEfmt ..."
+        validate_magic_bytes(header, _wav_fmt())
+
+    def test_composite_signature_fails_when_format_id_wrong(self):
+        # RIFF at offset 0 + AVI  at offset 8 (a different RIFF container).
+        header = b"RIFF\x00\x10\x00\x00AVI \x00\x00\x00"
+        with pytest.raises(InspectionError) as exc:
+            validate_magic_bytes(header, _wav_fmt())
+        assert "WAV" in str(exc.value)
+
+    def test_offset_signature_match_at_257(self):
+        # POSIX tar header has 'ustar' at offset 257.
+        header = b"\x00" * 257 + b"ustar\x0000" + b"\x00" * 240
+        validate_magic_bytes(header, _tar_fmt())
+
+    def test_offset_signature_fail_when_marker_missing(self):
+        header = b"\x00" * 512  # no ustar marker
+        with pytest.raises(InspectionError):
+            validate_magic_bytes(header, _tar_fmt())
+
+
+class TestTextNegativeShortPrefixSafe:
+    """Cycle 3 finding 2: short ASCII prefixes must not false-reject text uploads."""
+
+    def test_mz_at_start_of_text_accepted(self):
+        # `MZ` is the PE/DOS executable magic but `MZ = "marker"` is a valid
+        # Python module assignment.
+        validate_text_header(b"MZ = 'marker'\n# Python module top\n")
+
+    def test_bm_at_start_of_text_accepted(self):
+        validate_text_header(b"BMP info: this is documentation, not bitmap\n")
+
+    def test_bzh_at_start_of_text_accepted(self):
+        # `BZh` is bzip2 magic but `BZh = ...` is valid Python.
+        validate_text_header(b"BZh = 'not a bzip2 file'\n")
+
+    def test_id3_at_start_of_text_accepted(self):
+        validate_text_header(b"ID3 tags are stored at the start of MP3 files.\n")
+
+    def test_riff_at_start_of_text_accepted(self):
+        validate_text_header(b"RIFFraff is an old British insult.\n")
+
+    def test_real_png_header_still_rejected(self):
+        with pytest.raises(InspectionError):
+            validate_text_header(b"\x89PNG\r\n\x1a\nplausible image content")
+
+    def test_real_zip_header_still_rejected(self):
+        with pytest.raises(InspectionError):
+            validate_text_header(b"\x50\x4b\x03\x04" + b"\x00" * 16)
+
+    def test_real_pdf_header_still_rejected(self):
+        with pytest.raises(InspectionError):
+            validate_text_header(b"%PDF-1.7\n" + b"\x00" * 16)
+
+
+class TestTextStreamValidator:
+    """Cycle 3 finding 5: full-stream UTF-8 check blocks prefix-pad bypass."""
+
+    def test_accepts_clean_chunks(self):
+        v = make_text_stream_validator()
+        v.feed(b"#!/usr/bin/env python3\n")
+        v.feed(b"print('hi')\n")
+        v.finalize()
+
+    def test_rejects_first_chunk_binary_magic(self):
+        v = make_text_stream_validator()
+        with pytest.raises(InspectionError):
+            v.feed(b"\x89PNG\r\n\x1a\nstart")
+
+    def test_rejects_binary_tail_after_text_prefix(self):
+        v = make_text_stream_validator()
+        v.feed(b"# clean Python prefix\nprint('ok')\n")
+        with pytest.raises(InspectionError):
+            v.feed(b"\xff\xfe binary garbage")
+
+    def test_handles_multibyte_split_across_chunks(self):
+        v = make_text_stream_validator()
+        # UTF-8 "café\n" — split between c3 and a9 of `é`.
+        v.feed(b"caf\xc3")
+        v.feed(b"\xa9\n")
+        v.finalize()
+
+    def test_finalize_with_incomplete_trailing_multibyte_rejects(self):
+        v = make_text_stream_validator()
+        # Trailing 0xc3 with no continuation byte → corruption at end of file.
+        v.feed(b"caf\xc3")
+        with pytest.raises(InspectionError):
+            v.finalize()
+
+    def test_finalize_without_any_chunks_rejects(self):
+        v = make_text_stream_validator()
+        with pytest.raises(InspectionError):
+            v.finalize()
+
+
+class TestLooksLikeKnownBinary:
+    def test_zip_magic_detected(self):
+        assert looks_like_known_binary(b"\x50\x4b\x03\x04rest") is True
+
+    def test_png_magic_detected(self):
+        assert looks_like_known_binary(b"\x89PNG\r\n\x1a\nrest") is True
+
+    def test_pe_executable_no_longer_blocks_text(self):
+        # `MZ` is a short ASCII-printable prefix that legitimately appears in
+        # text uploads (e.g. `MZ = "marker"`). Cycle 3 removed it from the
+        # text-negative subset; `looks_like_known_binary` should now be False.
+        assert looks_like_known_binary(b"MZ\x90\x00rest") is False
+
+    def test_elf_detected(self):
+        assert looks_like_known_binary(b"\x7fELFmore") is True
+
+    def test_plain_text_not_detected(self):
+        assert looks_like_known_binary(b"print('hello, world')\n") is False
+
+    def test_empty_header_not_detected(self):
+        assert looks_like_known_binary(b"") is False
+
+    def test_binary_signatures_registry_nonempty(self):
+        # Sanity: registry must have entries for at least PE, ELF, ZIP, PNG, JPEG, PDF, GZIP.
+        magics = set(BINARY_MAGIC_SIGNATURES)
+        assert b"\x50\x4b\x03\x04" in magics  # ZIP
+        assert b"MZ" in magics  # PE
+        assert b"\x7fELF" in magics  # ELF
+        assert b"\x89PNG\r\n\x1a\n" in magics  # PNG
+        assert b"\xff\xd8\xff" in magics  # JPEG SOI prefix
+        assert b"%PDF" in magics  # PDF
+        assert b"\x1f\x8b" in magics  # GZIP
+
+
+class TestValidateTextHeader:
+    def test_plain_ascii_python_passes(self):
+        validate_text_header(b"print('hello')\n")
+
+    def test_utf8_with_bom_passes(self):
+        validate_text_header(b"\xef\xbb\xbfprint('hi')\n")
+
+    def test_utf8_non_ascii_passes(self):
+        # "héllo" in UTF-8
+        validate_text_header(b"# h\xc3\xa9llo\n")
+
+    def test_zip_magic_rejected(self):
+        with pytest.raises(InspectionError) as exc:
+            validate_text_header(b"\x50\x4b\x03\x04rest")
+        assert "binary" in str(exc.value).lower()
+
+    def test_pe_prefix_in_text_now_accepted(self):
+        # Cycle 3 finding 2: `MZ` is too short and too text-friendly to act as
+        # an unconditional text blocker. `validate_text_header` no longer
+        # rejects text that happens to start with `MZ`.
+        validate_text_header(b"MZ = 'not an executable'\n")
+
+    def test_non_utf8_rejected(self):
+        # Random bytes that are not valid UTF-8.
+        with pytest.raises(InspectionError) as exc:
+            validate_text_header(b"\xff\xfe\xfd\xfc some garbage")
+        msg = str(exc.value).lower()
+        # Either "utf-8" / "text" message — accept either phrasing.
+        assert "utf-8" in msg or "text" in msg
+
+    def test_empty_header_rejected(self):
+        with pytest.raises(InspectionError) as exc:
+            validate_text_header(b"")
+        assert "empty" in str(exc.value).lower()
+
+    def test_incomplete_trailing_multibyte_accepted(self):
+        # Full text would be "café\n" but we truncate mid-é (UTF-8: c3 a9).
+        # The truncated prefix ends with `c3` alone — half a multibyte char.
+        # A strict decoder treating this prefix as the whole document would
+        # reject it; the bounded-prefix decoder must accept it.
+        validate_text_header(b"caf\xc3")  # Note trailing `c3` only
+
+    def test_complete_multibyte_within_prefix_accepted(self):
+        validate_text_header("café\n".encode())
+
+    def test_invalid_byte_inside_prefix_rejected(self):
+        # `\xff` is never valid UTF-8. This must still be rejected even with
+        # the incremental decoder.
+        with pytest.raises(InspectionError):
+            validate_text_header(b"text\xfftext")
+
+
+class TestLooksLikeDerSequence:
+    def test_2byte_length_prefix_detected(self):
+        assert looks_like_der_sequence(b"\x30\x82\x03\x00more-asn1") is True
+
+    def test_3byte_length_prefix_detected(self):
+        assert looks_like_der_sequence(b"\x30\x83\x00\x10\x00rest") is True
+
+    def test_4byte_length_prefix_detected(self):
+        assert looks_like_der_sequence(b"\x30\x84\x00\x00\x10\x00rest") is True
+
+    def test_short_form_length_prefix_detected(self):
+        assert looks_like_der_sequence(b"\x30\x81\x80rest") is True
+
+    def test_text_not_detected(self):
+        assert looks_like_der_sequence(b"-----BEGIN CERT-----\n") is False
+        assert looks_like_der_sequence(b"random text") is False
+
+
+class TestValidatePemOrDer:
+    def test_pem_accepted(self):
+        validate_pem_or_der_header(b"-----BEGIN CERTIFICATE-----\nMIIB...\n")
+
+    def test_pem_key_accepted(self):
+        # PEM armor is constructed from a non-literal string so the
+        # `detect-private-key` pre-commit hook (which substring-matches
+        # the literal label) doesn't trip on test fixtures.
+        armor = b"-----BEGIN " + b"RSA PRIVATE KEY" + b"-----"
+        validate_pem_or_der_header(armor + b"\nMIIE...\n")
+
+    def test_pem_with_bom_accepted(self):
+        validate_pem_or_der_header(b"\xef\xbb\xbf-----BEGIN CERTIFICATE-----\n")
+
+    def test_der_2byte_length_accepted(self):
+        validate_pem_or_der_header(b"\x30\x82\x03\x10asn1-payload-bytes")
+
+    def test_der_3byte_length_accepted(self):
+        validate_pem_or_der_header(b"\x30\x83\x00\x10\x00asn1-payload-bytes")
+
+    def test_random_text_without_begin_rejected(self):
+        with pytest.raises(InspectionError):
+            validate_pem_or_der_header(b"some random text without PEM armor")
+
+    def test_random_binary_rejected(self):
+        with pytest.raises(InspectionError):
+            validate_pem_or_der_header(b"\x89PNG\r\n\x1a\nthis is a PNG")
+
+    def test_empty_rejected(self):
+        with pytest.raises(InspectionError):
+            validate_pem_or_der_header(b"")
+
+    def test_pem_marker_in_middle_of_text_rejected(self):
+        # Text containing the PEM marker later in the body, without being
+        # anchored at the start, must NOT pass. This prevents accidental
+        # / hostile uploads where unrelated prose precedes the marker.
+        header = b"# Notes\nSee certs below:\n-----BEGIN CERTIFICATE-----\n"
+        with pytest.raises(InspectionError):
+            validate_pem_or_der_header(header)
+
+    def test_pem_with_leading_whitespace_accepted(self):
+        # Leading whitespace (newlines, spaces) before the armor is accepted.
+        validate_pem_or_der_header(b"\n\n  -----BEGIN CERTIFICATE-----\nMIIB...\n")
+
+    def test_text_without_pem_armor_rejected(self):
+        # Plain text without armor and without DER prefix must be rejected.
+        with pytest.raises(InspectionError):
+            validate_pem_or_der_header(b"-----CERT START-----\nMIIB...\n")  # wrong armor format


### PR DESCRIPTION
## Summary

- **What changed:** Server-side header (and, for text uploads, full-body) content inspection at upload finalization across all three S3 upload paths — CTF challenge attachments, agent installers, experiment scripts. Closes the validation gap where finalization previously trusted only client-side checks.
- **Why:** Issue #696 — close the magic-byte validation gap. The platform allowed clients to upload arbitrary content under the allowlisted extensions; only client-side JS / Django form checks were in place, so an authenticated user could PUT mismatched bytes to a presigned URL and finalize the upload as a valid agent / script / attachment.

Closes #696.

## How

- **CTF challenge attachments** (`ctf.services.attachment.add_challenge_file`): inline pre-PutObject magic-byte check; TEXT-category extensions additionally stream-validated as UTF-8 inside the SHA256 chunk loop so a valid text prefix followed by binary content cannot bypass the bounded header check.
- **Agent installers** (`cms.services.complete_upload`, presigned direct-to-S3 flow): bounded range-GET via the new `ObjectStorage.read_object_header` method on the cloud seam, validated against the format derived from the signed filename, before tag/audit/`create_agent`. Mismatch deletes the rejected object.
- **Experiment scripts** (`cms.experiments.services.complete_script_upload`, presigned): full-body scan (`SCRIPT_MAX_FILE_SIZE_BYTES`, 1 MB cap) with strict UTF-8 (`final=True`) and no binary signature anywhere in the stream. Size match against the signed token now enforced (matches agent invariant).

Primitives live in the new `shared.uploads.inspection` module:

- `FileFormat` uses `signatures: tuple[MagicSignature(offset, pattern)]` so composite (RIFF/WAVE) and offset (POSIX tar `ustar`@257) checks are first-class.
- `_TEXT_INCOMPATIBLE_SIGNATURES` is a curated subset of the full binary registry; excludes short ASCII-printable prefixes (`MZ`, `BM`, `BZh`, `ID3`, `RIFF`) so legitimate scripts that happen to start with those bytes aren't false-rejected.
- `validate_text_header` uses `codecs.IncrementalDecoder` with `final=False` for bounded prefixes and `final=True` for complete bodies, so multibyte UTF-8 split across the byte boundary doesn't false-reject.
- `validate_pem_or_der_header` accepts either anchored PEM armor or DER ASN.1 SEQUENCE for `.crt`/`.key`.
- `TextStreamValidator` provides chunk-by-chunk UTF-8 + binary-magic checks for streaming inputs.

CTF rules (`ctf.inspection._RULES`) are verified at import time against `ctf.s3.ALLOWED_EXTENSIONS`; drift raises `RuntimeError` before any upload reaches the server.

`UPLOAD_INSPECTION_MAX_HEADER_BYTES` clamps to a 512-byte floor at settings load so a misconfigured env can't break offset signatures or trip the adapters' positive-`max_bytes` invariant. AWS adapter closes `StreamingBody` in `try/finally`.

## ADR Impact

- [x] No ADR impact
- [ ] Existing ADRs updated
- [ ] New ADR added
- [ ] Temporary exception added to \`docs/adr/exceptions.yaml\`

Architecture preflight at \`docs/architecture/server-side-upload-inspection-preflight-696.md\` is the binding design record per the existing pattern (matches the precedent set by \`vm-guest-credential-preflight-762.md\` and the other \`*-preflight-*.md\` documents). No ADR amendments.

## Guardrail Changes

- [x] No guardrail files changed
- [ ] Guardrail files changed and matching docs were updated

No \`.github/workflows/**\`, \`.pre-commit-config.yaml\`, \`.importlinter\`, \`.tflint.hcl\`, \`.kube-linter.yaml\`, or other guardrail files touched.

## Verification

- [x] \`python3 scripts/adr_guard/adr_guard.py --all --level ci\` — pass.
- [x] \`uv run ruff check .\` + \`uv run ruff format --check .\` — pass.
- [x] \`uv run lint-imports --config ../../.importlinter\` — pass; \`shared.uploads.inspection\` cleanly imported by \`cms\` and \`ctf\` per the existing cross-layer contract.
- [x] \`mypy (shifter_platform)\` — pass.
- [x] \`uv run pytest\` — **3053 passed**.
- [x] Pre-commit (full suite) — pass.

## Traceability

- Implements #696 ← \`shifter/shifter_platform/shared/uploads/inspection.py\`, \`shifter/shifter_platform/ctf/inspection.py\`, \`shifter/shifter_platform/cms/services.py\`, \`shifter/shifter_platform/cms/experiments/services.py\`, \`shifter/shifter_platform/ctf/services/attachment.py\`, \`shifter/shifter_platform/shared/cloud/{types,aws/storage,gcp/storage}.py\`, \`shifter/shifter_platform/cms/assets/{s3,validation}.py\`, \`shifter/shifter_platform/cms/experiments/s3.py\`, \`shifter/shifter_platform/config/settings.py\`.
- Tests #696 ← \`shifter/shifter_platform/tests/shared/uploads/test_inspection.py\`, \`shifter/shifter_platform/tests/shared/cloud/test_aws_storage.py\`, \`shifter/shifter_platform/tests/shared/cloud/test_gcp_storage.py\`, \`shifter/shifter_platform/tests/ctf/test_inspection.py\`, \`shifter/shifter_platform/tests/ctf/test_attachments.py\`, \`shifter/shifter_platform/tests/cms/test_services_upload.py\`, \`shifter/shifter_platform/tests/cms/experiments/test_script_inspection.py\`.

## Changelog

\`changelog.d/696.security.md\` (security type).

## Review history

Pre-push codex review ran three cycles before push; all findings (8 total, mixed core + security) were fixed with category-level structural changes:

- Cycle 1: prefix-only magic matching → `MagicSignature(offset, pattern)` primitive; `.crt`/`.key` DER-encoded rejection → new `PEM_OR_DER` category.
- Cycle 2: strict UTF-8 of bounded prefix → `IncrementalDecoder(final=False)`; PEM marker accepted anywhere → anchored regex; settings not validated → 512-byte floor clamp.
- Cycle 3: script size mismatch not enforced → exact-size check added; short magic prefixes false-rejecting text → curated `_TEXT_INCOMPATIBLE_SIGNATURES` subset; CTF rules vs allowlist drift → import-time parity assertion; S3 `StreamingBody` not closed → `try/finally`; text-inspection bypass via valid-prefix-binary-tail → full-body scan for scripts (1 MB) + streaming UTF-8 for CTF TEXT.

Decision records on the issue thread: [cycle 1](https://github.com/Brad-Edwards/shifter/issues/696#issuecomment-4434911522), [cycle 2](https://github.com/Brad-Edwards/shifter/issues/696#issuecomment-4434990606), [cycle 3](https://github.com/Brad-Edwards/shifter/issues/696#issuecomment-4435106283). User authorized proceeding to push without a cycle-4 verification cycle.