### PR TITLE
feat(mcp/ops): tool-surface invariant tests for ADR-014-R3/R5/R6

### DIFF
--- a/changelog.d/1202.security.md
+++ b/changelog.d/1202.security.md
@@ -1,0 +1,40 @@
+Add Phase 6 negative-surface tests for `mcp/ops` at
+`mcp/ops/tool-surface.test.js` (per parent issue #777). The suite is
+the load-bearing ADR-014-R3 / R5 / R6 invariant for this server: it
+exercises the live registration path — real `.shifter.yaml`, real
+`loadPolicy`, real `registerTool` — against a fake server and asserts:
+
+- Profile gating actually removes tools from the registered set
+  (`read_only` / `standard` / `destructive`); a disabled class
+  produces no `server.tool(...)` call at all (not "registered but
+  refused").
+- Two-phase classes (`infra_mutation`, `ssm_arbitrary`,
+  `db_arbitrary`) register `plan_<name>` / `execute_<name>` pairs
+  only; the direct `<name>` is absent. `execute_<name>` without a
+  `plan_id` arg throws `PolicyError`.
+- `class_defaults.secret_handle.return_mode = "handle"` is enforced
+  by the live policy (the ADR-014-R5 structural invariant);
+  `get_secret` is the only `secret_handle` registration on the
+  surface (`list_secrets` is correctly `observability`).
+- Prod-touching tools refuse without `confirm_env="prod"` (gate
+  applies class-wide, not tool-specific).
+- `dev_bypass_tunnel` descriptions are replaced with the
+  `policy.js` `REDACTED_DESCRIPTION` constant verbatim; the
+  defense-in-depth scan also checks for `/dev-login/`, `bypass`,
+  `Cognito`, and `MFA` substrings.
+- Consumer tools (`plan_query`, `plan_execute`,
+  `plan_ssm_send_command`) refuse fenced input unless
+  `acknowledge_untrusted_input: true` is set; the registered schema
+  exposes the control field.
+- Every `apex_operations[*].tool` rule in `.shifter.yaml` points at a
+  registered `execute_<name>`; `validateApexCoverage` is the
+  load-bearing gate, called from `registerAllOpsTools(ctx)`'s last
+  step.
+
+`mcp/ops/index.js` gains a narrow seam for this: the
+`registerTool(ctx, {...})` block + `validateApexCoverage(policy)`
+move into an exported `registerAllOpsTools(ctx)` function, and
+`new McpServer` / `loadPolicy` / `await server.connect(...)` move
+behind an `async main()` guarded by
+`if (import.meta.url === pathToFileURL(process.argv[1]).href)`.
+Live behavior when run as `node mcp/ops/index.js` is unchanged.

--- a/docs/architecture/mcp-ops-privileged-surface-preflight-777.md
+++ b/docs/architecture/mcp-ops-privileged-surface-preflight-777.md
@@ -411,6 +411,60 @@ audit writer, alternate policy file, or local class enum in
 `index.js`, and the shared helpers in `mcp/ops/lib.js` /
 `mcp/shared/aws-helpers.js`.
 
+## Phase 6 Preflight (#1202)
+
+Phase 6 adds negative-surface tests, not another policy engine. The
+test file should exercise the live registration seam the same way an
+MCP client sees it: instantiate a fake server, load the real
+`.shifter.yaml` through `loadPolicy`, register the real `mcp/ops`
+descriptors through `registerTool`, and inspect the resulting tool
+set, descriptions, schemas, and wrapped handlers. The test must not
+derive expected behavior by copying private policy helpers or by
+parsing `index.js` as a substitute for registration.
+
+The canonical precedent is `mcp/ngfw/tool-surface.test.js`: keep an
+explicit, reviewable expected surface and fail loudly when tools are
+added, removed, or registered through a shape the test cannot
+enumerate. For `mcp/ops`, the expected surface is profile-sensitive:
+`read_only`, `standard`, and `destructive` must each be built from the
+same real descriptors and policy file so profile gating proves tools
+are actually absent from the registered set, not merely disabled at
+call time.
+
+The load-bearing assertions are the ADR-014-R3 / R5 / R6 invariants:
+
+- `read_only`, `standard`, and `destructive` profiles expose only the
+  classes declared for that profile in `.shifter.yaml`; two-phase
+  classes register `plan_<name>` / `execute_<name>` pairs rather than
+  direct mutating tools.
+- `infra_mutation`, `ssm_arbitrary`, and `db_arbitrary` operations
+  cannot execute from a missing flag path. The dry-run/default
+  contract is now the two-phase `plan_` / `execute_` wrapper, so tests
+  should prove direct original tool names are absent and execution
+  requires a valid `plan_id`.
+- `secret_handle` tools never return raw secret bytes on successful
+  response paths. Error paths may pass through `isError`, but must not
+  introduce raw secret values.
+- Prod-touching calls refuse unless the caller supplies
+  `confirm_env="prod"`.
+- `dev_bypass_tunnel` descriptions visible through registration are
+  redacted: no `/dev-login/` URLs and no bypass procedure language.
+- Consumer tools with `untrusted_inputs` refuse fenced input unless
+  `acknowledge_untrusted_input: true`; producer tools fence every text
+  response with an allowlisted source label from `.shifter.yaml`.
+- Apex-covered tools require terminal confirmation via the existing
+  stderr token + `approve` flow; tests should drive or time-box the
+  wrapper without leaking the token into MCP responses or audit
+  records.
+
+Keep the test harness narrow. If `index.js` cannot expose descriptor
+registration without starting stdio transport or real AWS/database
+side effects, add the smallest descriptor-registration seam needed
+inside `mcp/ops/index.js` and keep `policy.js` as the only gate
+composition layer. Do not introduce duplicate capability maps,
+duplicate Zod schemas, duplicate audit sanitizers, or a test-only
+policy parser.
+
 ## Gotchas
 
 - A capability class tag is required for every registered tool. The

--- a/mcp/ops/SECURITY.md
+++ b/mcp/ops/SECURITY.md
@@ -24,8 +24,8 @@ capabilities of the agent.
 ## Implementation status
 
 This document describes the **target policy layer**, which has now
-landed across issue #777 + sub-issues #1198–#1201 (Phase 6 / #1202 is
-still pending). Today's runtime status:
+landed across issue #777 + sub-issues #1198–#1202. Today's runtime
+status:
 
 - `.shifter.yaml` exists at the repo root and `mcp/ops/policy.js`
   provides `parsePolicy`, `loadPolicy`, the `Policy` class, the
@@ -57,9 +57,12 @@ still pending). Today's runtime status:
   default `standard` profile excludes the destructive classes, so
   operators that need them must set
   `SHIFTER_OPS_PROFILE=destructive` at server startup.
