### PR TITLE
fix: scope platform plan trigger to terraform files

### DIFF
--- a/.github/workflows/_shifter-platform.yml
+++ b/.github/workflows/_shifter-platform.yml
@@ -42,7 +42,7 @@ jobs:
         working-directory: platform/terraform
       - run: terraform init -backend-config=${{ inputs.environment }}.s3.tfbackend
       - run: terraform validate
-      - run: terraform plan -no-color -out=tfplan && terraform show -no-color tfplan > plan.txt
+      - run: terraform plan -no-color -lock-timeout=5m -out=tfplan && terraform show -no-color tfplan > plan.txt
       - name: Comment PR
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
@@ -141,7 +141,7 @@ jobs:
         run: |
           # Check if Service Discovery service needs replacement
           echo "Running terraform plan to check for Service Discovery changes..."
-          terraform plan -detailed-exitcode -out=tfplan 2>&1 || PLAN_EXIT=$?
+          terraform plan -detailed-exitcode -lock-timeout=5m -out=tfplan 2>&1 || PLAN_EXIT=$?
 
           echo "Plan exit code: ${PLAN_EXIT:-0}"
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,7 @@ jobs:
       range: ${{ steps.filter.outputs.range }}
       shifter_engine: ${{ steps.filter.outputs.shifter_engine }}
       shifter_platform: ${{ steps.filter.outputs.shifter_platform }}
+      shifter_app: ${{ steps.filter.outputs.shifter_app }}
       mcp: ${{ steps.filter.outputs.mcp }}
       gcp: ${{ steps.filter.outputs.gcp }}
       aws_environment: ${{ steps.env.outputs.aws_environment }}
@@ -78,8 +79,9 @@ jobs:
               - 'platform/terraform/modules/portal/**'
               - 'platform/terraform/modules/guacamole/**'
               - 'platform/terraform/environments/*/portal/**'
-              - 'shifter/**'
               - '.github/workflows/_shifter-platform.yml'
+            shifter_app:
+              - 'shifter/**'
             mcp:
               - 'mcp/**'
               - '.github/workflows/_quality.yml'
@@ -216,6 +218,7 @@ jobs:
        needs.changes.outputs.range == 'true' ||
        needs.changes.outputs.shifter_engine == 'true' ||
        needs.changes.outputs.shifter_platform == 'true' ||
+       needs.changes.outputs.shifter_app == 'true' ||
        needs.changes.outputs.mcp == 'true' ||
        needs.changes.outputs.gcp == 'true' ||
        github.event_name == 'workflow_dispatch')

--- a/changelog.d/1176.fixed.md
+++ b/changelog.d/1176.fixed.md
@@ -1,0 +1,1 @@
+AWS platform pull-request planning now ignores Python-only application changes while still running Quality, and platform Terraform plans wait briefly for state locks instead of failing immediately.

--- a/docs/adr/index.yaml
+++ b/docs/adr/index.yaml
@@ -55,6 +55,11 @@
         "id": "ADR-003-R1",
         "description": "ADR conformance must run in CI even when tests are skipped.",
         "checks": ["adr-registry", "layer-imports", "cross-layer-model-imports"]
+      },
+      {
+        "id": "ADR-003-R2",
+        "description": "AWS platform Terraform plan routing must stay scoped to Terraform-consumed files, while platform application changes still trigger Quality through a separate app-source filter. AWS platform Terraform plan commands must wait for the state lock before failing.",
+        "checks": ["deploy-workflow-plan-scope"]
       }
     ],
     "exceptions": [],

--- a/scripts/adr_guard/adr_guard.py
+++ b/scripts/adr_guard/adr_guard.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import shlex
 import subprocess
 import sys
 import tomllib
