### PR TITLE
security: mcp/ngfw doc cleanup + secret-env guardrail (1191, 1193, 1195)

### DIFF
--- a/changelog.d/1191.changed.md
+++ b/changelog.d/1191.changed.md
@@ -1,0 +1,10 @@
+`mcp/ngfw/SECURITY.md` rewritten to describe the current `list_ngfws`-only
+tool surface and to mark the previously-registered PAN-OS administration
+tools (`run_command`, `show_system_info`, `show_routes`) as explicitly
+historical. `mcp/ngfw/tool-surface.test.js` is now the bidirectional
+guard: it parses `server.tool(...)` registrations out of `index.js` and
+asserts the set equals exactly `{"list_ngfws"}`; it asserts the security
+doc references the test by name and lists every live tool; and it
+asserts removed tools cannot be described before the
+`## Removed administration tools` section. A future surface change must
+update both the test's expected set and the security doc in the same PR.

--- a/changelog.d/1195.security.md
+++ b/changelog.d/1195.security.md
@@ -1,0 +1,18 @@
+New `no-populated-secret-env-files` `adr_guard` check (ADR-004-R9)
+prevents reintroducing populated values into tracked `*-secrets.env`
+files under `platform/k8s/`. Allowed: comments, blank lines, empty
+assignments (`KEY=`), and a **fixed** synthetic-placeholder allowlist
+(`REPLACE_AT_DEPLOY`, `CHANGE_ME`, `PLACEHOLDER`, `EXAMPLE`, plus the
+matching bracketed forms `<replace-at-deploy>`, `<change-me>`,
+`<placeholder>`, `<example>`). The bracket allowlist is explicit
+rather than a `<...>` pattern so a real credential cannot hide as
+`<attacker-known-password>`. Parser splits on the first `=` so
+non-identifier key shapes (`db.password=...`, `api-token=...`,
+`export DB_PASSWORD=...`) still flow through the value check; inline
+`# ...` is not honored as a comment; non-`=` lines are flagged as
+malformed. Containment uses `git ls-files`, so gitignored local-dev
+files are intentionally not scanned. Violation messages name the path
+and variable name only, never the rejected value. Registered in
+`fast` and `ci` levels; backstops gitleaks for low-entropy credentials
+it ignores. The plaintext-removal content fix already shipped in
+#1207.

--- a/docs/adr/index.yaml
+++ b/docs/adr/index.yaml
@@ -110,6 +110,11 @@
         "id": "ADR-004-R8",
         "description": "Generated and pre-staging sensitive artifacts must not be tracked in source: Terraform plan outputs (tfplan, tfplan.binary, plan.out, *.tfplan) under platform/terraform/environments/ and platform/terraform/gcp/environments/, and license/authcode bootstrap material (authcodes, *.authcodes) under temp/bootstrap/. The blocked path/name set is centralized in scripts/adr_guard/adr_guard.py; the guardrail fails closed and emits repo-relative paths only, never file contents.",
         "checks": ["no-tracked-generated-artifacts"]
+      },
+      {
+        "id": "ADR-004-R9",
+        "description": "Tracked *-secrets.env files under platform/k8s/ must contain only comments, blank lines, empty assignments (KEY=), or a small fixed synthetic-placeholder allowlist (REPLACE_AT_DEPLOY, CHANGE_ME, PLACEHOLDER, EXAMPLE, plus the matching bracketed forms <replace-at-deploy>, <change-me>, <placeholder>, <example>). The bracketed forms are an explicit fixed set, NOT a <...> pattern, to prevent hiding a real credential as <attacker-known-password>. Real runtime secrets must flow in at deploy time from GCP Secret Manager, a gitignored local env file, or a deploy-time Kubernetes Secret. Containment uses git ls-files so gitignored local-dev files (e.g. *.local.env) are intentionally not scanned. The parser splits on the first '=' so non-identifier key shapes (db.password=..., api-token=..., export DB_PASSWORD=...) still flow through the value check. Inline '# comment' is NOT honored (Kustomize env_file format treats '#' as a comment only at the start of a line). Non-comment lines without '=' are flagged as malformed. The blocked condition is centralized in scripts/adr_guard/adr_guard.py; violation messages name the repo-relative path and the variable name only, never the rejected value. Backstops gitleaks for low-entropy committed credentials it ignores and prevents reintroduction of the failure mode resolved by #1207 / #1195.",
+        "checks": ["no-populated-secret-env-files"]
       }
     ],
     "exceptions": [],