-- `mcp/ops/tool-surface.test.js` (the load-bearing
-  ADR-014-R3 / R5 invariant suite referenced below) is still Phase 6
-  (#1202) and **does not yet exist**.
+- Phase 6 (#1202) added `mcp/ops/tool-surface.test.js`, the
+  load-bearing ADR-014-R3 / R5 / R6 negative-surface suite referenced
+  below. Tools register through an exported `registerAllOpsTools(ctx)`
+  seam on `mcp/ops/index.js` so the surface tests can drive the live
+  registration path (real `.shifter.yaml`, real `loadPolicy`, real
+  `registerTool`) against a fake server without opening stdio.
 
 The rest of this document describes the policy layer as it stands
 today on the live server.
@@ -246,33 +249,43 @@ These describe the target policy layer; today only the seam exists.
 
 ## Regression coverage
 
-Current (this PR, #777):
+The shipped policy layer is covered by four test files in this
+package; all are live in the current tree.
 
 - `mcp/ops/spawn-roundtrip.test.js` proves that Node's `spawnSync`
   forwards argv elements byte-for-byte across the boundary. (Shared
-  across MCP servers via `mcp/shared/aws-helpers.js`.) Unchanged.
+  across MCP servers via `mcp/shared/aws-helpers.js`.)
 - `mcp/ops/lib.test.js` covers AWS argv builders for individual call
   sites — CloudWatch filters, SSM command parameters,
-  management-command SSM payloads, S3 bucket/key inputs. Unchanged.
-- `mcp/ops/policy.test.js` covers the **current** scope of the policy
-  wrapper: `parsePolicy` shape validation (top-level keys,
-  class-defaults coverage per declared class, profile membership,
-  version, env block), `loadPolicy` parsing the real `.shifter.yaml`,
-  the `Policy` class lookups (`classDeclared`, `classEnabled`,
-  `classDefaults`, `envDefault`, `envProdRequiresConfirm`), and
+  management-command SSM payloads, S3 bucket/key inputs.
+- `mcp/ops/policy.test.js` covers the policy wrapper end-to-end:
+  `parsePolicy` shape validation (top-level keys, class-defaults
+  coverage per declared class, profile membership, version, env
+  block); `loadPolicy` parsing the real `.shifter.yaml`; the
+  `Policy` class lookups (`classDeclared`, `classEnabled`,
+  `classDefaults`, `envDefault`, `envProdRequiresConfirm`);
   `registerTool`'s class-tag + profile gating (class-disabled tools
-  are not registered; missing / undeclared classes fail closed).
-
-Target (added by sub-issues):
-
-- `mcp/ops/policy.test.js` extended in #1198–#1200 to cover env
-  policy, dry-run gating, idempotency, rate caps, audit append,
-  secret-handle return mode, two-phase plan→execute, untrusted-input
-  fencing, description redaction. Those gates do not yet exist in
-  this PR.
+  are not registered; missing / undeclared classes fail closed); and
+  the per-gate behavior added by #1198–#1200 — env policy, dry-run
+  defaults, idempotency keys + retry caching, per-class rate caps,
+  audit append, secret-handle return mode, two-phase
+  `plan_<name>` / `execute_<name>` exchange, untrusted-input fencing
+  (producer/consumer), description redaction, and apex out-of-band
+  approval (stderr-only token, single-use consume, 60s timeout).
 - `mcp/ops/tool-surface.test.js` (added by #1202) is the
-  load-bearing surface invariant for ADR-014-R3 / R5 on this server:
-  every capability class behaves as policy declares; profile gating
-  actually removes tools from the registry; `dev_bypass_tunnel`
-  descriptions do not contain bypass procedures. The file does not
-  yet exist in this PR.
+  load-bearing surface invariant for ADR-014-R3 / R5 / R6 on this
+  server: profile gating removes tools from the registered set
+  (read_only / standard / destructive); two-phase classes
+  (`infra_mutation` / `ssm_arbitrary` / `db_arbitrary`) register
+  `plan_<name>` / `execute_<name>` pairs only — the direct name is
+  absent; `secret_handle` class defaults pin `return_mode: handle`
+  in the live policy; prod-touching tools refuse without
+  `confirm_env="prod"`; `dev_bypass_tunnel` descriptions are
+  replaced with the redacted constant; consumer tools refuse fenced
+  input without `acknowledge_untrusted_input: true`; every
+  `apex_operations[*].tool` rule in `.shifter.yaml` points at a live
+  registered `execute_<name>` (`validateApexCoverage` is the load-
+  bearing gate). The behavioral apex flow (stderr-only token, 60s
+  parking, `consumeApexToken` release) is unit-tested in
+  `mcp/ops/policy.test.js`; the surface test asserts only the
+  structural invariants that an MCP client sees.

--- a/mcp/ops/index.js
+++ b/mcp/ops/index.js
@@ -7,7 +7,7 @@ import { spawn } from "child_process";
 import pg from "pg";
 import net from "net";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import {
   REGION,
   LOCAL_PORTS,
@@ -333,36 +333,38 @@ function cleanup() {
   }
 }
 
-process.on("SIGTERM", () => {
-  cleanup();
-  process.exit(0);
-});
-process.on("SIGINT", () => {
-  cleanup();
-  process.exit(0);
-});
-process.on("exit", cleanup);
+// Signal handlers are installed inside `main()` (codex review #1202
+// cycle 1 finding 1). Module-level registration would fire on import,
+// adding `process.exit(0)`-ing handlers and ops cleanup to any host
+// process that merely imported `registerAllOpsTools` (e.g. the
+// surface tests, or future tooling) — and that contradicts the
+// side-effect-free import contract the seam exists to provide.
+function installLiveProcessHandlers() {
+  process.on("SIGTERM", () => {
+    cleanup();
+    process.exit(0);
+  });
+  process.on("SIGINT", () => {
+    cleanup();
+    process.exit(0);
+  });
+  process.on("exit", cleanup);
+}
 
 // ==========================================================================
 // MCP Server
+//
+// Phase 6 (#1202): the descriptor-registration block lives inside the
+// exported `registerAllOpsTools(ctx)` so `mcp/ops/tool-surface.test.js`
+// can drive registration against a fake server + real `.shifter.yaml`
+// without opening stdio. The live `main()` below builds the real
+// server, loads policy, calls `registerAllOpsTools`, and connects the
+// transport; the entrypoint guard at the bottom ensures importing this
+// module from a test is side-effect-free.
 // ==========================================================================
 
-const server = new McpServer({ name: "shifter-ops", version: "1.0.0" });
-
-// Phase 5 (#1201): load .shifter.yaml at startup. The active profile
-// is `SHIFTER_OPS_PROFILE` (read once here; runtime profile flips
-// would be a confused-deputy surface). A missing or malformed
-// `.shifter.yaml` throws and the server exits before any tool is
-// registered — fail closed is the only correct path.
-const _HERE = path.dirname(fileURLToPath(import.meta.url));
-const _REPO_ROOT = path.resolve(_HERE, "..", "..");
-const policy = loadPolicy({
-  path: path.join(_REPO_ROOT, ".shifter.yaml"),
-  profile: profileFromEnv(process.env),
-});
-const ctx = { server, policy };
-
-// `approve` is the operator-confirmation MCP tool. The agent reads
+export function registerAllOpsTools(ctx) {
+  // `approve` is the operator-confirmation MCP tool. The agent reads
 // the token off the operator's terminal (which the server printed to
 // stderr just before an apex operation parked) and calls this tool
 // with it. Registered as `observability` so every profile sees it —
@@ -3033,16 +3035,43 @@ registerTool(ctx, {
   },
 });
 
+  // Codex review #1201 cycle 1 finding 4: every `apex_operations[*].tool`
+  // rule in .shifter.yaml must point at a descriptor that actually
+  // reached registerTool. Run this AFTER every registerTool call so a
+  // typo in .shifter.yaml fails startup rather than silently disabling
+  // the intended apex gate.
+  validateApexCoverage(ctx.policy);
+}
+
 // ==========================================================================
 // Start server
 // ==========================================================================
 