@@ -2037,6 +2038,198 @@ def check_no_tracked_generated_artifacts(
     return violations
 
 
+_DEPLOY_WORKFLOW_PATH = ".github/workflows/deploy.yml"
+_PLATFORM_WORKFLOW_PATH = ".github/workflows/_shifter-platform.yml"
+_ADR_GUARD_SCRIPT_PATH = "scripts/adr_guard/adr_guard.py"
+_PLAN_SCOPE_CHECK = "deploy-workflow-plan-scope"
+_PLAN_SCOPE_RULE = "ADR-003-R2"
+_SHIFTER_APP_OUTPUT = "shifter_app: ${{ steps.filter.outputs.shifter_app }}"
+_SHIFTER_APP_QUALITY_CONDITION = "needs.changes.outputs.shifter_app == 'true'"
+
+
+def _deploy_plan_scope_relevant(files: list[str] | None) -> bool:
+    if files is None:
+        return True
+    relevant = {_DEPLOY_WORKFLOW_PATH, _PLATFORM_WORKFLOW_PATH, _ADR_GUARD_SCRIPT_PATH}
+    return any(path in relevant for path in files)
+
+
+def _paths_filter_block(deploy_text: str, filter_name: str) -> list[str]:
+    block: list[str] = []
+    in_block = False
+    block_indent: int | None = None
+    for raw_line in deploy_text.splitlines():
+        stripped = raw_line.strip()
+        indent = len(raw_line) - len(raw_line.lstrip(" "))
+        if stripped == f"{filter_name}:":
+            in_block = True
+            block_indent = indent
+            continue
+        if not in_block:
+            continue
+        if stripped and block_indent is not None and indent <= block_indent:
+            break
+        block.append(stripped)
+    return block
+
+
+def _workflow_job_block(workflow_text: str, job_name: str) -> list[str]:
+    block: list[str] = []
+    in_block = False
+    for raw_line in workflow_text.splitlines():
+        stripped = raw_line.strip()
+        indent = len(raw_line) - len(raw_line.lstrip(" "))
+        if indent == 2 and stripped == f"{job_name}:":
+            in_block = True
+            continue
+        if in_block and stripped and indent == 2 and not stripped.startswith("- "):
+            break
+        if in_block:
+            block.append(stripped)
+    return block
+
+
+def _block_contains_glob(block: list[str], glob: str) -> bool:
+    return glob in _filter_globs(block)
+
+
+def _filter_globs(block: list[str]) -> list[str]:
+    globs: list[str] = []
+    for line in block:
+        if not line.startswith("- "):
+            continue
+        glob = line[2:].strip()
+        if len(glob) >= 2 and glob[0] == glob[-1] and glob[0] in {"'", '"'}:
+            glob = glob[1:-1]
+        if glob:
+            globs.append(glob)
+    return globs
+
+
+def _active_line_contains(block: list[str], needle: str) -> bool:
+    return any(needle in line for line in block if not line.lstrip().startswith("#"))
+
+
+def _terraform_plan_has_lock_timeout(stripped_line: str) -> bool:
+    if stripped_line.startswith("- run:"):
+        command = stripped_line.split(":", 1)[1].strip()
+    else:
+        command = stripped_line
+    try:
+        tokens = shlex.split(command, comments=True)
+    except ValueError:
+        tokens = command.split()
+    return "-lock-timeout=5m" in tokens
+
+
+def _plan_scope_violation(path: str, message: str) -> Violation:
+    return Violation(_PLAN_SCOPE_CHECK, _PLAN_SCOPE_RULE, path, message)
+
+
+def _platform_app_source_globs(deploy_text: str) -> list[str]:
+    platform_block = _paths_filter_block(deploy_text, "shifter_platform")
+    return [
+        glob
+        for glob in _filter_globs(platform_block)
+        if glob == "shifter/**" or glob.startswith("shifter/")
+    ]
+
+
+def _check_deploy_workflow_plan_routing(deploy_text: str) -> list[Violation]:
+    violations: list[Violation] = []
+    app_source_globs = _platform_app_source_globs(deploy_text)
+    if app_source_globs:
+        violations.append(
+            _plan_scope_violation(
+                _DEPLOY_WORKFLOW_PATH,
+                "`shifter_platform` must not include app-source globs under `shifter/`; "
+                f"found {', '.join(app_source_globs)}",
+            )
+        )
+
+    app_block = _paths_filter_block(deploy_text, "shifter_app")
+    changes_block = _workflow_job_block(deploy_text, "changes")
+    quality_block = _workflow_job_block(deploy_text, "quality")
+    if not app_block or not _active_line_contains(changes_block, _SHIFTER_APP_OUTPUT):
+        violations.append(
+            _plan_scope_violation(
+                _DEPLOY_WORKFLOW_PATH,
+                "Platform app source changes must retain a `shifter_app` filter/output "
+                "wired into Quality after the Terraform-only `shifter_platform` split; "
+                "missing the filter or changes-job output",
+            )
+        )
+    elif not _block_contains_glob(app_block, "shifter/**"):
+        violations.append(
+            _plan_scope_violation(
+                _DEPLOY_WORKFLOW_PATH,
+                "`shifter_app` must include `shifter/**` so Python application changes "
+                "continue to trigger Quality after the platform plan scope split",
+            )
+        )
+    elif not _active_line_contains(quality_block, _SHIFTER_APP_QUALITY_CONDITION):
+        violations.append(
+            _plan_scope_violation(
+                _DEPLOY_WORKFLOW_PATH,
+                "The Quality job must include `needs.changes.outputs.shifter_app == 'true'` "
+                "so Python application changes still run Quality",
+            )
+        )
+    return violations
+
+
+def _check_platform_plan_lock_timeout(platform_text: str) -> list[Violation]:
+    violations: list[Violation] = []
+    for lineno, line in enumerate(platform_text.splitlines(), start=1):
+        stripped = line.strip()
+        if "terraform plan" not in stripped:
+            continue
+        if stripped.startswith(("#", "echo ")):
+            continue
+        if _terraform_plan_has_lock_timeout(stripped):
+            continue
+        violations.append(
+            _plan_scope_violation(
+                f"{_PLATFORM_WORKFLOW_PATH}:{lineno}",
+                "AWS platform Terraform plan commands must include `-lock-timeout=5m` "
+                "so legitimate concurrent plans wait for the state lock instead of failing",
+            )
+        )
+    return violations
+
+
+def check_deploy_workflow_plan_scope(repo_root: Path, files: list[str] | None) -> list[Violation]:
+    """Keep AWS platform PR planning scoped to Terraform inputs."""
+    if not _deploy_plan_scope_relevant(files):
+        return []
+
+    violations: list[Violation] = []
+    deploy_path = repo_root / _DEPLOY_WORKFLOW_PATH
+    platform_path = repo_root / _PLATFORM_WORKFLOW_PATH
+
+    if not deploy_path.exists():
+        violations.append(
+            _plan_scope_violation(
+                _DEPLOY_WORKFLOW_PATH,
+                "Required workflow is missing; ADR-003-R2 cannot verify platform plan routing",
+            )
+        )
+    else:
+        violations.extend(_check_deploy_workflow_plan_routing(deploy_path.read_text(encoding="utf-8")))
+
+    if not platform_path.exists():
+        violations.append(
+            _plan_scope_violation(
+                _PLATFORM_WORKFLOW_PATH,
+                "Required workflow is missing; ADR-003-R2 cannot verify platform Terraform plan commands",
+            )
+        )
+    else:
+        violations.extend(_check_platform_plan_lock_timeout(platform_path.read_text(encoding="utf-8")))
+
+    return violations
+
+
 # Canonical Python packages whose pyproject.toml must enforce the per-function
 # complexity gate. Keyed off `.pre-commit-config.yaml` ruff hooks. Adding a new
 # Python package with a ruff-pre-commit hook means adding it here too.
@@ -2517,6 +2710,7 @@ CHECKS = {
     "no-tracked-generated-artifacts": check_no_tracked_generated_artifacts,
     "mcp-ops-tls-strict": check_mcp_ops_tls_strict,
     "python-complexity-gate": check_python_complexity_gate,
+    "deploy-workflow-plan-scope": check_deploy_workflow_plan_scope,
 }
 CHECK_LEVELS = {
     "fast": [
@@ -2530,6 +2724,7 @@ CHECK_LEVELS = {
         "no-tracked-generated-artifacts",
         "mcp-ops-tls-strict",
         "python-complexity-gate",
+        "deploy-workflow-plan-scope",
     ],
     "ci": [
         "adr-registry",
@@ -2543,6 +2738,7 @@ CHECK_LEVELS = {
         "no-tracked-generated-artifacts",
         "mcp-ops-tls-strict",
         "python-complexity-gate",
+        "deploy-workflow-plan-scope",
     ],
     "all": list(CHECKS),
 }

--- a/scripts/adr_guard/tests/test_adr_guard.py
+++ b/scripts/adr_guard/tests/test_adr_guard.py
@@ -108,6 +108,203 @@ class AdrGuardTests(unittest.TestCase):
         self.assertEqual(filtered[0].rule_id, "ADR-002-R1")
 
 
+class DeployWorkflowPlanScopeTests(unittest.TestCase):
+    """Tests for the AWS platform plan trigger and lock-timeout guardrail."""
+
+    def _write_workflows(self, repo_root: Path, deploy: str, platform: str) -> None:
+        workflow_dir = repo_root / ".github" / "workflows"
+        workflow_dir.mkdir(parents=True)
+        (workflow_dir / "deploy.yml").write_text(deploy, encoding="utf-8")
+        (workflow_dir / "_shifter-platform.yml").write_text(platform, encoding="utf-8")
+
+    def _deploy_text(
+        self,
+        *,
+        platform_globs: list[str] | None = None,
+        app_globs: list[str] | None = None,
+        quality_condition: str = "needs.changes.outputs.shifter_app == 'true'",
+    ) -> str:
+        platform_globs = platform_globs or ["platform/terraform/modules/portal/**"]
+        app_globs = app_globs or ["shifter/**"]
+        platform_lines = "".join(f"              - '{glob}'\n" for glob in platform_globs)
+        app_lines = "".join(f"              - '{glob}'\n" for glob in app_globs)
+        return (
+            "jobs:\n"
+            "  changes:\n"
+            "    outputs:\n"
+            "      shifter_app: ${{ steps.filter.outputs.shifter_app }}\n"
+            "    steps:\n"
+            "      - id: filter\n"
+            "        with:\n"
+            "          filters: |\n"
+            "            shifter_platform:\n"
+            f"{platform_lines}"
+            "            shifter_app:\n"
+            f"{app_lines}"
+            "  quality:\n"
+            "    if: |\n"
+            f"      {quality_condition}\n"
+        )
+
+    def _platform_text(self, plan_args: str = "-no-color -lock-timeout=5m -out=tfplan") -> str:
+        return (
+            "jobs:\n"
+            "  plan:\n"
+            "    steps:\n"
+            f"      - run: terraform plan {plan_args}\n"
+        )
+
+    def test_flags_python_glob_in_platform_plan_scope(self) -> None:
+        cases = ("shifter/**", "shifter/shifter_platform/**", "shifter/**/*.py")
+        for app_glob in cases:
+            with self.subTest(app_glob=app_glob), tempfile.TemporaryDirectory() as tmp:
+                repo_root = Path(tmp)
+                self._write_workflows(
+                    repo_root,
+                    self._deploy_text(platform_globs=["platform/terraform/modules/portal/**", app_glob]),
+                    self._platform_text(),
+                )
+
+                violations = ADR_GUARD.check_deploy_workflow_plan_scope(repo_root, None)
+
+                self.assertEqual(len(violations), 1)
+                self.assertEqual(violations[0].rule_id, "ADR-003-R2")
+                self.assertIn(app_glob, violations[0].message)
+
+    def test_flags_platform_plan_without_lock_timeout(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            self._write_workflows(
+                repo_root,
+                self._deploy_text(),
+                self._platform_text("-no-color -out=tfplan"),
+            )
+
+            violations = ADR_GUARD.check_deploy_workflow_plan_scope(repo_root, None)
+
+            self.assertEqual(len(violations), 1)
+            self.assertEqual(violations[0].rule_id, "ADR-003-R2")
+            self.assertIn("-lock-timeout=5m", violations[0].message)
+
+    def test_targeted_mode_runs_for_relevant_workflow_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            self._write_workflows(
+                repo_root,
+                self._deploy_text(platform_globs=["shifter/**"]),
+                self._platform_text(),
+            )
+
+            violations = ADR_GUARD.check_deploy_workflow_plan_scope(
+                repo_root, [".github/workflows/deploy.yml"]
+            )
+
+            self.assertEqual(len(violations), 1)
+
+    def test_flags_missing_app_quality_scope_after_platform_scope_split(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            self._write_workflows(
+                repo_root,
+                "jobs:\n"
+                "  changes:\n"
+                "    steps:\n"
+                "      - id: filter\n"
+                "        with:\n"
+                "          filters: |\n"
+                "            shifter_platform:\n"
+                "              - 'platform/terraform/modules/portal/**'\n",
+                self._platform_text(),
+            )
+
+            violations = ADR_GUARD.check_deploy_workflow_plan_scope(repo_root, None)
+
+            self.assertEqual(len(violations), 1)
+            self.assertIn("shifter_app", violations[0].message)
+
+    def test_flags_shifter_app_filter_without_app_source_glob(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            self._write_workflows(
+                repo_root,
+                self._deploy_text(app_globs=["docs/**"]),
+                self._platform_text(),
+            )
+
+            violations = ADR_GUARD.check_deploy_workflow_plan_scope(repo_root, None)
+
+            self.assertEqual(len(violations), 1)
+            self.assertIn("shifter/**", violations[0].message)
+
+    def test_flags_shifter_app_condition_outside_quality_job(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            deploy = self._deploy_text(quality_condition="needs.changes.outputs.mcp == 'true'")
+            deploy += "  gcp-dev:\n    if: needs.changes.outputs.shifter_app == 'true'\n"
+            self._write_workflows(repo_root, deploy, self._platform_text())
+
+            violations = ADR_GUARD.check_deploy_workflow_plan_scope(repo_root, None)
+
+            self.assertEqual(len(violations), 1)
+            self.assertIn("Quality", violations[0].message)
+
+    def test_flags_missing_required_workflow_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            (repo_root / ".github" / "workflows").mkdir(parents=True)
+
+            violations = ADR_GUARD.check_deploy_workflow_plan_scope(repo_root, None)
+
+            flagged = {violation.path for violation in violations}
+            self.assertIn(".github/workflows/deploy.yml", flagged)
+            self.assertIn(".github/workflows/_shifter-platform.yml", flagged)
+
+    def test_ignores_commented_shifter_app_output_and_quality_condition(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            deploy = (
+                "jobs:\n"
+                "  changes:\n"
+                "    outputs:\n"
+                "      # shifter_app: ${{ steps.filter.outputs.shifter_app }}\n"
+                "    steps:\n"
+                "      - id: filter\n"
+                "        with:\n"
+                "          filters: |\n"
+                "            shifter_platform:\n"
+                "              - 'platform/terraform/modules/portal/**'\n"
+                "            shifter_app:\n"
+                "              - 'shifter/**'\n"
+                "  quality:\n"
+                "    if: |\n"
+                "      # needs.changes.outputs.shifter_app == 'true'\n"
+            )
+            self._write_workflows(repo_root, deploy, self._platform_text())
+
+            violations = ADR_GUARD.check_deploy_workflow_plan_scope(repo_root, None)
+
+            self.assertEqual(len(violations), 1)
+            self.assertIn("output", violations[0].message)
+
+    def test_ignores_commented_lock_timeout(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            self._write_workflows(
+                repo_root,
+                self._deploy_text(),
+                self._platform_text("-no-color -out=tfplan # -lock-timeout=5m"),
+            )
+
+            violations = ADR_GUARD.check_deploy_workflow_plan_scope(repo_root, None)
+
+            self.assertEqual(len(violations), 1)
+            self.assertIn("-lock-timeout=5m", violations[0].message)
+
+    def test_clean_real_repo_passes(self) -> None:
+        violations = ADR_GUARD.check_deploy_workflow_plan_scope(ADR_GUARD.REPO_ROOT, None)
+        self.assertEqual(violations, [], msg=f"Unexpected deploy workflow violations: {violations}")
+
+
 class CloudFactorySeamTests(unittest.TestCase):
     def _make_cloud_tree(self, tmp: str, aws_files: list[str], gcp_files: list[str]) -> Path:
         """Create a minimal cloud adapter tree under a fake repo root."""

--- a/shifter/shifter_platform/documentation/docs/technical/dev/adr-enforcement.md
+++ b/shifter/shifter_platform/documentation/docs/technical/dev/adr-enforcement.md
@@ -96,6 +96,16 @@ The first slice intentionally stays small:
   This includes the GCP deploy workflow's Terraform state-backend hardening
   (`_gcp-dev.yml`) so retention and IAM policy bootstrap logic remains valid.
 
+- `deploy-workflow-plan-scope`
+  Enforces ADR-003-R2 for the AWS platform workflow. The `shifter_platform`
+  change filter in `.github/workflows/deploy.yml` must stay scoped to
+  Terraform-consumed platform files, with application source changes routed
+  through the separate `shifter_app` filter so Quality still runs without
+  launching a platform Terraform plan. The check also requires every
+  `terraform plan` command in `_shifter-platform.yml` to include
+  `-lock-timeout=5m`, so legitimate concurrent platform plans wait on the
+  backend state lock instead of failing immediately.
+
 - `TFLint`
   Adds Terraform linting on top of `terraform fmt` and `terraform validate`.
   The initial profile is intentionally narrow: it leaves existing repo-wide


### PR DESCRIPTION
## Summary

Scope AWS platform pull-request planning to Terraform-consumed platform files while preserving Quality coverage for Python application changes, and make platform Terraform plans wait briefly for state locks.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #1176

## ADR Impact

- ADR-003-R2

## Changes

- Split the `shifter_app` paths-filter output from the AWS `shifter_platform` Terraform-plan filter in `.github/workflows/deploy.yml`.
- Added `-lock-timeout=5m` to platform Terraform plan commands in `.github/workflows/_shifter-platform.yml`.
- Added `deploy-workflow-plan-scope` ADR guard enforcement and tests covering app-source glob bypasses, missing workflow files, comment-only markers, and lock-timeout semantics.
- Updated ADR registry/developer docs and added the changelog fragment for #1176.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Validated after rebasing onto current origin/dev: `python3 -m unittest scripts.adr_guard.tests.test_adr_guard.DeployWorkflowPlanScopeTests`, `actionlint`, targeted ADR fast gate, and `python3 scripts/adr_guard/adr_guard.py --all --level ci`. Before push, also ran `pre-commit run --all-files` successfully after the final local fix.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: issue #1176 ← .github/workflows/deploy.yml, .github/workflows/_shifter-platform.yml, scripts/adr_guard/adr_guard.py
- TESTS: issue #1176 ← scripts/adr_guard/tests/test_adr_guard.py, actionlint, python3 scripts/adr_guard/adr_guard.py --all --level ci, pre-commit run --all-files

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/1176.fixed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