--- a/docs/architecture/gcp-runtime-secret-env-preflight-1195.md
+++ b/docs/architecture/gcp-runtime-secret-env-preflight-1195.md
@@ -1,0 +1,160 @@
+# GCP Runtime Secret Env Preflight
+
+Issue: GitHub #1195, "Security: remove tracked plaintext GCP runtime secret
+env files".
+
+This note records the architecture boundary for removing the committed
+`platform-runtime-secrets.env` values from the GCP Kustomize overlay. It is not
+an implementation plan.
+
+## Decision Boundary
+
+`platform-runtime-secrets.env` is deployment secret material, not source
+configuration. The repository may keep a structural example only if every
+assignment is synthetic and fail-loud; real values must be supplied through the
+existing deployment secret paths at render/apply time.
+
+The implementation must not solve this by moving plaintext into another
+committed env file, Terraform variable file, workflow literal, generated
+ConfigMap, or command line. The desired end state is a source tree that can run
+static Kustomize validation without carrying usable runtime secret values, plus
+a deployment path that documents where real values come from.
+
+## Canonical Incumbents
+
+| Concern | Canonical incumbent | Guardrail for #1195 |
+| --- | --- | --- |
+| GCP runtime generation | `scripts/gcp/render_runtime_env.py`, `scripts/gcp/tests/test_render_runtime_env.py` | Generated runtime files carry non-secret configuration and secret references only. Do not add secret values to `platform-runtime.generated.env`. |
+| Bootstrap deployment | `.github/workflows/_gcp-dev.yml`, `scripts/bootstrap/deploy.py`, `platform/k8s/gcp/README.md` | CI/bootstrap should hydrate or create Kubernetes Secrets from GitHub Secrets, Terraform outputs, or GCP Secret Manager payloads before `kubectl apply -k`; keep the contract documented. |
+| Runtime secret store | `platform/terraform/gcp/modules/platform-core/*`, `runtime_secret_ids`, `shifter/shifter_platform/entrypoint.sh`, `shifter/shifter_platform/documentation/docs/technical/dev/secrets.md` | Prefer GCP Secret Manager bundle IDs and existing entrypoint hydration for app/database/cache secrets. Kubernetes Secrets are a runtime binding layer, not a source-of-truth vault. |
+| Kustomize overlay shape | `platform/k8s/gcp/overlays/gcp-dev/kustomization.yaml`, `patch-runtime-secretref.yaml` | If the overlay keeps `secretGenerator`, its input must be local/gitignored or synthetic-only. Preserve `envFrom.secretRef` shape for workloads unless the Helm/bootstrap path intentionally supersedes it. |
+| Secret scanning | `.gitleaks.toml`, `.pre-commit-config.yaml`, `scripts/adr_guard/adr_guard.py`, `docs/adr/index.yaml` | Add the repo-specific low-entropy guardrail to `adr_guard`; do not rely on entropy scanning alone for `*-secrets.env` files. Guardrail-file changes must update ADR docs. |
+| Kubernetes validation | ADR-004-R5, ADR-006, `.kube-linter.yaml`, kubeconform, `_quality.yml` rendered-kustomize checks | Placeholder/example secret inputs must still let `kustomize build`, kube-linter, and kubeconform validate the rendered deployment shape. |
+| Deploy secret inventory | `docs/dev/deploy-secrets.md` | Document any new GitHub secret, local generated file, or Secret Manager bootstrap prerequisite there instead of scattering setup instructions. |
+
+## Cross-Cutting Layers
+
+Security layers the design must satisfy:
+
+- Auth surface: this issue should not alter Identity Platform, Django session
+  creation, bootstrap-operator elevation, or Mission Control authorization.
+  Any runtime secrets consumed by auth must still be sourced through the
+  existing GCP Secret Manager / entrypoint path.
+- Secret-handling surface: real values belong in GitHub Actions secrets for CI
+  inputs, GCP Secret Manager for runtime bundles, or a Kubernetes Secret created
+  at deploy time from those sources. Committed files may contain only
+  placeholders such as `REPLACE_AT_DEPLOY` or non-sensitive structural keys.
+- Env-binding shape: workloads currently consume `platform-runtime` plus
+  `platform-runtime-secrets` via `envFrom`. Preserve that shape unless the
+  implementation migrates the overlay to the chart/bootstrap runtime contract in
+  one reviewed change. ConfigMap-bound files remain non-secret; Secret-bound
+  files must not be committed with real assignments.
+- Config validators: `gitleaks` is necessary but insufficient because lab
+  defaults and short placeholders can be low entropy. Add a deterministic
+  `adr_guard` check that fails on tracked `*-secrets.env` files containing
+  populated assignments outside approved synthetic example paths. Tests should
+  cover comments, blank values, placeholders, and real-looking assignments.
+- OS/process exposure: deployment scripts must avoid passing secret values in
+  process argv, shell-expanded command strings, workflow logs, or generated
+  files that survive checkout. Prefer stdin, `--from-env-file` with a
+  gitignored local file, Secret Manager access, or Kubernetes Secret manifests
+  applied without echoing values.
+- Error envelopes and logging: validation failures should report file paths and
+  variable names only. Do not print rejected secret values in `adr_guard`,
+  workflow preflights, bootstrap errors, or Kustomize helper output.
+- Kubernetes runtime surface: `Secret` objects generated by Kustomize are
+  acceptable only as deployment-time artifacts. Do not treat a committed
+  Kustomize `secretGenerator` input as an acceptable secret store.
+
+Maintainability incumbents the implementation must build on:
+
+- `scripts/adr_guard/adr_guard.py` and its tests for repo-specific policy.
+- ADR-004 / ADR-002 in `docs/adr/index.yaml` for documenting guardrail changes.
+- Existing GCP Secret Manager bundles and `runtime_secret_ids` outputs.
+- Existing entrypoint hydration for app, DB, Guacamole, and Redis secret
+  payloads.
+- Existing GCP runtime renderer tests for negative assertions that generated env
+  files do not carry secret values.
+- Existing docs: `docs/dev/deploy-secrets.md`, `platform/k8s/gcp/README.md`,
+  and `shifter/shifter_platform/documentation/docs/technical/dev/secrets.md`.
+
+## Extensibility Seam
+
+Parameterize the guardrail around path patterns and allowed synthetic tokens,
+not around today’s single file. The next reasonable variation is another
+overlay or environment adding `*-secrets.env`; it should be covered without
+editing the checker. The deployment seam should be environment-owned
+(`gcp-dev`, future `gcp-prod`, local) and should accept a secret source choice
+such as generated local env file, Secret Manager bundle, or Kubernetes Secret
+name without changing workload manifests.
+
+## Whole-Repo Scope
+
+In scope for the future implementation:
+
+- `platform/k8s/gcp/overlays/gcp-dev/platform-runtime-secrets.env` and any
+  replacement example or gitignored local filename.
+- `platform/k8s/gcp/overlays/gcp-dev/kustomization.yaml` and
+  `patch-runtime-secretref.yaml` if the secret binding changes.
+- `.gitignore` if a generated local secret env file is introduced.
+- `scripts/adr_guard/adr_guard.py`, `scripts/adr_guard/tests/test_adr_guard.py`,
+  `docs/adr/index.yaml`, and ADR enforcement docs if adding the required
+  guardrail.
+- `.gitleaks.toml` only for entropy-scanner tuning; do not use broad allowlists
+  as the primary control.
+- `docs/dev/deploy-secrets.md`, `platform/k8s/gcp/README.md`, and developer
+  secrets docs for operator-facing bootstrap instructions.
+- `.github/workflows/_gcp-dev.yml` and `scripts/bootstrap/deploy.py` only if the
+  CI/bootstrap flow needs to create or hydrate the runtime Kubernetes Secret.
+
+## Gotchas And Anti-Patterns
+
+- Do not rename the file while keeping assignments in source.
+- Do not replace one committed secret env file with a committed Kubernetes
+  Secret manifest containing base64-encoded values. Base64 is not encryption.
+- Do not move values into `platform-runtime.env`,
+  `platform-runtime.generated.env`, Terraform `*.tfvars`, workflow YAML, or
+  README command examples.
+- Do not add a gitleaks allowlist that hides `platform/k8s/gcp/**` secrets.
+- Do not conflate secret values with secret references. `DB_SECRET_ID`,
+  `APP_SECRET_ID`, and similar provider resource IDs may be config; passwords,
+  tokens, JSON-auth keys, private keys, and Redis AUTH strings are values.
+- Do not weaken Kustomize, kube-linter, kubeconform, ADR guard, or workflow
+  checks to make a placeholder file pass.
+- Do not introduce a new secret manager abstraction for this issue. Existing
+  GCP Secret Manager, entrypoint, bootstrap, and Kubernetes Secret seams cover
+  the need.
+- Do not log generated env file contents or `kubectl create secret` literals in
+  workflow output.
+
+## Non-Goals
+
+- Do not redesign Identity Platform auth, Guacamole JSON auth, Redis AUTH/TLS,
+  per-instance guest credentials, or cloud adapter protocols.
+- Do not migrate the whole GCP deployment from Kustomize to Helm or vice versa
+  as part of this remediation.
+- Do not rotate production secrets or rewrite git history in this code change;
+  that is an operational incident-response task if real secrets were exposed.
+- Do not add user-managed secret UI, a generic vault service, or a new
+  exception hierarchy.
+- Do not broaden Workload Identity, Secret Manager IAM, network policy, or pod
+  security to compensate for secret bootstrap friction.
+
+## Validation
+
+At minimum, changes on this path must run:
+
+```bash
+python3 scripts/adr_guard/adr_guard.py --all --level ci
+```
+
+Then add the stack-native checks for touched surfaces:
+
+- `kube-linter lint --config .kube-linter.yaml platform/k8s/` and
+  `kubeconform -strict -summary -ignore-missing-schemas -kubernetes-version 1.31.0 platform/k8s/gcp/base/*.yaml`
+  when Kubernetes manifests or overlay inputs change.
+- `actionlint` when workflows change.
+- `python3 -m unittest scripts/adr_guard/tests/test_adr_guard.py` when ADR
+  guard logic changes.
+- Targeted GCP renderer/bootstrap tests if the deployment hydration path
+  changes.

--- a/docs/architecture/ngfw-security-doc-preflight-1191.md
+++ b/docs/architecture/ngfw-security-doc-preflight-1191.md
@@ -1,0 +1,105 @@
+# NGFW MCP Security Documentation Preflight (#1191)
+
+Status: pre-implementation guidance
+
+Date: 2026-05-13
+
+Tracking issue: <https://github.com/Brad-Edwards/shifter/issues/1191>
+
+## Scope Boundary
+
+This workstream updates the threat model documentation for the current
+`shifter-ngfw` MCP server. It is documentation and guardrail alignment, not a
+feature change. The GitHub issue title, body, and acceptance criteria are the
+shipping contract.
+
+Do not reintroduce removed NGFW administration capabilities to make old security
+text true. The current server exports only `list_ngfws`, which performs EC2
+instance discovery through the shared AWS CLI argv-array helpers.
+
+## Architecture Decisions
+
+- Treat `mcp/ngfw` as a least-privilege general MCP surface under ADR-014-R1:
+  non-secret, non-mutating observability only.
+- `mcp/ngfw/SECURITY.md` must describe the live exported tool surface from
+  `mcp/ngfw/index.js`, not historical helper capabilities left in `mcp/ngfw/lib.js`.
+- Command-execution internals for removed tools are not active threat-model
+  content. If retained at all, they must be explicitly labeled historical or
+  deleted from the active NGFW security boundary.
+- The doc guard belongs with the existing surface invariant:
+  `mcp/ngfw/tool-surface.test.js` is the canonical check that removed PAN-OS
+  execution tools and Secrets Manager access are absent.
+- Future NGFW tool additions must update the security doc and the surface test
+  in the same change. The durable seam is a declared expected tool list in the
+  test, derived from `server.tool(...)` registrations, rather than prose-only
+  review.
+
+## Incumbents To Reuse
+
+| Concern | Canonical incumbent | Guardrail for #1191 |
+| --- | --- | --- |
+| MCP registration | `mcp/ngfw/index.js` `server.tool(...)` calls | Document only the exported tools registered here. |
+| Tool input shape | `EnvSchema` in `mcp/ngfw/index.js` | Keep `env` as the Zod-validated `dev`/`prod` selector; do not add duplicate schemas in docs or tests. |
+| AWS process boundary | `mcp/shared/aws-helpers.js`, re-exported by `mcp/ngfw/lib.js` | Keep AWS calls on argv arrays through `awsJson`; no shell strings or local command execution surface. |
+| Credential selection | `PROFILES`, `PANW_SHIFTER_DEV_PROFILE`, `PANW_SHIFTER_PROD_PROFILE`, `getProfile` | Describe these as local AWS profile selection, not authorization or RBAC. |
+| Surface hardening | `mcp/ngfw/tool-surface.test.js`, ADR-014-R3 | Extend this test or equivalent enforcement so tool-surface changes require security-doc review. |
+| ADR enforcement | ADR-010, ADR-014, `scripts/adr_guard/adr_guard.py` | Preserve argv-array and least-privilege MCP surface rules. |
+| CI workflow | `.github/workflows/_quality.yml` `mcp-lint` and `mcp-tests` jobs | Validate with `cd mcp/ngfw && npm test` and lint when JS/test files change. |
+
+## Cross-Cutting Layers
+
+- Auth surface: `mcp/ngfw` has no application actor identity or RBAC layer.
+  Therefore the design must remain least-privilege and must not expose privileged
+  NGFW administration tools to arbitrary connected MCP clients.
+- Secret-handling surface: the active server must not call Secrets Manager or
+  return SSH private keys, passwords, tokens, or secret-bearing URLs in MCP
+  responses. `tool-surface.test.js` already asserts absent Secrets Manager calls.
+- Env-binding shape: `EnvSchema` allows only `dev` or `prod` and defaults to
+  `dev`; `PROFILES` maps those values to `PANW_SHIFTER_*_PROFILE`. This selects
+  credentials but is not an authorization boundary.
+- Config validators: architecture changes must continue to satisfy ADR-010 and
+  ADR-014 via `adr_guard`. MCP package changes must satisfy the package-native
+  Node test and lint jobs.
+- OS/process exposure: `list_ngfws` may invoke `aws` only through
+  `mcp/shared/aws-helpers.js` with argv arrays. No token, profile, command body,
+  or shell pipeline should be constructed as a process command string.
+- Error envelope: the handler currently returns `Error: ${err.message}` in MCP
+  text content. Keep errors operation-labeled and non-secret; do not surface
+  raw secret values, private keys, shell command bodies, or multiline payloads.
+
+## Extensibility Seam
+
+The extensibility seam is the NGFW tool-surface invariant. Keep a single expected
+tool list in `mcp/ngfw/tool-surface.test.js` or an equivalent package-local
+guard, and make the test assert that `mcp/ngfw/SECURITY.md` names that guard.
+The next legitimate addition, such as another read-only discovery tool, should
+require one test list update and one security-doc update, not a new test
+framework or duplicated schema.
+
+## Gotchas And Anti-Patterns
+
+- Do not conflate `mcp/ngfw/lib.js` helper exports with active MCP capabilities;
+  only `server.tool(...)` registrations define the live tool surface.
+- Do not describe `run_command`, `show_system_info`, `show_routes`, SSH key
+  retrieval, SSM command forwarding, or PAN-OS CLI execution as active NGFW MCP
+  capabilities.
+- Do not weaken `tool-surface.test.js` into a loose grep for stale words. The
+  useful invariant is exported tools present/absent and no Secrets Manager use.
+- Do not add a separate doc parser, schema registry, or policy layer for this
+  maintenance issue. Reuse the existing test and ADR guard seams.
+- Do not imply that `env=prod` plus an AWS profile is safe for privileged
+  operations. The current surface is safe because it is non-mutating discovery,
+  not because `EnvSchema` authorizes the caller.
+- Do not remove ADR-010 AWS argv-array guidance from the security doc when
+  deleting stale PAN-OS command text; `list_ngfws` still crosses the AWS CLI
+  process boundary.
+
+## Non-Goals
+
+- No new MCP tools, no PAN-OS administration, no SSM/SSH command path, and no
+  Secrets Manager integration.
+- No migration from AWS CLI helpers to an AWS SDK.
+- No new authorization system, audit framework, config schema, exception
+  hierarchy, logging framework, or workflow.
+- No ADR change is needed unless the implementation changes the NGFW MCP
+  capability class or introduces a new enforcement mechanism.

--- a/mcp/ngfw/SECURITY.md
+++ b/mcp/ngfw/SECURITY.md
@@ -1,12 +1,37 @@
 # shifter-ngfw MCP security boundaries
 
-The ngfw MCP server runs with the local operator's AWS credentials and
-only exposes EC2 discovery metadata (`list_ngfws`). It does **not**
-execute PAN-OS CLI commands and does not retrieve NGFW SSH keys from
-Secrets Manager. The remaining shell boundary that must stay closed:
+The `shifter-ngfw` MCP server runs with the local operator's AWS
+credentials and exposes a single read-only EC2 discovery tool. It does
+**not** execute PAN-OS CLI commands, does **not** open SSH or SSM
+sessions to firewall instances, and does **not** read NGFW SSH private
+keys or any other material from AWS Secrets Manager. The remaining
+process boundary that must stay closed:
 
 1. **Local host shell** — every `aws` invocation runs as an argv array
    via `spawn`/`spawnSync`/`execFile`. Shell strings are forbidden.
+
+## Current tool surface
+
+The MCP server registers exactly one tool through `server.tool(...)`
+in `mcp/ngfw/index.js`:
+
+| Tool | Action | AWS calls |
+| --- | --- | --- |
+| `list_ngfws` | Read-only discovery: returns EC2 instances whose `Name` tag contains `ngfw`, with `InstanceId`, `Name`, `State`, `PrivateIp`, and `KeyName` (the EC2 KeyPair name attached to each instance, not the SSH key material). | `aws ec2 describe-instances` via `mcp/shared/aws-helpers.js`. |
+
+The live tool surface is enforced by
+`mcp/ngfw/tool-surface.test.js`. That suite parses
+`server.tool("<name>", ...)` registrations out of `index.js` and
+asserts the set equals exactly `{"list_ngfws"}`. It also asserts that
+this document names each registered tool and back-references the
+surface test by file name. A future PR that adds a tool must update
+the test's `EXPECTED_TOOLS` set **and** this document in the same
+change; either edit on its own fails the test.
+
+`mcp/ngfw/lib.js` exports legacy helpers (e.g. NGFW SSH command-pipeline
+builders). They are NOT registered as MCP tools and are not part of the
+active capability surface. Only `server.tool(...)` registrations in
+`index.js` define what the MCP client can invoke.
 
 ## AWS CLI execution
 
@@ -16,58 +41,53 @@ Secrets Manager. The remaining shell boundary that must stay closed:
 - Shared AWS helpers should accept structured argv segments, not a
   pre-joined command string. Call sites should pass JSON values as a
   single argv element after `JSON.stringify`.
-- Shell escaping is not a remediation strategy for this component. If a
-  value must be interpreted by a remote shell through SSM, keep that
-  interpretation isolated to the remote command payload and do not
-  route it through the local MCP host shell.
+- Shell escaping is not a remediation strategy for this component.
 - Do not import `execSync` from `child_process` in this package.
   ADR-010-R1 forbids the import outright; the `mcp-no-shell-exec`
   static check in `scripts/adr_guard/adr_guard.py` enforces it.
 
-## NGFW admin boundary
+## Non-goals (explicit boundary)
 
-- Do not add MCP tools that run PAN-OS CLI commands through SSM/SSH.
-- Do not retrieve NGFW SSH private keys from Secrets Manager in this
-  server.
-- If operational firewall administration is needed, use a separate
-  break-glass operator workflow with approval and RBAC.
-The PAN-OS CLI command supplied to `run_command`, `show_system_info`,
-and `show_routes` is forwarded to the NGFW via the portal jump host.
-The portal command pipeline is built by
-`buildNgfwSshCommands({ sshKey, ngfwIp, command })` in `lib.js`:
+- No NGFW administration. The MCP server must not gain tools that
+  mutate firewall configuration, push commits, reboot devices, or
+  forward arbitrary shell commands to firewall instances.
+- No Secrets Manager access. The server must not call
+  `secretsmanager:GetSecretValue`, `secretsmanager:ListSecrets`, or any
+  other Secrets Manager API. NGFW SSH private keys and any other
+  secret material remain out of scope.
+- No SSH or SSM sessions from this server. Interactive firewall
+  administration belongs in a separate break-glass workflow with
+  approval and RBAC, not in a general-purpose MCP surface.
+- No new MCP tools without a matching update to
+  `mcp/ngfw/tool-surface.test.js` and this document.
 
-- The user command is base64-encoded (`command + "\n"` so PAN-OS
-  receives a complete line — the appliance is line-oriented and needs
-  Enter to execute) into a single argv-safe token. Base64 outputs only
-  `[A-Za-z0-9+/=]`, none of which are shell-special inside single
-  quotes, so `printf %s '<base64>'` cannot be broken open by
-  attacker-controlled bytes.
-- The portal decodes the base64 (`base64 -d`) and pipes the resulting
-  bytes into `ssh`'s stdin. The portal shell never sees the raw command.
-- The SSH private key rides via a single-quoted heredoc terminator
-  (`<< 'EOFKEY'`). The single quotes around the terminator suppress
-  expansion of `$`, backticks, and `$( )` inside the heredoc body.
-- The temporary key path is per-invocation (`/tmp/ngfw-<uuid>.pem`) so
-  concurrent MCP calls cannot clobber or delete each other's key
-  material. `buildNgfwSshCommands` validates any caller-supplied
-  `keyPath` against `^/tmp/ngfw-[A-Za-z0-9._-]+\.pem$` so a future
-  caller cannot widen the boundary.
-- SSH host-key verification is enforced. The portal jump host must have
-  the expected NGFW host key in its configured known_hosts before these
-  management commands run.
-- `ngfwIp` is interpolated into the SSH target argument. It is sourced
-  from EC2 `describe-instances` (AWS-controlled), but
-  `validateNgfwIp` enforces a strict dotted-quad IPv4 check before
-  interpolation as defense in depth.
+## Removed administration tools
 
-Single-quote escaping of arbitrary command bytes is explicitly NOT the
-remediation strategy. Base64 is the boundary.
+The following tools were previously registered by this server and have
+been removed. They are listed here only so a reader of the security
+doc can see what is **no longer** part of the surface; they are not
+active capabilities and must not be re-introduced without a new
+threat-model review.
+
+- `run_command` — forwarded an arbitrary PAN-OS CLI command to an NGFW
+  instance through the portal jump host over SSH.
+- `show_system_info` — wrapped `show system info` against the NGFW.
+- `show_routes` — wrapped `show routing route` against the NGFW.
+
+The removal also dropped this server's prior dependence on retrieving
+NGFW SSH private keys from AWS Secrets Manager. The
+`tool-surface.test.js` regression assertions cover both the absent
+tool registrations and the absent Secrets Manager API references
+(`secretsmanager`, `get-secret-value`, `list-secrets`).
 
 ## Validation and boundaries
 
 - Reuse the existing Zod schemas in `index.js` for tool input shape and
   the shared helpers in `lib.js` (`buildAwsArgv`, `awsExec`, `awsJson`,
   `awsText`).
+- `EnvSchema` accepts `dev` or `prod` and selects the local AWS profile
+  via `PROFILES`. This is credential selection, not authorization;
+  do not treat `env=prod` as a security boundary.
 
 ## Shared helper module at `mcp/shared/aws-helpers.js`
 
@@ -88,18 +108,19 @@ re-implement the helpers locally.
 
 ## Regression coverage
 
-Regression tests for AWS command construction prove that payloads
-containing `$()`, backticks, single and double quotes, semicolons,
-spaces, and newlines remain literal argv values and are never
-evaluated by the local shell. Cover each user-facing tool path that
-reaches the shared AWS helpers.
+`mcp/ngfw/tool-surface.test.js` is the canonical guard for the points
+above. It asserts that:
 
-`mcp/ngfw/tool-surface.test.js` asserts that the MCP tool surface does
-not expose the removed admin execution tools and that the server does
-not call Secrets Manager APIs.
+- `index.js` registers exactly the expected set of tools (currently
+  just `list_ngfws`).
+- This document references the surface test and names every live tool.
+- This document does not describe any removed tool as an active
+  capability (removed-tool names may appear only under the
+  `## Removed administration tools` section above).
+- `index.js` never calls Secrets Manager APIs.
 
 `mcp/ops/spawn-roundtrip.test.js` proves that Node's `spawnSync`
 forwards argv elements byte-for-byte for every metacharacter shape
-that matters. Because both packages now share `spawnSync` through
-`mcp/shared/aws-helpers.js`, that single suite covers the boundary
-for every Shifter MCP server.
+that matters. Because both packages share `spawnSync` through
+`mcp/shared/aws-helpers.js`, that single suite covers the local-shell
+boundary for every Shifter MCP server.

--- a/mcp/ngfw/tool-surface.test.js
+++ b/mcp/ngfw/tool-surface.test.js
@@ -6,18 +6,160 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const indexSource = readFileSync(path.join(__dirname, "index.js"), "utf-8");
+const securitySource = readFileSync(
+  path.join(__dirname, "SECURITY.md"),
+  "utf-8",
+);
+
+// Exported tools registered on the MCP server. Update when (and only
+// when) `index.js` adds or removes a `server.tool(...)` registration.
+// A change here without a matching `SECURITY.md` update is rejected by
+// the "doc references the live tool surface" assertion below.
+const EXPECTED_TOOLS = new Set(["list_ngfws"]);
+
+// Tools that used to live in `mcp/ngfw` (PAN-OS administration via SSH/SSM
+// through the portal jump host) and were removed. The security doc must
+// not describe these as active capabilities; if mentioned at all, they
+// belong under an explicit "Removed administration tools" section so a
+// reader cannot mistake them for the current surface.
+const REMOVED_TOOLS = ["run_command", "show_system_info", "show_routes"];
+
+// Match a `server.tool(...)` call whose first argument is a static
+// string literal in any of the three JavaScript forms: double-quoted,
+// single-quoted, or backtick template literal WITHOUT `${...}`
+// interpolation. Interpolated template literals are intentionally
+// excluded so they trigger the "non-literal registration" guard below.
+const TOOL_REGISTRATION_LITERAL = new RegExp(
+  // server.tool(  +  string-literal-of-any-quote-style
+  String.raw`server\.tool\(\s*(?:"([^"\\]+)"|'([^'\\]+)'|` + "`" +
+    String.raw`([^` + "`" + String.raw`$\\]+)` + "`" + String.raw`)`,
+  "g",
+);
+
+// Match ANY `server.tool(` registration regardless of the first
+// argument's shape (literal, identifier, function call, interpolated
+// template literal). Used to detect non-literal forms and fail loudly
+// so the surface invariant cannot be silently bypassed by a future
+// registration like `server.tool(toolName, ...)` or
+// `server.tool(`tool_${env}`, ...)`.
+const TOOL_REGISTRATION_ANY = /server\.tool\s*\(\s*[^,)]/g;
+
+function extractRegisteredTools(source) {
+  const tools = new Set();
+  for (const match of source.matchAll(TOOL_REGISTRATION_LITERAL)) {
+    tools.add(match[1] ?? match[2] ?? match[3]);
+  }
+  return tools;
+}
+
+function countLiteralRegistrations(source) {
+  return [...source.matchAll(TOOL_REGISTRATION_LITERAL)].length;
+}
+
+function countAnyRegistrations(source) {
+  return [...source.matchAll(TOOL_REGISTRATION_ANY)].length;
+}
+
+function quotedFormsOf(name) {
+  // Generate the three string-literal forms a tool name can appear in
+  // inside `index.js`. The escapes follow JS regex rules; tool names
+  // are simple identifiers so no characters in them are regex-special.
+  return [`"${name}"`, `'${name}'`, "`" + name + "`"];
+}
 
 describe("ngfw MCP tool surface hardening", () => {
   it("keeps instance discovery while removing PAN-OS execution tools", () => {
-    assert.match(indexSource, /"list_ngfws"/);
-    assert.doesNotMatch(indexSource, /"run_command"/);
-    assert.doesNotMatch(indexSource, /"show_system_info"/);
-    assert.doesNotMatch(indexSource, /"show_routes"/);
+    assert.ok(
+      extractRegisteredTools(indexSource).has("list_ngfws"),
+      "index.js must register the `list_ngfws` MCP tool.",
+    );
+    // Removed tools must not appear as a server.tool registration
+    // string-literal in ANY of the three JS quoting forms (double,
+    // single, backtick). The class fix from cycle 3 generalizes the
+    // earlier double-quote-only assertion.
+    for (const tool of REMOVED_TOOLS) {
+      for (const quoted of quotedFormsOf(tool)) {
+        assert.ok(
+          !indexSource.includes(`server.tool(${quoted}`) &&
+            !indexSource.includes(`server.tool( ${quoted}`),
+          `index.js must not register removed tool \`${tool}\` (in ${quoted} form).`,
+        );
+      }
+    }
   });
 
   it("does not fetch firewall SSH keys from Secrets Manager", () => {
     assert.doesNotMatch(indexSource, /secretsmanager/);
     assert.doesNotMatch(indexSource, /get-secret-value/);
     assert.doesNotMatch(indexSource, /list-secrets/);
+  });
+
+  it("only registers tools via static string literals", () => {
+    // Every `server.tool(` invocation must use a static string literal
+    // as the tool name so the surface can be enumerated statically.
+    // A future registration like `server.tool(toolName, ...)` or
+    // `server.tool(`tool_${env}`, ...)` would slip past the
+    // EXPECTED_TOOLS set assertion below, defeating the invariant.
+    const literalCount = countLiteralRegistrations(indexSource);
+    const anyCount = countAnyRegistrations(indexSource);
+    assert.strictEqual(
+      literalCount,
+      anyCount,
+      `index.js has ${anyCount} \`server.tool(\` call(s) but only ` +
+        `${literalCount} use a static string literal as the tool name. ` +
+        "Inline the tool name as a literal or extend the regex in " +
+        "`extractRegisteredTools` / the literal-form guard to recognize " +
+        "the new shape.",
+    );
+  });
+
+  it("exports exactly the expected tool set (no extras, no missing)", () => {
+    const registered = extractRegisteredTools(indexSource);
+    assert.deepStrictEqual(
+      registered,
+      EXPECTED_TOOLS,
+      `index.js registers ${[...registered].join(", ")}; expected ${[...EXPECTED_TOOLS].join(", ")}. ` +
+        "Update EXPECTED_TOOLS in this file AND mcp/ngfw/SECURITY.md when " +
+        "the tool surface changes.",
+    );
+  });
+
+  it("SECURITY.md references the tool-surface guard and every live tool", () => {
+    assert.match(
+      securitySource,
+      /tool-surface\.test\.js/,
+      "SECURITY.md must name `tool-surface.test.js` so future surface changes " +
+        "have a discoverable enforcement seam.",
+    );
+    for (const tool of EXPECTED_TOOLS) {
+      assert.ok(
+        securitySource.includes(tool),
+        `SECURITY.md must describe the currently-registered tool \`${tool}\`.`,
+      );
+    }
+  });
+
+  it("SECURITY.md does not describe removed tools as active capabilities", () => {
+    // Removed tools may be named only inside an explicit "Removed
+    // administration tools" section so a reader cannot mistake them for
+    // the current surface. Everything before that heading must be silent
+    // on them.
+    const removedHeadingMatch = securitySource.match(
+      /^##\s+Removed administration tools\s*$/m,
+    );
+    assert.ok(
+      removedHeadingMatch,
+      "SECURITY.md must include a `## Removed administration tools` " +
+        "section that marks the removed PAN-OS tools as historical.",
+    );
+    const before = securitySource.slice(0, removedHeadingMatch.index);
+    for (const tool of REMOVED_TOOLS) {
+      assert.ok(
+        !before.includes(tool),
+        `SECURITY.md mentions removed tool \`${tool}\` before the ` +
+          "`Removed administration tools` section, which presents it as " +
+          "an active capability. Move the reference under that section.",
+      );
+    }
   });
 });

--- a/scripts/adr_guard/adr_guard.py
+++ b/scripts/adr_guard/adr_guard.py
@@ -1995,6 +1995,256 @@ def _git_tracked_under_roots(repo_root: Path) -> list[str] | None:
     return [entry for entry in output.split("\0") if entry]
 
 
+# Centralized scope for the `no-populated-secret-env-files` check
+# (ADR-004-R9). Each entry is a repo-relative path prefix under which
+# `*-secrets.env` files are scanned. Adding a future overlay (e.g.
+# `platform/k8s/gcp/overlays/gcp-prod/`) is automatically covered;
+# adding a new top-level location (e.g. a different cluster tree) is
+# one entry here.
+_SECRET_ENV_ROOTS: tuple[str, ...] = ("platform/k8s/",)
+
+# Basename suffix that selects "secret env" files. Matched on the
+# basename only so unrelated `*.env` files (config-bearing, not
+# secret-bearing) are not scanned by this check.
+_SECRET_ENV_SUFFIX = "-secrets.env"
+
+# Fail-loud synthetic values that may appear as the RHS of an
+# assignment in a tracked secret env file. The intent is that
+# committed files render Kustomize / kube-linter / kubeconform
+# successfully while making it obvious to anyone who deploys with the
+# committed values that they have NOT supplied real secrets. Real
+# values flow in at deploy time from GitHub Secrets, GCP Secret
+# Manager, a gitignored local env file, or a deploy-time Kubernetes
+# Secret.
+#
+# The allowlist is intentionally small and FIXED. Codex review cycle 3
+# caught that an earlier `<...>` regex would accept any angle-bracket
+# value (e.g. `DB_PASSWORD=<attacker-known-password>`) — a committer
+# could wrap a real low-entropy credential in brackets, the guard
+# would call it a placeholder, and Kustomize would treat the bracketed
+# bytes as the literal Secret value at deploy. The bracket-syntax
+# entries below are therefore an explicit fixed set, not a pattern.
+# Broader synonyms must come through a deliberate ADR update, not
+# ad-hoc growth.
+_SECRET_ENV_PLACEHOLDERS: frozenset[str] = frozenset(
+    {
+        # Bare placeholder tokens
+        "REPLACE_AT_DEPLOY",
+        "CHANGE_ME",
+        "PLACEHOLDER",
+        "EXAMPLE",
+        # Equivalent bracketed forms (conventional in some example files);
+        # the bracket allowlist is fixed, not pattern-based, to close the
+        # angle-bracket bypass from cycle 3.
+        "<replace-at-deploy>",
+        "<replace_at_deploy>",
+        "<REPLACE_AT_DEPLOY>",
+        "<change-me>",
+        "<change_me>",
+        "<CHANGE_ME>",
+        "<placeholder>",
+        "<PLACEHOLDER>",
+        "<example>",
+        "<EXAMPLE>",
+    }
+)
+
+def _is_secret_env_in_scope(rel_path: str) -> bool:
+    """Return True for a repo-relative path that the secret-env check scans."""
+    if not any(rel_path.startswith(root) for root in _SECRET_ENV_ROOTS):
+        return False
+    basename = rel_path.rsplit("/", 1)[-1]
+    return basename.endswith(_SECRET_ENV_SUFFIX)
+
+
+def _iter_secret_env_candidates(repo_root: Path) -> list[str]:
+    """Return repo-relative paths of secret-env files in scope.
+
+    Mirrors the tracked-only contract of
+    `check_no_tracked_generated_artifacts`: prefer `git ls-files` so
+    gitignored local-dev files (e.g. a developer's
+    `platform-runtime-secrets.local.env`) are intentionally NOT
+    scanned. Falls back to a filesystem walk only in the synthetic
+    tmpdir test path where no `.git` directory exists.
+    """
+    tracked = _git_tracked_under_roots_for_secret_env(repo_root)
+    if tracked is None:
+        return _walk_filesystem_secret_env(repo_root)
+    return [p for p in tracked if _is_secret_env_in_scope(p)]
+
+
+def _git_tracked_under_roots_for_secret_env(repo_root: Path) -> list[str] | None:
+    """Tracked + non-ignored repo-relative paths under the secret-env
+    roots, or `None` if `repo_root` is not a git working tree."""
+    if not (repo_root / ".git").exists():
+        return None
+    cmd = [
+        "git",
+        "-C",
+        str(repo_root),
+        "ls-files",
+        "-z",
+        "--cached",
+        "--others",
+        "--exclude-standard",
+        "--",
+        *_SECRET_ENV_ROOTS,
+    ]
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            check=False,
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError):
+        # `git` unavailable or hung — fall back to filesystem walk so
+        # the check still runs (synthetic-mode contract).
+        return None
+    if result.returncode != 0:
+        return None
+    raw = result.stdout.split(b"\x00")
+    return [entry.decode("utf-8") for entry in raw if entry]
+
+
+def _walk_filesystem_secret_env(repo_root: Path) -> list[str]:
+    """Test-mode fallback: walk the configured secret-env roots."""
+    candidates: list[str] = []
+    for root in _SECRET_ENV_ROOTS:
+        base = repo_root / root
+        if not base.exists():
+            continue
+        for path in base.rglob("*"):
+            if not path.is_file():
+                continue
+            rel = _repo_relative(path, repo_root)
+            if _is_secret_env_in_scope(rel):
+                candidates.append(rel)
+    return candidates
+
+
+def _is_synthetic_placeholder(value: str) -> bool:
+    """Return True if `value` is an allowed fail-loud placeholder.
+
+    The allowlist is a fixed set (see `_SECRET_ENV_PLACEHOLDERS`).
+    Pattern-based bracket matching was removed in cycle 3 because it
+    accepted arbitrary `<...>` content, which would allow a committer
+    to hide a real credential as `<attacker-known-password>` and have
+    the guardrail pass.
+    """
+    stripped = value.strip()
+    if stripped == "":
+        return True
+    return stripped in _SECRET_ENV_PLACEHOLDERS
+
+
+def _scan_secret_env_file(abs_path: Path, rel_path: str) -> list[Violation]:
+    """Return violations for any populated, non-placeholder line.
+
+    Parsing rules:
+
+    - A line whose first non-whitespace character is `#`, or that is
+      blank after strip, is a comment / blank and is skipped.
+    - Any other line MUST contain `=` and is parsed by splitting on
+      the first `=`. The LHS is treated as the variable name verbatim
+      (any shape — `KEY`, `db.password`, `api-token`, `export KEY`)
+      so non-identifier-key shapes cannot bypass the value check.
+    - Inline `# ...` is NOT a comment. Kustomize's
+      `secretGenerator.envs` loader follows the Docker env_file
+      format: `#` is a comment only when it is the first non-
+      whitespace character on a line; mid-line `#` is part of the
+      value. Treating mid-line `#` as a comment would create a
+      bypass (`TOKEN=#real-secret` would normalize to empty and pass
+      the placeholder check while the bytes remain in source).
+    - A non-comment, non-blank line that does NOT contain `=` is
+      flagged as malformed so a committed value smuggled in via a
+      non-`=` shape (free text, YAML, etc.) cannot slip past the
+      value check.
+
+    The violation message names the line number, the variable shape,
+    and the path; it never echoes the rejected value, per the
+    preflight contract that validation reports paths and variable
+    names only.
+    """
+    violations: list[Violation] = []
+    try:
+        text = abs_path.read_text(encoding="utf-8")
+    except OSError:
+        return violations
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        stripped_line = line.strip()
+        if not stripped_line or stripped_line.startswith("#"):
+            continue
+        if "=" not in stripped_line:
+            violations.append(
+                Violation(
+                    check="no-populated-secret-env-files",
+                    rule_id="ADR-004-R9",
+                    path=rel_path,
+                    message=(
+                        f"Tracked secret-env line {lineno} is not a "
+                        "comment, blank line, or `KEY=value` "
+                        "assignment. Use one of the allowed synthetic "
+                        "placeholders (REPLACE_AT_DEPLOY, CHANGE_ME, "
+                        "PLACEHOLDER, EXAMPLE, or <placeholder>) or "
+                        "remove the line."
+                    ),
+                )
+            )
+            continue
+        key, _, rhs = line.partition("=")
+        var_name = key.strip()
+        if _is_synthetic_placeholder(rhs):
+            continue
+        violations.append(
+            Violation(
+                check="no-populated-secret-env-files",
+                rule_id="ADR-004-R9",
+                path=rel_path,
+                message=(
+                    f"Tracked secret-env assignment `{var_name}` "
+                    f"(line {lineno}) has a non-placeholder value. "
+                    "Replace with an allowed synthetic placeholder "
+                    "(REPLACE_AT_DEPLOY, CHANGE_ME, PLACEHOLDER, "
+                    "EXAMPLE, or <placeholder>); real values must come "
+                    "from GCP Secret Manager, a gitignored local env "
+                    "file, or a deploy-time Kubernetes Secret."
+                ),
+            )
+        )
+    return violations
+
+
+def check_no_populated_secret_env_files(
+    repo_root: Path, files: list[str] | None
+) -> list[Violation]:
+    """Forbid populated assignments in tracked `*-secrets.env` files (ADR-004-R9).
+
+    Scans tracked `*-secrets.env` files under `_SECRET_ENV_ROOTS` (currently
+    `platform/k8s/`). Allows comments, blank lines, empty assignments
+    (`KEY=`), and a small synthetic-placeholder set. Anything else is
+    flagged as a real value that must not ship in source.
+
+    Reports violations with `rule_id="ADR-004-R9"`. Violation messages
+    name the path and the variable name; they NEVER echo the rejected
+    value. Mirrors `check_no_tracked_generated_artifacts` in using
+    `git ls-files` for containment (so gitignored local-dev files are
+    intentionally not scanned) with a filesystem-walk fallback for
+    synthetic-tmpdir unit tests.
+    """
+    if files is not None:
+        in_scope = sorted({p for p in files if _is_secret_env_in_scope(p)})
+    else:
+        in_scope = sorted(set(_iter_secret_env_candidates(repo_root)))
+    violations: list[Violation] = []
+    for rel in in_scope:
+        abs_path = repo_root / rel
+        if not abs_path.exists() or not abs_path.is_file():
+            continue
+        violations.extend(_scan_secret_env_file(abs_path, rel))
+    return violations
+
+
 def check_no_tracked_generated_artifacts(
     repo_root: Path, files: list[str] | None
 ) -> list[Violation]:
@@ -2515,6 +2765,7 @@ CHECKS = {
     "k8s-network-policy-coverage": check_k8s_network_policy_coverage,
     "no-plaintext-secrets-in-tfvars": check_no_plaintext_secrets_in_tfvars,
     "no-tracked-generated-artifacts": check_no_tracked_generated_artifacts,
+    "no-populated-secret-env-files": check_no_populated_secret_env_files,
     "mcp-ops-tls-strict": check_mcp_ops_tls_strict,
     "python-complexity-gate": check_python_complexity_gate,
 }
@@ -2528,6 +2779,7 @@ CHECK_LEVELS = {
         "mcp-no-shell-exec",
         "no-plaintext-secrets-in-tfvars",
         "no-tracked-generated-artifacts",
+        "no-populated-secret-env-files",
         "mcp-ops-tls-strict",
         "python-complexity-gate",
     ],
@@ -2541,6 +2793,7 @@ CHECK_LEVELS = {
         "k8s-network-policy-coverage",
         "no-plaintext-secrets-in-tfvars",
         "no-tracked-generated-artifacts",
+        "no-populated-secret-env-files",
         "mcp-ops-tls-strict",
         "python-complexity-gate",
     ],

--- a/scripts/adr_guard/tests/test_adr_guard.py
+++ b/scripts/adr_guard/tests/test_adr_guard.py
@@ -2656,5 +2656,448 @@ class NoTrackedGeneratedArtifactsTests(unittest.TestCase):
         self.assertIn("no-tracked-generated-artifacts", ADR_GUARD.CHECK_LEVELS["fast"])
 
 
+class NoPopulatedSecretEnvFilesTests(unittest.TestCase):
+    """Tests for ADR-004-R9: forbid populated tracked ``*-secrets.env`` files.
+
+    The check guards against re-introducing the failure mode resolved by
+    PR #1207, where ``platform-runtime-secrets.env`` carried plaintext
+    runtime credentials. Synthetic placeholders are allowed so the
+    Kustomize overlay still renders for static validation, but real
+    values must be supplied at deploy time (GCP Secret Manager,
+    deploy-time Kubernetes Secret, or a gitignored local env file).
+
+    Violation messages must name only the path and variable name,
+    never the rejected value.
+    """
+
+    SECRETS_ENV_REL = (
+        "platform/k8s/gcp/overlays/gcp-dev/platform-runtime-secrets.env"
+    )
+
+    def _make_overlay(self, repo_root: Path, rel: str) -> Path:
+        d = repo_root / rel
+        d.mkdir(parents=True)
+        return d
+
+    def test_passes_when_file_is_comments_only(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            overlay = self._make_overlay(
+                repo_root, "platform/k8s/gcp/overlays/gcp-dev"
+            )
+            (overlay / "platform-runtime-secrets.env").write_text(
+                "# header comment\n#\n# another comment line\n\n",
+                encoding="utf-8",
+            )
+
+            violations = ADR_GUARD.check_no_populated_secret_env_files(
+                repo_root, None
+            )
+
+            self.assertEqual(violations, [])
+
+    def test_passes_with_empty_assignment(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            overlay = self._make_overlay(
+                repo_root, "platform/k8s/gcp/overlays/gcp-dev"
+            )
+            (overlay / "platform-runtime-secrets.env").write_text(
+                "DB_PASSWORD=\nAPP_TOKEN=\n",
+                encoding="utf-8",
+            )
+
+            violations = ADR_GUARD.check_no_populated_secret_env_files(
+                repo_root, None
+            )
+
+            self.assertEqual(violations, [])
+
+    def test_passes_with_synthetic_placeholders(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            overlay = self._make_overlay(
+                repo_root, "platform/k8s/gcp/overlays/gcp-dev"
+            )
+            (overlay / "platform-runtime-secrets.env").write_text(
+                "DB_PASSWORD=REPLACE_AT_DEPLOY\n"
+                "API_TOKEN=CHANGE_ME\n"
+                "SHARED_KEY=PLACEHOLDER\n"
+                "DEMO_VALUE=EXAMPLE\n"
+                "BRACKETED=<replace-at-deploy>\n",
+                encoding="utf-8",
+            )
+
+            violations = ADR_GUARD.check_no_populated_secret_env_files(
+                repo_root, None
+            )
+
+            self.assertEqual(violations, [])
+
+    def test_flags_populated_assignment_without_echoing_value(self) -> None:
+        # Use a distinctive value so the assertion that violation
+        # messages do NOT contain the value is unambiguous.
+        sentinel_value = "ActualSensitiveValue123XYZ"
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            overlay = self._make_overlay(
+                repo_root, "platform/k8s/gcp/overlays/gcp-dev"
+            )
+            (overlay / "platform-runtime-secrets.env").write_text(
+                f"DB_PASSWORD={sentinel_value}\n",
+                encoding="utf-8",
+            )
+
+            violations = ADR_GUARD.check_no_populated_secret_env_files(
+                repo_root, None
+            )
+
+            self.assertEqual(len(violations), 1)
+            v = violations[0]
+            self.assertEqual(v.rule_id, "ADR-004-R9")
+            self.assertEqual(v.path, self.SECRETS_ENV_REL)
+            self.assertIn("DB_PASSWORD", v.message)
+            self.assertNotIn(sentinel_value, v.message)
+
+    def test_skips_files_outside_path_allowlist(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            other = repo_root / "tests" / "fixtures"
+            other.mkdir(parents=True)
+            (other / "platform-runtime-secrets.env").write_text(
+                "DB_PASSWORD=SomeRealValue\n",
+                encoding="utf-8",
+            )
+
+            violations = ADR_GUARD.check_no_populated_secret_env_files(
+                repo_root, None
+            )
+
+            self.assertEqual(violations, [])
+
+    def test_only_scans_secrets_env_basename_pattern(self) -> None:
+        # Non-secrets env files in the same overlay must NOT be scanned.
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            overlay = self._make_overlay(
+                repo_root, "platform/k8s/gcp/overlays/gcp-dev"
+            )
+            (overlay / "platform-runtime.env").write_text(
+                "DB_HOST=postgresql.example.com\nDB_PORT=5432\n",
+                encoding="utf-8",
+            )
+
+            violations = ADR_GUARD.check_no_populated_secret_env_files(
+                repo_root, None
+            )
+
+            self.assertEqual(violations, [])
+
+    def test_files_arg_narrows_scope(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            dev = self._make_overlay(
+                repo_root, "platform/k8s/gcp/overlays/gcp-dev"
+            )
+            (dev / "platform-runtime-secrets.env").write_text(
+                "DB_PASSWORD=DevRealVal\n",
+                encoding="utf-8",
+            )
+            prod = self._make_overlay(
+                repo_root, "platform/k8s/gcp/overlays/gcp-prod"
+            )
+            (prod / "platform-runtime-secrets.env").write_text(
+                "DB_PASSWORD=ProdRealVal\n",
+                encoding="utf-8",
+            )
+
+            scoped = ADR_GUARD.check_no_populated_secret_env_files(
+                repo_root,
+                [
+                    "platform/k8s/gcp/overlays/gcp-dev/"
+                    "platform-runtime-secrets.env"
+                ],
+            )
+
+            self.assertEqual(len(scoped), 1)
+            self.assertEqual(
+                scoped[0].path,
+                "platform/k8s/gcp/overlays/gcp-dev/"
+                "platform-runtime-secrets.env",
+            )
+
+    def test_flags_only_violating_lines_not_placeholder_siblings(self) -> None:
+        # Mixed-content file: placeholders are OK, populated lines flag.
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            overlay = self._make_overlay(
+                repo_root, "platform/k8s/gcp/overlays/gcp-dev"
+            )
+            (overlay / "platform-runtime-secrets.env").write_text(
+                "# header\n"
+                "DB_PASSWORD=REPLACE_AT_DEPLOY\n"
+                "API_TOKEN=NotASynthetic\n"
+                "APP_KEY=\n",
+                encoding="utf-8",
+            )
+
+            violations = ADR_GUARD.check_no_populated_secret_env_files(
+                repo_root, None
+            )
+
+            flagged_vars = [v.message for v in violations]
+            self.assertEqual(len(violations), 1)
+            self.assertIn("API_TOKEN", flagged_vars[0])
+
+    def test_flags_value_starting_with_hash(self) -> None:
+        # Bypass regression: `KEY=#actualsecret` must NOT be treated as
+        # an empty/commented assignment. Kustomize's env_file loader
+        # (Docker-compat) only honors `#` as a comment when it is the
+        # first non-whitespace character on a line; mid-line `#` is
+        # part of the value. Treating it otherwise would let a
+        # committer hide plaintext credentials behind an inline-
+        # comment shape. Codex review cycle 1 caught this.
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            overlay = self._make_overlay(
+                repo_root, "platform/k8s/gcp/overlays/gcp-dev"
+            )
+            (overlay / "platform-runtime-secrets.env").write_text(
+                "DB_PASSWORD=#actualsecret\n",
+                encoding="utf-8",
+            )
+
+            violations = ADR_GUARD.check_no_populated_secret_env_files(
+                repo_root, None
+            )
+
+            self.assertEqual(len(violations), 1)
+            v = violations[0]
+            self.assertEqual(v.rule_id, "ADR-004-R9")
+            self.assertIn("DB_PASSWORD", v.message)
+            self.assertNotIn("actualsecret", v.message)
+
+    def test_flags_value_with_inline_hash_after_placeholder(self) -> None:
+        # Bypass regression: `KEY=REPLACE_AT_DEPLOY#real` must be
+        # flagged. Inline `#` is part of the value, so the RHS is not
+        # exactly one of the approved placeholders.
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            overlay = self._make_overlay(
+                repo_root, "platform/k8s/gcp/overlays/gcp-dev"
+            )
+            (overlay / "platform-runtime-secrets.env").write_text(
+                "API_TOKEN=REPLACE_AT_DEPLOY#realtoken\n",
+                encoding="utf-8",
+            )
+
+            violations = ADR_GUARD.check_no_populated_secret_env_files(
+                repo_root, None
+            )
+
+            self.assertEqual(len(violations), 1)
+            v = violations[0]
+            self.assertIn("API_TOKEN", v.message)
+            self.assertNotIn("realtoken", v.message)
+
+    def test_flags_value_with_inline_hash_and_whitespace(self) -> None:
+        # Bypass regression: `KEY=actual # note` is also flagged.
+        # Treating ` # note` as a comment would allow committed values
+        # of the form `KEY=actual # note` to slip through.
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            overlay = self._make_overlay(
+                repo_root, "platform/k8s/gcp/overlays/gcp-dev"
+            )
+            (overlay / "platform-runtime-secrets.env").write_text(
+                "SHARED_KEY=actualvalue # not a comment\n",
+                encoding="utf-8",
+            )
+
+            violations = ADR_GUARD.check_no_populated_secret_env_files(
+                repo_root, None
+            )
+
+            self.assertEqual(len(violations), 1)
+            self.assertIn("SHARED_KEY", violations[0].message)
+            self.assertNotIn("actualvalue", violations[0].message)
+
+    def test_flags_non_identifier_key_with_real_value(self) -> None:
+        # Bypass regression (codex review cycle 2): a key with a dot
+        # (`db.password=...`) is a valid Kubernetes Secret data key
+        # shape. The earlier strict-identifier regex silently skipped
+        # such lines; the parser now splits on the first `=` and
+        # validates the RHS regardless of key shape.
+        sentinel = "DotKeyRealValueZ9"
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            overlay = self._make_overlay(
+                repo_root, "platform/k8s/gcp/overlays/gcp-dev"
+            )
+            (overlay / "platform-runtime-secrets.env").write_text(
+                f"db.password={sentinel}\n",
+                encoding="utf-8",
+            )
+
+            violations = ADR_GUARD.check_no_populated_secret_env_files(
+                repo_root, None
+            )
+
+            self.assertEqual(len(violations), 1)
+            self.assertEqual(violations[0].rule_id, "ADR-004-R9")
+            self.assertIn("db.password", violations[0].message)
+            self.assertNotIn(sentinel, violations[0].message)
+
+    def test_flags_hyphenated_key_with_real_value(self) -> None:
+        # Hyphenated keys are also valid Kubernetes Secret data keys.
+        sentinel = "HyphenKeyRealValueQ7"
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            overlay = self._make_overlay(
+                repo_root, "platform/k8s/gcp/overlays/gcp-dev"
+            )
+            (overlay / "platform-runtime-secrets.env").write_text(
+                f"api-token={sentinel}\n",
+                encoding="utf-8",
+            )
+
+            violations = ADR_GUARD.check_no_populated_secret_env_files(
+                repo_root, None
+            )
+
+            self.assertEqual(len(violations), 1)
+            self.assertIn("api-token", violations[0].message)
+            self.assertNotIn(sentinel, violations[0].message)
+
+    def test_flags_export_prefixed_assignment(self) -> None:
+        # `export KEY=value` is a shell-style assignment that the
+        # strict-identifier regex would skip. The parser now reports
+        # the full LHS (`export KEY`) so the bypass is closed.
+        sentinel = "ExportShellValueK3"
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            overlay = self._make_overlay(
+                repo_root, "platform/k8s/gcp/overlays/gcp-dev"
+            )
+            (overlay / "platform-runtime-secrets.env").write_text(
+                f"export DB_PASSWORD={sentinel}\n",
+                encoding="utf-8",
+            )
+
+            violations = ADR_GUARD.check_no_populated_secret_env_files(
+                repo_root, None
+            )
+
+            self.assertEqual(len(violations), 1)
+            self.assertIn("export DB_PASSWORD", violations[0].message)
+            self.assertNotIn(sentinel, violations[0].message)
+
+    def test_flags_non_assignment_line(self) -> None:
+        # A non-comment, non-blank line that does not contain `=` is a
+        # malformed shape. Flag it so a real value smuggled in as YAML
+        # / free text cannot slip past the value check.
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            overlay = self._make_overlay(
+                repo_root, "platform/k8s/gcp/overlays/gcp-dev"
+            )
+            (overlay / "platform-runtime-secrets.env").write_text(
+                "some random secret-bearing text without an equals sign\n",
+                encoding="utf-8",
+            )
+
+            violations = ADR_GUARD.check_no_populated_secret_env_files(
+                repo_root, None
+            )
+
+            self.assertEqual(len(violations), 1)
+            self.assertIn("not a comment", violations[0].message)
+            self.assertNotIn("secret-bearing", violations[0].message)
+
+    def test_passes_non_identifier_key_with_placeholder(self) -> None:
+        # The placeholder check applies regardless of key shape, so a
+        # valid Kubernetes Secret data key with a placeholder value
+        # still passes (consistency: the rule is about values, not
+        # key shapes).
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            overlay = self._make_overlay(
+                repo_root, "platform/k8s/gcp/overlays/gcp-dev"
+            )
+            (overlay / "platform-runtime-secrets.env").write_text(
+                "db.password=REPLACE_AT_DEPLOY\n"
+                "api-token=<replace-at-deploy>\n",
+                encoding="utf-8",
+            )
+
+            violations = ADR_GUARD.check_no_populated_secret_env_files(
+                repo_root, None
+            )
+
+            self.assertEqual(violations, [])
+
+    def test_flags_arbitrary_bracketed_value(self) -> None:
+        # Bypass regression (codex review cycle 3 security finding):
+        # the placeholder allowlist must be a fixed set, NOT a `<...>`
+        # pattern. A pattern would accept a real credential wrapped in
+        # angle brackets (e.g. `DB_PASSWORD=<attacker-known-password>`)
+        # and the deployment would consume those bracketed bytes as
+        # the literal Secret value.
+        sentinel = "AttackerKnownValueB7"
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            overlay = self._make_overlay(
+                repo_root, "platform/k8s/gcp/overlays/gcp-dev"
+            )
+            (overlay / "platform-runtime-secrets.env").write_text(
+                f"DB_PASSWORD=<{sentinel}>\n",
+                encoding="utf-8",
+            )
+
+            violations = ADR_GUARD.check_no_populated_secret_env_files(
+                repo_root, None
+            )
+
+            self.assertEqual(len(violations), 1)
+            self.assertEqual(violations[0].rule_id, "ADR-004-R9")
+            self.assertIn("DB_PASSWORD", violations[0].message)
+            self.assertNotIn(sentinel, violations[0].message)
+
+    def test_passes_only_explicit_bracketed_allowlist_entries(self) -> None:
+        # The explicit bracketed forms in the allowlist still pass
+        # (consistency: the allowlist is fixed but it does include the
+        # common bracketed example tokens).
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            overlay = self._make_overlay(
+                repo_root, "platform/k8s/gcp/overlays/gcp-dev"
+            )
+            (overlay / "platform-runtime-secrets.env").write_text(
+                "A=<replace-at-deploy>\n"
+                "B=<placeholder>\n"
+                "C=<PLACEHOLDER>\n"
+                "D=<example>\n"
+                "E=<change-me>\n",
+                encoding="utf-8",
+            )
+
+            violations = ADR_GUARD.check_no_populated_secret_env_files(
+                repo_root, None
+            )
+
+            self.assertEqual(violations, [])
+
+    def test_check_registered_at_ci_and_fast_levels(self) -> None:
+        self.assertIn("no-populated-secret-env-files", ADR_GUARD.CHECKS)
+        self.assertIn(
+            "no-populated-secret-env-files",
+            ADR_GUARD.CHECK_LEVELS["ci"],
+        )
+        self.assertIn(
+            "no-populated-secret-env-files",
+            ADR_GUARD.CHECK_LEVELS["fast"],
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/shifter/shifter_platform/documentation/docs/technical/dev/adr-enforcement.md
+++ b/shifter/shifter_platform/documentation/docs/technical/dev/adr-enforcement.md
@@ -290,6 +290,39 @@ The first slice intentionally stays small:
   through `git add -f`), and complements
   `no-plaintext-secrets-in-tfvars`. Enforces ADR-004-R8.
 
+- `no-populated-secret-env-files`
+  Architecture check that fails the build when a tracked
+  `*-secrets.env` file under `platform/k8s/` carries a real value on
+  any assignment. Comments (lines whose first non-whitespace
+  character is `#`), blank lines, empty assignments (`KEY=`), and a
+  small **fixed** synthetic-placeholder allowlist
+  (`REPLACE_AT_DEPLOY`, `CHANGE_ME`, `PLACEHOLDER`, `EXAMPLE`, plus
+  the matching bracketed forms `<replace-at-deploy>`, `<change-me>`,
+  `<placeholder>`, `<example>`) are allowed; anything else is
+  flagged. The bracket allowlist is an explicit fixed set rather
+  than a `<...>` pattern so a committer cannot hide a real credential
+  inside angle brackets (e.g. `DB_PASSWORD=<attacker-known-password>`).
+  The parser splits on the first `=` so non-identifier key shapes
+  (`db.password=...`, `api-token=...`, `export DB_PASSWORD=...`) are
+  still subject to the value check; inline `# ...` is **not**
+  honored as a comment (Kustomize / Docker env_file treats `#` as a
+  comment only when it is the first non-whitespace character on a
+  line); non-comment, non-blank lines without `=` are flagged as
+  malformed. Containment uses `git ls-files` so gitignored local-dev
+  files (e.g. `platform-runtime-secrets.local.env`) are intentionally
+  not scanned; a synthetic-tree test-mode fallback walks the
+  filesystem for unit tests. The roots and the synthetic-placeholder
+  allowlist are centralized in `scripts/adr_guard/adr_guard.py` so
+  adding a future overlay (e.g. `gcp-prod`) is automatic and adding
+  a new cluster tree is one entry. Failure reporting names the
+  repo-relative path and the variable name only; the rejected value
+  is never echoed. Real runtime secrets must flow in at deploy time
+  from GCP Secret Manager, a gitignored local env file, or a
+  deploy-time Kubernetes Secret. Backstops gitleaks for low-entropy
+  committed credentials it ignores and prevents reintroduction of
+  the failure mode resolved by PR #1207 (issue #1195). Enforces
+  ADR-004-R9.
+
 - `rds-pending-modifications`
   Post-`terraform apply` gate in `_shifter-platform.yml`. Reads the portal
   Terraform outputs, then calls `aws rds describe-db-instances` for each


### PR DESCRIPTION
## Summary

Bundled `initial-release` / `security` PR closing #1191 (core), #1193, and #1195. Anchored on #1191 (NGFW MCP security doc cleanup). #1193 work already shipped on `dev` via PR #1214 (closure only). #1195's plaintext-removal content fix already shipped via PR #1207; this PR adds the remaining acceptance criterion — the guardrail preventing reintroduction. Pre-push codex review: 3 cycles × 2/1/3 findings, all fix, all addressed with regression tests; user authorized push at cap-3 without cycle 4. Additional fragment ships at `changelog.d/1195.security.md`.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #1191
Closes #1193
Closes #1195

## ADR Impact

- ADR-004 (R9 added)

## Changes

- #1191 — Rewrite mcp/ngfw/SECURITY.md to describe the current `list_ngfws`-only tool surface (full return shape including KeyName). Move removed PAN-OS administration tools (run_command, show_system_info, show_routes, SSH-key retrieval, Secrets Manager access) into an explicit `## Removed administration tools` section. Tighten mcp/ngfw/tool-surface.test.js into a bidirectional guard: parses server.tool(...) registrations in all three JS string-literal forms, asserts the set equals exactly {"list_ngfws"}, asserts SECURITY.md references the guard by name and lists every live tool, asserts removed tools cannot appear before the Removed section, and fails loud on any non-literal registration so future template-literal or identifier-named tools cannot silently bypass.
- #1193 — No new code. Bandit policy already shipped on dev via PR #1214 (all 7 SAST jobs blocking, scope/owner comment in _quality.yml). Closed by this PR per user direction.
- #1195 — New `no-populated-secret-env-files` adr_guard check (ADR-004-R9) prevents reintroducing populated values into tracked *-secrets.env files under platform/k8s/. Fixed synthetic-placeholder allowlist (REPLACE_AT_DEPLOY, CHANGE_ME, PLACEHOLDER, EXAMPLE plus matching bracketed forms — explicit set, not a <...> pattern). Parser splits on first `=` so non-identifier key shapes still flow through the value check. Inline `#` is not a comment (matches Kustomize/Docker env_file). Non-`=` lines flagged as malformed. Containment via git ls-files. Violation messages name path + variable, never the value. Registered in fast + ci levels. ADR-004-R9 entry in docs/adr/index.yaml; enforcement docs updated; second fragment at changelog.d/1195.security.md.

## Test Plan

Stack-native gates (no cfg.workflow.completion_command/test_command set):

- [x] `python3 scripts/adr_guard/adr_guard.py --all --level ci` passes (now includes `no-populated-secret-env-files`).
- [x] `python3 -m unittest scripts.adr_guard.tests.test_adr_guard` 160/160.
- [x] `node --test mcp/ngfw/` 27/27.
- [x] `pre-commit run --all-files` passes.

Pre-push codex review: 3 cycles × 2/1/3 findings, all `fix`. Decision records on issue thread (cycles 1, 2, 3 + escalation summary). User authorized push at cap-3 without cycle 4.

## Ground Control Checks

- [x] `make policy` passes
- [x] Repository guardrails pass (changelog fragments, ADR enforcement docs, ADR-004-R9 registered in fast + ci levels)

## Traceability

- IMPLEMENTS: #1191 ← mcp/ngfw/SECURITY.md (Current tool surface + Removed administration tools sections) + mcp/ngfw/tool-surface.test.js (bidirectional surface guard), #1193 ← (no new code — implementation shipped in #1214 on dev), #1195 ← scripts/adr_guard/adr_guard.py::check_no_populated_secret_env_files + docs/adr/index.yaml (ADR-004-R9) + adr-enforcement.md
- TESTS: #1191 ← mcp/ngfw/tool-surface.test.js (6 tests covering surface set equality, three-quote-form coverage, removed-tool absence, doc/test bidirectional reference, removed-tools-section invariant, non-literal-registration guard), #1195 ← scripts/adr_guard/tests/test_adr_guard.py::NoPopulatedSecretEnvFilesTests (19 tests covering comments-only, empty assignment, synthetic placeholders, populated assignment flagged without value echo, path-allowlist containment, basename pattern filter, files-arg scoping, partial-violation reporting, level registration, three bypass regressions for inline `#`, three for non-identifier keys, and two for the fixed bracket allowlist)

## Checklist

- [x] Code follows project coding standards
- [x] Changelog fragments added at `changelog.d/1191.changed.md` and `changelog.d/1195.security.md`
- [x] Architectural docs updated (`docs/adr/index.yaml` ADR-004-R9, `shifter/shifter_platform/documentation/docs/technical/dev/adr-enforcement.md`)