-// Codex review #1201 cycle 1 finding 4: every `apex_operations[*].tool`
-// rule in .shifter.yaml must point at a descriptor that actually
-// reached registerTool. Run this AFTER every registerTool call so a
-// typo in .shifter.yaml fails startup rather than silently disabling
-// the intended apex gate.
-validateApexCoverage(policy);
+// Phase 5 (#1201): load .shifter.yaml at startup. The active profile
+// is `SHIFTER_OPS_PROFILE` (read once here; runtime profile flips
+// would be a confused-deputy surface). A missing or malformed
+// `.shifter.yaml` throws and the server exits before any tool is
+// registered — fail closed is the only correct path.
+async function main() {
+  installLiveProcessHandlers();
+  const _HERE = path.dirname(fileURLToPath(import.meta.url));
+  const _REPO_ROOT = path.resolve(_HERE, "..", "..");
+  const server = new McpServer({ name: "shifter-ops", version: "1.0.0" });
+  const policy = loadPolicy({
+    path: path.join(_REPO_ROOT, ".shifter.yaml"),
+    profile: profileFromEnv(process.env),
+  });
+  registerAllOpsTools({ server, policy });
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
 
-const transport = new StdioServerTransport();
-await server.connect(transport);
+// Codex review #1202 cycle 1 finding 2: `process.argv[1]` is undefined
+// in valid Node import contexts (e.g. `node --input-type=module -e
+// "import('./mcp/ops/index.js')"`, embedded runners, repl programmatic
+// loads). Guard the conversion so merely importing this module never
+// throws before the caller can use the exported registration seam.
+const _entrypointArg = process.argv[1];
+if (_entrypointArg && import.meta.url === pathToFileURL(_entrypointArg).href) {
+  await main();
+}

--- a/mcp/ops/policy.js
+++ b/mcp/ops/policy.js
@@ -1552,6 +1552,22 @@ export function registerTool(ctx, descriptor) {
   // the active subset.
   registeredDescriptorNames.add(name);
 
+  // Phase 6 (#1202) optional inspection hook for surface tests. Codex
+  // review #1202 cycle 3 finding 2: surface-suite assertions on
+  // descriptor metadata (the `klass`, `untrusted_source`,
+  // `sensitive_args`, `is_write` fields that decide which wrapper
+  // gates compose around the handler) can't be made from
+  // `server.tool(name, description, schema, handler)` alone — that
+  // signature carries only the wrapped artifacts. Production callers
+  // (`mcp/ops/index.js::main()` and its `McpServer` ctx) do not set
+  // this callback, so the live server is unchanged. Tests set it on
+  // the FakeServer ctx to capture descriptor metadata post-validation
+  // / pre-gate-composition, without copying capability maps or
+  // re-parsing index.js.
+  if (typeof ctx.onRegisterDescriptor === "function") {
+    ctx.onRegisterDescriptor(descriptor);
+  }
+
   // Codex review #1201 cycle 3 finding 3: under Phase 3 the dry-run
   // gate is gone — execution-default is enforced only via the
   // two-phase plan_/execute_ pair. A resolved tool policy of

--- a/mcp/ops/policy.js
+++ b/mcp/ops/policy.js
@@ -1563,10 +1563,10 @@ export function registerTool(ctx, descriptor) {
   // this callback, so the live server is unchanged. Tests set it on
   // the FakeServer ctx to capture descriptor metadata post-validation
   // / pre-gate-composition, without copying capability maps or
-  // re-parsing index.js.
-  if (typeof ctx.onRegisterDescriptor === "function") {
-    ctx.onRegisterDescriptor(descriptor);
-  }
+  // re-parsing index.js. Written as optional-chained invocation so
+  // the SonarCloud cognitive-complexity gate stays under threshold
+  // (S3776: optional chaining is a single expression, not a branch).
+  ctx.onRegisterDescriptor?.(descriptor);
 
   // Codex review #1201 cycle 3 finding 3: under Phase 3 the dry-run
   // gate is gone — execution-default is enforced only via the

--- a/mcp/ops/tool-surface.test.js
+++ b/mcp/ops/tool-surface.test.js
@@ -567,20 +567,45 @@ describe("dev_bypass_tunnel descriptions are redacted", () => {
 // =====================================================================
 
 describe("untrusted-input fencing + acknowledge flag", () => {
-  it("plan_query rejects fenced SQL without acknowledge_untrusted_input", async () => {
-    const { server } = buildSurface("destructive");
-    const entry = server.byName("plan_query");
-    await assert.rejects(
-      () =>
-        entry.handler({
-          env: "dev",
-          sql: "[UNTRUSTED:logs:BEGIN]select 1[UNTRUSTED:logs:END]",
-        }),
-      (err) =>
-        err instanceof PolicyError &&
-        /contains an untrusted-input fence/.test(err.message),
-    );
-  });
+  // Parameterized rejection table: each entry exercises one consumer
+  // descriptor's `untrusted_inputs` field. Consolidated from three
+  // near-identical `it()` blocks (SonarCloud cycle 1, duplicated-
+  // lines-density gate); the loop still produces three independently
+  // reported subtests via `it.test.each`-equivalent `for`-then-`it`
+  // pattern (node:test exposes each `it` line as its own report row).
+  const CONSUMER_REJECTION_CASES = [
+    {
+      tool: "plan_query",
+      field: "sql",
+      extra: {},
+      fence: "[UNTRUSTED:logs:BEGIN]select 1[UNTRUSTED:logs:END]",
+    },
+    {
+      tool: "plan_execute",
+      field: "sql",
+      extra: {},
+      fence: "[UNTRUSTED:logs:BEGIN]update foo set a=1[UNTRUSTED:logs:END]",
+    },
+    {
+      tool: "plan_ssm_send_command",
+      field: "command",
+      extra: { instance_id: "i-0123456789abcdef0" },
+      fence: "[UNTRUSTED:logs:BEGIN]uname -a[UNTRUSTED:logs:END]",
+    },
+  ];
+
+  for (const c of CONSUMER_REJECTION_CASES) {
+    it(`${c.tool} rejects fenced ${c.field} without acknowledge_untrusted_input`, async () => {
+      const { server } = buildSurface("destructive");
+      const entry = server.byName(c.tool);
+      await assert.rejects(
+        () => entry.handler({ env: "dev", ...c.extra, [c.field]: c.fence }),
+        (err) =>
+          err instanceof PolicyError &&
+          /contains an untrusted-input fence/.test(err.message),
+      );
+    });
+  }
 
   it("plan_query accepts fenced SQL when acknowledge_untrusted_input is true", async () => {
     const { server } = buildSurface("destructive");
@@ -592,37 +617,6 @@ describe("untrusted-input fencing + acknowledge flag", () => {
     });
     const payload = JSON.parse(result.content[0].text);
     assert.equal(payload.summary.tool, "query");
-  });
-
-  it("plan_execute rejects fenced SQL without acknowledge_untrusted_input", async () => {
-    const { server } = buildSurface("destructive");
-    const entry = server.byName("plan_execute");
-    await assert.rejects(
-      () =>
-        entry.handler({
-          env: "dev",
-          sql: "[UNTRUSTED:logs:BEGIN]update foo set a=1[UNTRUSTED:logs:END]",
-        }),
-      (err) =>
-        err instanceof PolicyError &&
-        /contains an untrusted-input fence/.test(err.message),
-    );
-  });
-
-  it("plan_ssm_send_command rejects fenced command without acknowledge_untrusted_input", async () => {
-    const { server } = buildSurface("destructive");
-    const entry = server.byName("plan_ssm_send_command");
-    await assert.rejects(
-      () =>
-        entry.handler({
-          env: "dev",
-          instance_id: "i-0123456789abcdef0",
-          command: "[UNTRUSTED:logs:BEGIN]uname -a[UNTRUSTED:logs:END]",
-        }),
-      (err) =>
-        err instanceof PolicyError &&
-        /contains an untrusted-input fence/.test(err.message),
-    );
   });
 
   it("consumer descriptors expose acknowledge_untrusted_input on the registered schema", () => {

--- a/mcp/ops/tool-surface.test.js
+++ b/mcp/ops/tool-surface.test.js
@@ -1,0 +1,822 @@
+// ADR-014-R3 / R5 / R6 negative-surface tests for the mcp/ops MCP
+// server. The contract here is "exercise the live registration seam
+// the way an MCP client sees it": instantiate a FakeServer, load the
+// real `.shifter.yaml` via `loadPolicy`, register the real `mcp/ops`
+// descriptors through the real `registerTool`, then inspect the
+// resulting tool set, descriptions, schemas, and wrapped handlers.
+//
+// The test deliberately does NOT parse `index.js` as text or copy
+// private policy helpers — that would let a future refactor silently
+// diverge the test from the live behavior. The expected surface is
+// hardcoded per profile so adding or removing a tool requires updating
+// EXPECTED_<PROFILE> in this file (the same maintenance contract as
+// `mcp/ngfw/tool-surface.test.js`).
+//
+// See `docs/architecture/mcp-ops-privileged-surface-preflight-777.md`
+// § "Phase 6 Preflight (#1202)" for the architecture rationale.
+
+import { after, before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import yaml from "yaml";
+
+import {
+  loadPolicy,
+  PolicyError,
+  consumeApexToken,
+  _resetGateCachesForTests,
+} from "./policy.js";
+import { registerAllOpsTools } from "./index.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+const LIVE_POLICY_PATH = path.join(REPO_ROOT, ".shifter.yaml");
+
+// Codex review #1202 cycle 2 finding 1 (class) and cycle 3 finding 1
+// (one-off): the wrapped handlers the surface tests invoke all call
+// `appendAuditRecord` — including refusal paths — and the LIVE
+// `.shifter.yaml`'s `audit.path` points at `~/.shifter-ops-audit.jsonl`.
+// Running the test against that path would (a) make the suite
+// non-hermetic and (b) inject synthetic entries into the operator's
+// real ops audit history. The fix preserves the "real `.shifter.yaml`
+// through loadPolicy" contract by reading the live file, parsing it,
+// overriding ONLY `mcp_ops.audit.path` to a per-process temp file,
+// re-serializing it as YAML to a temp file, and then calling the real
+// `loadPolicy({path, profile})` against the temp file. This exercises
+// the same startup path `main()` uses; if `loadPolicy` later changes
+// config discovery / namespace extraction / startup failure behavior,
+// the surface suite is still covering it.
+let TMP_DIR = null;
+let TMP_AUDIT_PATH = null;
+let TMP_POLICY_PATH = null;
+
+before(() => {
+  // Hold the temp dir under the test file's parent (not /tmp) to
+  // sidestep SonarCloud S5443 and keep the path predictable for
+  // post-mortem inspection if a test ever fails.
+  TMP_DIR = mkdtempSync(path.join(__dirname, ".surface-test-"));
+  TMP_AUDIT_PATH = path.join(TMP_DIR, "audit.jsonl");
+  TMP_POLICY_PATH = path.join(TMP_DIR, "shifter.yaml");
+  const doc = yaml.parse(readFileSync(LIVE_POLICY_PATH, "utf-8"));
+  doc.mcp_ops.audit.path = TMP_AUDIT_PATH;
+  writeFileSync(TMP_POLICY_PATH, yaml.stringify(doc));
+});
+
+after(() => {
+  if (TMP_DIR) {
+    rmSync(TMP_DIR, { recursive: true, force: true });
+  }
+});
+
+// The redacted-description constant lives in `policy.js` and is the
+// strict equality target asserted by the dev_bypass_tunnel test below.
+// Asserting equality (rather than "does not contain /dev-login/") is
+// the stronger invariant: it proves the entire raw description was
+// replaced, not phrase-stripped.
+const REDACTED_DESCRIPTION =
+  "[description redacted per ADR-014-R6 — operator agent tool]";
+
+// FakeServer mirrors the SDK's `server.tool(name, description, schema,
+// handler)` shape so `registerTool` records the wrapped handler that
+// would otherwise be handed to an MCP client. Kept structurally
+// identical to the FakeServer in `policy.test.js`; not imported to
+// preserve the parallel-duplication precedent set by the NGFW surface
+// test.
+class FakeServer {
+  constructor() {
+    this.registered = [];
+  }
+  tool(name, description, schema, handler) {
+    this.registered.push({ name, description, schema, handler });
+  }
+  names() {
+    return new Set(this.registered.map((r) => r.name));
+  }
+  byName(name) {
+    return this.registered.find((r) => r.name === name);
+  }
+}
+
+function buildSurface(profile) {
+  // `_resetGateCachesForTests` clears the module-level
+  // `registeredDescriptorNames` set so successive `buildSurface(...)`
+  // calls under different profiles don't accumulate state. Without
+  // this, `validateApexCoverage` would still pass — it checks set
+  // membership, not equality — but the test would be implicitly
+  // relying on a side effect of a previous run.
+  _resetGateCachesForTests();
+  // Real `.shifter.yaml` content (with the audit-path override
+  // applied at module-level `before`) goes through the real
+  // `loadPolicy`, so the surface suite covers the same startup path
+  // `main()` uses.
+  const policy = loadPolicy({ path: TMP_POLICY_PATH, profile });
+  const server = new FakeServer();
+  // Codex review #1202 cycle 3 finding 2 (class): capture descriptor
+  // metadata through the `onRegisterDescriptor` hook on `policy.js`'s
+  // `registerTool`. Production server context never sets this
+  // callback (no live behavior change); tests use it to assert
+  // `klass`, `untrusted_source`, `sensitive_args`, `is_write` on the
+  // LIVE descriptors — the metadata the wrapper actually composes
+  // gates from. Without this, "tool name X is registered under
+  // profile Y" passes even when the descriptor's class was silently
+  // changed to a different class in the same profile (which would
+  // skip the secret_handle wrap, the producer fence, etc.).
+  const descriptors = [];
+  registerAllOpsTools({
+    server,
+    policy,
+    onRegisterDescriptor: (d) => descriptors.push(d),
+  });
+  return { server, policy, descriptors };
+}
+
+// --- Hardcoded expected surface per profile ----------------------------
+//
+// Adding or removing a `registerTool(ctx, {...})` call in `index.js`
+// MUST be accompanied by an edit here. That is the entire point of
+// this file.
+
+const EXPECTED_OBSERVABILITY_TOOLS = [
+  "approve",
+  "describe_log_streams",
+  "get_log_events",
+  "filter_log_events",
+  "tail_logs",
+  "list_ec2_instances",
+  "list_ecs_tasks",
+  "describe_ecs_service",
+  "list_secrets",
+  "describe_asg",
+  "describe_target_health",
+  "risk_dashboard",
+  "risk_matrix",
+  "list_s3_buckets",
+  "list_s3_objects",
+  "get_s3_object",
+  "terraform_state",
+  "cost_summary",
+  "daily_spend",
+];
+
+const EXPECTED_NAMED_DB_READ_TOOLS = [
+  "list_risks",
+  "get_risk",
+  "risk_audit_log",
+  "list_ranges",
+  "get_range",
+  "list_subnet_allocations",
+];
+
+const EXPECTED_NAMED_DB_WRITE_TOOLS = [
+  "create_risk",
+  "update_risk",
+  "delete_risk",
+  "restore_risk",
+  "add_risk_comment",
+  "delete_risk_comment",
+];
+
+const EXPECTED_SECRET_HANDLE_TOOLS = ["get_secret"];
+const EXPECTED_SSM_NAMED_TOOLS = ["run_manage_command"];
+
+// Two-phase classes: every descriptor of these classes is registered
+// as a `plan_<name>` / `execute_<name>` PAIR; the direct `<name>` does
+// NOT appear in the surface.
+const TWO_PHASE_SSM_ARBITRARY_BASES = [
+  "ssm_send_command",
+  "ssm_get_command_output",
+];
+const TWO_PHASE_DB_ARBITRARY_BASES = [
+  "list_tables",
+  "describe_table",
+  "query",
+  "execute",
+];
+const TWO_PHASE_INFRA_MUTATION_BASES = [
+  "start_ec2_instance",
+  "stop_ec2_instance",
+  "terminate_ec2_instance",
+  "restart_ecs_service",
+  "reconcile_ranges",
+];
+
+const EXPECTED_DEV_BYPASS_TUNNEL_TOOLS = [
+  "start_portal_test_tunnel",
+  "stop_portal_test_tunnel",
+];
+
+// Codex review #1202 cycle 3 finding 2 (class): the descriptor metadata
+// the wrapper actually composes gates from. Adding / changing /
+// removing a producer's `untrusted_source`, a consumer's
+// `untrusted_inputs`, `approve`'s `sensitive_args`, or `execute`'s
+// `is_write` must update this file; the assertions below pull the
+// matching descriptor out of the captured-descriptor list and check
+// equality, so a regression that silently drops `untrusted_source`
+// on `tail_logs` (which would skip producer fencing on log bodies)
+// fails the suite.
+const EXPECTED_PRODUCER_LABELS = {
+  get_log_events: "logs",
+  filter_log_events: "logs",
+  tail_logs: "logs",
+  ssm_get_command_output: "ssm_stdout",
+  list_s3_objects: "s3",
+  get_s3_object: "s3",
+  terraform_state: "s3",
+};
+
+const EXPECTED_CONSUMER_INPUTS = {
+  ssm_send_command: ["command"],
+  query: ["sql"],
+  execute: ["sql"],
+  run_manage_command: ["command"],
+};
+
+function twoPhasePairs(bases) {
+  return bases.flatMap((b) => [`plan_${b}`, `execute_${b}`]);
+}
+
+const EXPECTED_READ_ONLY = new Set([
+  ...EXPECTED_OBSERVABILITY_TOOLS,
+  ...EXPECTED_NAMED_DB_READ_TOOLS,
+]);
+
+const EXPECTED_STANDARD = new Set([
+  ...EXPECTED_READ_ONLY,
+  ...EXPECTED_NAMED_DB_WRITE_TOOLS,
+  ...EXPECTED_SECRET_HANDLE_TOOLS,
+  ...EXPECTED_SSM_NAMED_TOOLS,
+]);
+
+const EXPECTED_DESTRUCTIVE = new Set([
+  ...EXPECTED_STANDARD,
+  ...twoPhasePairs(TWO_PHASE_SSM_ARBITRARY_BASES),
+  ...twoPhasePairs(TWO_PHASE_DB_ARBITRARY_BASES),
+  ...twoPhasePairs(TWO_PHASE_INFRA_MUTATION_BASES),
+  ...EXPECTED_DEV_BYPASS_TUNNEL_TOOLS,
+]);
+
+const ALL_TWO_PHASE_BASES = [
+  ...TWO_PHASE_SSM_ARBITRARY_BASES,
+  ...TWO_PHASE_DB_ARBITRARY_BASES,
+  ...TWO_PHASE_INFRA_MUTATION_BASES,
+];
+
+// =====================================================================
+// Scope bullet 1: Profile gating actually removes tools from the
+// registered set (`read_only`, `standard`, `destructive`).
+// =====================================================================
+
+describe("mcp/ops profile gating removes tools from the registered set", () => {
+  it("read_only profile exposes only observability + named_db_read tools", () => {
+    const { server } = buildSurface("read_only");
+    assert.deepStrictEqual(
+      server.names(),
+      EXPECTED_READ_ONLY,
+      "read_only registration mismatch — update EXPECTED_READ_ONLY in this file AND the corresponding `registerTool` block in mcp/ops/index.js.",
+    );
+  });
+
+  it("standard profile additionally exposes named_db_write, secret_handle, ssm_named", () => {
+    const { server } = buildSurface("standard");
+    assert.deepStrictEqual(
+      server.names(),
+      EXPECTED_STANDARD,
+      "standard registration mismatch — update EXPECTED_STANDARD in this file.",
+    );
+  });
+
+  it("destructive profile exposes every class, two-phase ones as plan_/execute_ pairs", () => {
+    const { server } = buildSurface("destructive");
+    assert.deepStrictEqual(
+      server.names(),
+      EXPECTED_DESTRUCTIVE,
+      "destructive registration mismatch — update EXPECTED_DESTRUCTIVE in this file.",
+    );
+  });
+
+  it("class-gated tools are ABSENT (not registered) when the profile excludes their class", () => {
+    // The strong invariant: a disabled class produces NO `server.tool`
+    // call. A "registered-but-refused-at-call-time" implementation
+    // would let the tool name leak through `list_tools` and into the
+    // LLM's tool catalog. Read_only must not expose any destructive
+    // surface at all — assert the absence of every higher-class tool
+    // name, including both direct names and the two-phase pairs.
+    const { server } = buildSurface("read_only");
+    const names = server.names();
+    const forbidden = [
+      ...EXPECTED_NAMED_DB_WRITE_TOOLS,
+      ...EXPECTED_SECRET_HANDLE_TOOLS,
+      ...EXPECTED_SSM_NAMED_TOOLS,
+      ...EXPECTED_DEV_BYPASS_TUNNEL_TOOLS,
+      ...ALL_TWO_PHASE_BASES,
+      ...twoPhasePairs(ALL_TWO_PHASE_BASES),
+    ];
+    for (const name of forbidden) {
+      assert.ok(
+        !names.has(name),
+        `read_only must NOT register \`${name}\`; profile gating removes it from the registered set.`,
+      );
+    }
+  });
+});
+
+// =====================================================================
+// Scope bullet 2: infra_mutation / ssm_arbitrary / db_arbitrary tools
+// cannot bypass dry-run via missing flag.
+//
+// Class default `two_phase: true` (enforced as an ADR-014-R5 invariant
+// by `_assertAdr014Invariants` in policy.js) means the original direct
+// tool name is NEVER registered — only the `plan_<name>` /
+// `execute_<name>` pair. Calling `execute_<name>` without a `plan_id`
+// throws PolicyError (the `plan_id` argument is required is the
+// structural gate).
+// =====================================================================
+
+describe("two-phase classes cannot execute via a missing-flag path", () => {
+  it("direct tool names for infra_mutation / ssm_arbitrary / db_arbitrary are NEVER registered under destructive", () => {
+    const { server } = buildSurface("destructive");
+    const names = server.names();
+    for (const base of ALL_TWO_PHASE_BASES) {
+      assert.ok(
+        !names.has(base),
+        `Two-phase tool \`${base}\` must NOT register a direct entry under destructive; only \`plan_${base}\` + \`execute_${base}\` are permitted.`,
+      );
+      assert.ok(
+        names.has(`plan_${base}`),
+        `\`plan_${base}\` must be registered under destructive.`,
+      );
+      assert.ok(
+        names.has(`execute_${base}`),
+        `\`execute_${base}\` must be registered under destructive.`,
+      );
+    }
+  });
+
+  it("execute_<name> rejects calls that omit plan_id", async () => {
+    const { server } = buildSurface("destructive");
+    // Pick one representative tool per two-phase class so a future
+    // class change is visible here too.
+    const samples = ["execute_terminate_ec2_instance", "execute_query", "execute_ssm_send_command"];
+    for (const name of samples) {
+      const entry = server.byName(name);
+      assert.ok(entry, `${name} must be in the registered surface`);
+      await assert.rejects(
+        () => entry.handler({}),
+        (err) =>
+          err instanceof PolicyError &&
+          /plan_id argument is required/.test(err.message),
+        `${name} must throw PolicyError when plan_id is missing.`,
+      );
+    }
+  });
+
+  it("plan_<name> issues a plan_id without invoking the underlying handler", async () => {
+    const { server } = buildSurface("destructive");
+    // `plan_terminate_ec2_instance` exercises the infra_mutation path.
+    // The handler closure inside `index.js` would call AWS if it ran;
+    // the plan-time wrapper short-circuits that and returns a stored
+    // plan envelope, so this test reaching success proves the inner
+    // handler was NOT invoked.
+    const entry = server.byName("plan_terminate_ec2_instance");
+    const result = await entry.handler({
+      env: "prod",
+      confirm_env: "prod",
+      instance_id: "i-0123456789abcdef0",
+    });
+    assert.ok(result?.content?.[0]?.type === "text");
+    const payload = JSON.parse(result.content[0].text);
+    assert.ok(
+      /^[0-9a-f-]{36}$/.test(payload.plan_id),
+      `plan_id must be a UUID; got ${payload.plan_id}`,
+    );
+    assert.equal(payload.ttl_seconds, 60);
+    assert.equal(payload.summary.tool, "terminate_ec2_instance");
+    assert.equal(payload.summary.class, "infra_mutation");
+    assert.equal(payload.summary.env, "prod");
+  });
+});
+
+// =====================================================================
+// Scope bullet 3: `secret_handle` tools cannot return raw secret values
+// in any response path.
+//
+// The surface invariant is structural: `class_defaults.secret_handle`
+// declares `return_mode: handle` in the live `.shifter.yaml`, which is
+// enforced as an ADR-014-R5 invariant by `_assertAdr014Invariants` in
+// `policy.js`. Tampering with this field (or removing it) fails
+// `loadPolicy` at startup. The wrap mechanism itself (raw secret →
+// `shf-secret:<uuid>`) is unit-tested in `policy.test.js`; here we
+// lock in that the LIVE policy keeps the class invariant and that the
+// LIVE registered surface includes `get_secret` under its expected
+// classes only.
+// =====================================================================
+
+describe("secret_handle tools cannot return raw secret values", () => {
+  it("the live policy declares class_defaults.secret_handle.return_mode = 'handle'", () => {
+    const { policy } = buildSurface("standard");
+    const defaults = policy.classDefaults("secret_handle");
+    assert.equal(
+      defaults.return_mode,
+      "handle",
+      "ADR-014-R5 requires class_defaults.secret_handle.return_mode = 'handle'; loadPolicy must reject any tampered value.",
+    );
+  });
+
+  it("get_secret's LIVE descriptor is class secret_handle (and list_secrets is observability)", () => {
+    // Codex review #1202 cycle 3 finding 2 (class): assert the
+    // descriptor metadata, not just the registered tool name. If a
+    // future edit silently re-classed `get_secret` from
+    // `secret_handle` to another standard-only class (e.g.
+    // `observability` to "make list_tools cleaner"), the secret-wrap
+    // would stop firing AND a name-only assertion would still pass.
+    // Re-asserting `klass` against the live descriptor closes that.
+    const { server, descriptors } = buildSurface("standard");
+    const getSecret = descriptors.find((d) => d.name === "get_secret");
+    assert.ok(getSecret, "get_secret descriptor must reach registerTool");
+    assert.equal(
+      getSecret.klass,
+      "secret_handle",
+      "get_secret.klass must be 'secret_handle' so _wrapSecretReturn fires on success paths.",
+    );
+    const listSecrets = descriptors.find((d) => d.name === "list_secrets");
+    assert.ok(listSecrets, "list_secrets descriptor must reach registerTool");
+    assert.equal(
+      listSecrets.klass,
+      "observability",
+      "list_secrets.klass must stay 'observability' — it returns discovery metadata only, no secret material.",
+    );
+    // And both must reach the registered surface under standard.
+    const names = server.names();
+    assert.ok(names.has("get_secret"));
+    assert.ok(names.has("list_secrets"));
+  });
+
+  it("get_secret is ABSENT under read_only (secret_handle class disabled)", () => {
+    const { server } = buildSurface("read_only");
+    assert.ok(
+      !server.names().has("get_secret"),
+      "get_secret must NOT be registered when the active profile excludes secret_handle.",
+    );
+  });
+});
+
+// =====================================================================
+// Scope bullet 4: Prod-touching tools refuse without `confirm_env="prod"`.
+// =====================================================================
+
+describe("prod calls require confirm_env='prod'", () => {
+  it("plan_terminate_ec2_instance({env:'prod'}) without confirm_env throws PolicyError", async () => {
+    const { server } = buildSurface("destructive");
+    const entry = server.byName("plan_terminate_ec2_instance");
+    await assert.rejects(
+      () => entry.handler({ env: "prod", instance_id: "i-0123456789abcdef0" }),
+      (err) =>
+        err instanceof PolicyError &&
+        /env="prod" requires confirm_env="prod"/.test(err.message),
+    );
+  });
+
+  it("plan_query({env:'prod'}) without confirm_env throws PolicyError (class-wide gate)", async () => {
+    // Re-running the gate on a different class proves env policy is
+    // class-wide, not tool-specific.
+    const { server } = buildSurface("destructive");
+    const entry = server.byName("plan_query");
+    await assert.rejects(
+      () => entry.handler({ env: "prod", sql: "select 1" }),
+      (err) =>
+        err instanceof PolicyError &&
+        /env="prod" requires confirm_env="prod"/.test(err.message),
+    );
+  });
+
+  it("plan_terminate_ec2_instance({env:'prod', confirm_env:'prod'}) is accepted", async () => {
+    const { server } = buildSurface("destructive");
+    const entry = server.byName("plan_terminate_ec2_instance");
+    const result = await entry.handler({
+      env: "prod",
+      confirm_env: "prod",
+      instance_id: "i-0123456789abcdef0",
+    });
+    const payload = JSON.parse(result.content[0].text);
+    assert.equal(payload.summary.env, "prod");
+  });
+});
+
+// =====================================================================
+// Scope bullet 5: `dev_bypass_tunnel` tool descriptions don't contain
+// bypass-procedure language or `/dev-login/` URLs.
+// =====================================================================
+
+describe("dev_bypass_tunnel descriptions are redacted", () => {
+  it("start_portal_test_tunnel description is the redacted constant verbatim", () => {
+    const { server } = buildSurface("destructive");
+    const entry = server.byName("start_portal_test_tunnel");
+    assert.ok(entry, "start_portal_test_tunnel must be registered under destructive");
+    assert.equal(
+      entry.description,
+      REDACTED_DESCRIPTION,
+      "Description must be the policy.js REDACTED_DESCRIPTION constant verbatim — not phrase-stripped — to guarantee no bypass procedure language can leak via list_tools.",
+    );
+  });
+
+  it("stop_portal_test_tunnel description is the redacted constant verbatim", () => {
+    const { server } = buildSurface("destructive");
+    const entry = server.byName("stop_portal_test_tunnel");
+    assert.equal(entry.description, REDACTED_DESCRIPTION);
+  });
+
+  it("redacted descriptions contain no bypass-procedure language or /dev-login/ URLs", () => {
+    // Defense-in-depth scan that catches a future regression where
+    // REDACTED_DESCRIPTION is loosened. The hardcoded substrings are
+    // the ones operators most commonly grep `list_tools` for when
+    // looking up the bypass procedure — they are exactly what ADR-014-R6
+    // wants to keep out of the LLM's tool catalog.
+    const { server } = buildSurface("destructive");
+    for (const name of EXPECTED_DEV_BYPASS_TUNNEL_TOOLS) {
+      const entry = server.byName(name);
+      for (const forbidden of ["/dev-login/", "bypass", "Cognito", "MFA"]) {
+        assert.ok(
+          !entry.description.includes(forbidden),
+          `${name} description must not include \`${forbidden}\`; got: ${entry.description}`,
+        );
+      }
+    }
+  });
+});
+
+// =====================================================================
+// Scope bullet 6: Untrusted-input fencing + acknowledge flag enforced
+// on consumer tools.
+//
+// Consumer tools (those that accept free-form text that becomes an
+// operative payload — SQL, shell commands) declare `untrusted_inputs`
+// in their descriptor; the wrapper refuses calls whose declared field
+// values contain a producer fence opener unless
+// `acknowledge_untrusted_input: true` is set.
+//
+// Producer tools (those that return text from outside the operator's
+// trust boundary) declare `untrusted_source` in their descriptor; the
+// wrapper validates the label against `.shifter.yaml`'s
+// `untrusted_sources` allowlist at registration time. If any producer
+// in `mcp/ops/index.js` had a malformed or unallowlisted label,
+// `registerAllOpsTools` would throw — so the fact that
+// `buildSurface("destructive")` returns without throwing is itself the
+// proof for the producer side.
+// =====================================================================
+
+describe("untrusted-input fencing + acknowledge flag", () => {
+  it("plan_query rejects fenced SQL without acknowledge_untrusted_input", async () => {
+    const { server } = buildSurface("destructive");
+    const entry = server.byName("plan_query");
+    await assert.rejects(
+      () =>
+        entry.handler({
+          env: "dev",
+          sql: "[UNTRUSTED:logs:BEGIN]select 1[UNTRUSTED:logs:END]",
+        }),
+      (err) =>
+        err instanceof PolicyError &&
+        /contains an untrusted-input fence/.test(err.message),
+    );
+  });
+
+  it("plan_query accepts fenced SQL when acknowledge_untrusted_input is true", async () => {
+    const { server } = buildSurface("destructive");
+    const entry = server.byName("plan_query");
+    const result = await entry.handler({
+      env: "dev",
+      sql: "[UNTRUSTED:logs:BEGIN]select 1[UNTRUSTED:logs:END]",
+      acknowledge_untrusted_input: true,
+    });
+    const payload = JSON.parse(result.content[0].text);
+    assert.equal(payload.summary.tool, "query");
+  });
+
+  it("plan_execute rejects fenced SQL without acknowledge_untrusted_input", async () => {
+    const { server } = buildSurface("destructive");
+    const entry = server.byName("plan_execute");
+    await assert.rejects(
+      () =>
+        entry.handler({
+          env: "dev",
+          sql: "[UNTRUSTED:logs:BEGIN]update foo set a=1[UNTRUSTED:logs:END]",
+        }),
+      (err) =>
+        err instanceof PolicyError &&
+        /contains an untrusted-input fence/.test(err.message),
+    );
+  });
+
+  it("plan_ssm_send_command rejects fenced command without acknowledge_untrusted_input", async () => {
+    const { server } = buildSurface("destructive");
+    const entry = server.byName("plan_ssm_send_command");
+    await assert.rejects(
+      () =>
+        entry.handler({
+          env: "dev",
+          instance_id: "i-0123456789abcdef0",
+          command: "[UNTRUSTED:logs:BEGIN]uname -a[UNTRUSTED:logs:END]",
+        }),
+      (err) =>
+        err instanceof PolicyError &&
+        /contains an untrusted-input fence/.test(err.message),
+    );
+  });
+
+  it("consumer descriptors expose acknowledge_untrusted_input on the registered schema", () => {
+    // The wrapper's `_augmentSchemaWithControlKeys` adds an
+    // `acknowledge_untrusted_input` Zod field to consumer descriptors'
+    // schemas so MCP clients see it in `list_tools`. Its absence on
+    // the registered schema would mean the agent has no idiomatic way
+    // to opt in to fenced input — and would be a silent regression of
+    // the Phase 4 contract.
+    const { server } = buildSurface("destructive");
+    for (const name of ["plan_query", "plan_execute", "plan_ssm_send_command"]) {
+      const entry = server.byName(name);
+      assert.ok(
+        entry.schema?.acknowledge_untrusted_input,
+        `${name} registered schema must include acknowledge_untrusted_input.`,
+      );
+    }
+  });
+
+  it("registering all descriptors succeeds — every producer's untrusted_source label is in the allowlist", () => {
+    // If any descriptor declared a malformed or unallowlisted
+    // `untrusted_source` (e.g. typo `s33` instead of `s3`),
+    // `registerTool` would throw `PolicyError` at registration time.
+    // We re-run `buildSurface` here under each profile to make the
+    // load-bearing assertion explicit; the previous tests rely on
+    // this implicitly.
+    assert.doesNotThrow(() => buildSurface("read_only"));
+    assert.doesNotThrow(() => buildSurface("standard"));
+    assert.doesNotThrow(() => buildSurface("destructive"));
+  });
+
+  it("LIVE producer descriptors declare the expected untrusted_source labels", () => {
+    // Codex review #1202 cycle 3 finding 2 (class): asserting only
+    // "registering succeeds" proves that any declared producer
+    // labels are allowlist-valid — but a regression that DROPS the
+    // `untrusted_source` field on `tail_logs` (so the wrapper stops
+    // fencing log bodies) would still pass that assertion. Locking
+    // in expected labels per producer closes that.
+    const { descriptors, policy } = buildSurface("destructive");
+    const allow = policy.untrustedSources();
+    for (const [name, expectedLabel] of Object.entries(EXPECTED_PRODUCER_LABELS)) {
+      const d = descriptors.find((x) => x.name === name);
+      assert.ok(d, `producer descriptor '${name}' must reach registerTool`);
+      assert.equal(
+        d.untrusted_source,
+        expectedLabel,
+        `${name}.untrusted_source must equal '${expectedLabel}' (drives _wrapUntrustedSource fencing).`,
+      );
+      assert.ok(
+        allow.has(d.untrusted_source),
+        `${name}.untrusted_source '${d.untrusted_source}' must be in .shifter.yaml's untrusted_sources allowlist.`,
+      );
+    }
+  });
+
+  it("LIVE consumer descriptors declare the expected untrusted_inputs fields", () => {
+    // Same shape as the producer assertion above. Silently dropping
+    // `untrusted_inputs: ["sql"]` from `query` would let fenced SQL
+    // bypass the acknowledgement gate, and a name-only assertion
+    // would not notice.
+    const { descriptors } = buildSurface("destructive");
+    for (const [name, expectedInputs] of Object.entries(EXPECTED_CONSUMER_INPUTS)) {
+      const d = descriptors.find((x) => x.name === name);
+      assert.ok(d, `consumer descriptor '${name}' must reach registerTool`);
+      assert.deepStrictEqual(
+        d.untrusted_inputs,
+        expectedInputs,
+        `${name}.untrusted_inputs must equal ${JSON.stringify(expectedInputs)} (drives _enforceUntrustedInputGate).`,
+      );
+    }
+  });
+
+  it("LIVE execute descriptor declares is_write: true (so class-keyed apex requires_write fires on it)", () => {
+    // The class-keyed apex rule `{class: db_arbitrary, env: prod,
+    // operation_kind: execute, requires_write: true}` in
+    // .shifter.yaml only matches descriptors whose `is_write` is
+    // `true`. Without this on `execute`, prod `execute` would slip
+    // past apex out-of-band confirmation while `query` /
+    // `list_tables` correctly stay out — proving the field is
+    // load-bearing for ADR-014-R6 apex coverage.
+    const { descriptors } = buildSurface("destructive");
+    const exec = descriptors.find((d) => d.name === "execute");
+    assert.ok(exec, "execute descriptor must reach registerTool");
+    assert.equal(exec.is_write, true, "execute.is_write must be true so apex requires_write rules match it.");
+  });
+});
+
+// =====================================================================
+// Scope bullet 7: Apex tools require terminal confirmation token.
+//
+// Surface assertions are structural: the apex_operations rules in
+// `.shifter.yaml` must point at LIVE registered descriptors, and the
+// `approve` tool (which consumes the token) must be available in every
+// profile. The behavioral apex flow (stderr-only token emission, 60s
+// timeout, `consumeApexToken` releases the parked handler) is
+// exhaustively covered in `policy.test.js`; replicating it here would
+// duplicate test logic without adding surface coverage.
+// =====================================================================
+
+describe("apex out-of-band confirmation surface", () => {
+  it("registerAllOpsTools validates apex coverage — every apex_operations[*].tool maps to a real descriptor", () => {
+    // `registerAllOpsTools` calls `validateApexCoverage(ctx.policy)`
+    // as its last step. If any `apex_operations[*].tool` in
+    // `.shifter.yaml` pointed at a typoed / non-registered descriptor,
+    // `buildSurface` would throw PolicyError. Reaching this assertion
+    // proves the live config is internally consistent.
+    assert.doesNotThrow(() => buildSurface("destructive"));
+  });
+
+  it("every apex_operations[*].tool rule maps to a registered execute_<name>", () => {
+    const { server, policy } = buildSurface("destructive");
+    const names = server.names();
+    for (const rule of policy.apexOperations()) {
+      if (!rule.tool) continue;
+      // The class default for the rule's class is `two_phase: true`,
+      // so the apex-gated entry point is `execute_<name>`, never the
+      // direct name. The rule's `operation_kind` is "execute" in the
+      // shipped policy.
+      assert.ok(
+        names.has(`execute_${rule.tool}`),
+        `apex_operations rule for tool '${rule.tool}' must point at a registered \`execute_${rule.tool}\``,
+      );
+    }
+  });
+
+  it("the `approve` tool is registered under every profile (without it no apex op can complete)", () => {
+    for (const profile of ["read_only", "standard", "destructive"]) {
+      const { server } = buildSurface(profile);
+      assert.ok(
+        server.names().has("approve"),
+        `\`approve\` must be registered under ${profile}; otherwise no apex op can release its parked handler.`,
+      );
+    }
+  });
+
+  it("the LIVE approve descriptor declares sensitive_args: ['token']", () => {
+    // Codex review #1202 cycle 3 finding 2 (class): the schema check
+    // alone passed even when the `sensitive_args: ["token"]` line on
+    // the approve descriptor was removed (the `token` schema field
+    // is the registered Zod entry, not the sensitive-args list).
+    // Assert the live descriptor metadata directly: that field is
+    // what drives `_safeOutputArgs` to replace the token bytes with
+    // `<redacted>` before they reach the audit log.
+    const { descriptors } = buildSurface("destructive");
+    const approve = descriptors.find((d) => d.name === "approve");
+    assert.ok(approve, "approve descriptor must reach registerTool");
+    assert.deepStrictEqual(
+      approve.sensitive_args,
+      ["token"],
+      "approve.sensitive_args must equal ['token'] so apex tokens never land in the audit log.",
+    );
+    assert.equal(approve.klass, "observability");
+  });
+
+  it("driving approve through the wrapped handler redacts the token from the audit record", async () => {
+    // Effect-based proof: even with the descriptor metadata above,
+    // a future change that re-wired `_safeOutputArgs` could still
+    // silently leak the token. This test invokes the wrapped
+    // `approve` handler against an unknown token (so
+    // `consumeApexToken` returns false and the handler errors
+    // cleanly), then inspects the audit file the wrapper wrote.
+    // The audit record must (a) reference the approve invocation,
+    // (b) replace the token field with `<redacted>`, and (c)
+    // contain ZERO occurrences of the literal token bytes anywhere
+    // in the file's contents.
+    const { server } = buildSurface("destructive");
+    const entry = server.byName("approve");
+    // 32 hex characters — passes the descriptor's Zod regex if the
+    // SDK were enforcing schema, and matches the apex-token shape
+    // the wrapper expects. Distinct from any real apex token.
+    const SYNTHETIC_TOKEN = "0".repeat(31) + "1";
+    const result = await entry.handler({ token: SYNTHETIC_TOKEN });
+    assert.equal(
+      result.isError,
+      true,
+      "approve with an unknown token must return an isError envelope.",
+    );
+    // `consumeApexToken` directly with the synthetic token must
+    // also return false — proves the token never entered the
+    // pending-apex map by way of the audit/handler path.
+    assert.equal(consumeApexToken(SYNTHETIC_TOKEN), false);
+
+    const auditContent = readFileSync(TMP_AUDIT_PATH, "utf-8");
+    assert.ok(
+      auditContent.includes('"tool":"approve"'),
+      `audit must record the approve invocation; got:\n${auditContent}`,
+    );
+    assert.ok(
+      !auditContent.includes(SYNTHETIC_TOKEN),
+      `audit must NOT contain the literal token bytes; got:\n${auditContent}`,
+    );
+    assert.ok(
+      /"token"\s*:\s*"<redacted>"/.test(auditContent),
+      `audit must render approve.token as "<redacted>"; got:\n${auditContent}`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Phase 6 of the policy-layer rollout under parent #777. Adds the load-bearing negative-surface tests for `mcp/ops` that lock in the ADR-014-R3 / R5 / R6 invariants: profile gating actually removes tools from the registered set; two-phase classes register `plan_<name>` / `execute_<name>` pairs only; `secret_handle` pins `return_mode: handle`; prod calls require `confirm_env="prod"`; `dev_bypass_tunnel` descriptions are replaced with the redacted constant; consumer tools refuse fenced input without `acknowledge_untrusted_input`; apex tools gate on terminal confirmation via the `approve` flow. The suite exercises the live registration path — real `.shifter.yaml` through `loadPolicy`, real `registerTool`, real descriptors — against a fake server, and asserts live descriptor metadata (klass / untrusted_source / untrusted_inputs / sensitive_args / is_write) so name-only regressions cannot slip past.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #1202

## ADR Impact

- ADR-014 (R3 / R5 / R6 — surface invariants verified, not amended)

## Changes

- Add `mcp/ops/tool-surface.test.js` — 30 surface tests across 7 describe blocks (one per issue scope bullet) plus the descriptor-metadata strengthening from codex cycle 3.
- Add `mcp/ops/index.js::registerAllOpsTools(ctx)` export: descriptor registrations + `validateApexCoverage` move into this function; `new McpServer` / `loadPolicy` / `await server.connect(...)` move behind `async main()` guarded by `if (process.argv[1] && import.meta.url === pathToFileURL(_entrypointArg).href) { await main(); }`. Live behavior is unchanged when run as `node mcp/ops/index.js`. Signal handler installation moves inside `main()` so importing the module from a test no longer mutates process-global state.
- Add an opt-in `ctx.onRegisterDescriptor` callback to `mcp/ops/policy.js::registerTool` so the surface suite can capture live descriptor metadata post-validation, pre-gate-composition, without copying capability maps. Production server context never sets the callback; no live behavior change.
- Update `mcp/ops/SECURITY.md`: implementation-status entry for #1202; regression-coverage section restructured to reflect the shipped (#1198–#1202) state.
- Add `changelog.d/1202.security.md`.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Local gates at HEAD:
- `cd mcp/ops && npm test` → 297/297 pass (was 267 pre-PR; +30 new tests in this file)
- `pre-commit run --all-files` → clean (including `test (mcp/ops)`, `test (mcp/ngfw)`, k8s checks, layer imports, ADR guard fast)
- `python3 scripts/adr_guard/adr_guard.py --all --level ci` → all 13 checks pass
- `cd mcp/ops && npm run lint` → 28 warnings, 0 errors (26 pre-existing; 2 new false-positive `security/detect-non-literal-fs-filename` on `mkdtempSync`-derived temp paths, matching the audit.js precedent of unsuppressed warnings)
- Audit-pollution proof: `stat -c%s ~/.shifter-ops-audit.jsonl` byte-identical (17700 → 17700) before/after a fresh `npm test` — the temp `.shifter.yaml` redirect (`mcp_ops.audit.path` override → per-process temp file, cleaned by `after()`) keeps the suite hermetic.

Pre-push codex review history (per ADR-029, all decision records on the issue thread):
- Cycle 1 — 2 findings (one-off): process-handler import side effect; entrypoint guard threw without `argv[1]`. Both fixed.
- Cycle 2 — 1 class + 1 one-off: audit-log pollution at every handler-invocation site (class); stale SECURITY.md regression-coverage section (one-off). Both fixed.
- Cycle 3 — 1 one-off + 1 class: cycle-2 fix dropped `loadPolicy` from the surface contract; name-only assertions don't catch descriptor-metadata regressions (class). Both fixed; loadPolicy contract restored via a temp `.shifter.yaml`; descriptor metadata captured via the new `onRegisterDescriptor` hook.
- Cycle 4 — user-authorized skip after cycle-3 closed cleanly.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: issue acceptance: 'Surface tests pass' ← mcp/ops/tool-surface.test.js, issue acceptance: 'Changelog fragment' ← changelog.d/1202.security.md
- TESTS: mcp/ops/tool-surface.test.js — 30 surface tests covering all 7 scope bullets

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/1202.security.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed