### PR TITLE
chore: adopt SPDX file-header convention (ADR-015) + relicense MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,13 +1,21 @@
-Copyright (c) 2025 Palo Alto Networks, Inc. All rights reserved.
+MIT License
+
+Copyright (c) 2026 Palo Alto Networks, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-Repo held on behalf of Palo Alto Networks, Inc. (PANW) by Brad Edwards until transfer to PANW at PANW's sole discretion at a time of PANW's choosing.
-
-The contents of this repository are work product of Palo Alto Networks, Inc. (PANW) and are not intended for use by any other party.
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -53,6 +53,11 @@ Current mechanisms:
   hard-fail on current signal without immediately breaking on unrelated
   legacy Terraform debt.
 - `.gitleaks.toml`: secret scanning configuration
+- `sonar-project.properties`: SonarCloud project configuration.
+  `sonar.html.fileHeader` enforces the ADR-015 file-header convention
+  on HTML templates by failing `Web:HeaderCheck` on any template that
+  does not begin with the canonical two-line SPDX Django-comment
+  header.
 - `.kube-linter.yaml`: Kubernetes security and best-practice linting
   configuration (enforces ADR-006 checks)
 - `scripts/adr_guard/adr_guard.py` `mcp-no-shell-exec` check:

--- a/docs/adr/complexity-backlog.md
+++ b/docs/adr/complexity-backlog.md
@@ -14,9 +14,7 @@ canonical `pyproject.toml`, and the relevant table rows in one PR.
 | Package | File | Function | Complexity at introduction | Tracking issue |
 |---|---|---|---|---|
 | shifter_platform | `shifter/shifter_platform/cms/services.py` | `list_agents` | 16 | #1142 |
-| shifter_platform | `shifter/shifter_platform/cms/services.py` | `initiate_upload` | 16 | #1144 |
 | shifter_platform | `shifter/shifter_platform/ctf/services/participant.py` | `bulk_import_participants` | 16 | #1145 |
-| provisioner | `shifter/engine/provisioner/orchestrators/setup_orchestrator.py` | `_execute_step` | 22 | #1152 |
 
 `submit_flag` (was complexity 19, tracking #1146) dropped below the
 threshold when its participant→challenge availability checks were
@@ -31,9 +29,31 @@ were extracted into `_compute_hint_purchase_info`,
 `_resolve_target_connection_info`, and `_compute_attempt_state`
 helpers in `ctf/views.py`. The `# noqa: C901` was removed.
 
-Total: 3 functions in `shifter_platform` (2 in `cms/services`, 1 in
-`ctf/services`), plus 1 in
-`provisioner/orchestrators/setup_orchestrator.py`. The other six
+`initiate_upload` (was complexity 16, tracking #1144) dropped below
+the threshold when its input-validation block (user / name / filename
+/ file_size checks) was extracted into
+`_validate_initiate_upload_inputs` in `cms/services.py`. The
+`# noqa: C901` was removed.
+
+`_execute_step` (was complexity 22, tracking #1152) dropped below the
+threshold when its per-attempt body was extracted into
+`_run_one_attempt` returning an `_AttemptOutcome` discriminated union
+(`_AttemptSuccess` / `_AttemptRetry` / `_AttemptFailHard`), with the
+PAN-OS post-success block factored into `_classify_successful_attempt`
++ `_handle_panos_poll` and the per-outcome logging into
+`_log_step_success` / `_log_step_failure` /
+`_log_panos_commit_outcome`. The retry/raise/fallthrough asymmetry is
+preserved (transport-error and PAN-OS poll/commit-fail exhaustion
+raise `SetupError`; exit-nonzero exhaustion returns a failed
+`StepResult`). The `# noqa: C901` was removed. The underlying
+architectural smell — PAN-OS specifics leaking into a generic
+`Executor`/`SetupPlan` abstraction (e.g., the `SetupStep.poll_for_job`
+flag) — remains, and the long-term fix (a `StepValidator` protocol
+that pushes PAN-OS knowledge into a dedicated validator) is tracked
+on #1152 even though the C901 entry is closed.
+
+Total: 2 functions in `shifter_platform` (1 in `cms/services`, 1 in
+`ctf/services`); zero in `provisioner/`. The other six
 lint-scoped Python packages (`shifter/packer`, `shifter/installation`,
 `scripts/bootstrap`, `scripts/gcp`, `scripts/check_layer_imports`,
 `scripts/check_rds_pending_modifications`) ship with zero exemptions

--- a/docs/adr/index.yaml
+++ b/docs/adr/index.yaml
@@ -588,5 +588,41 @@
       "shifter/shifter_platform/config/settings.py",
       "shifter/shifter_platform/shared/log_sanitize.py"
     ]
+  },
+  {
+    "id": "ADR-015",
+    "title": "Source files carry SPDX copyright and license headers",
+    "status": "accepted",
+    "scope": "repository",
+    "decision": "Source files in this repository start with a two-line SPDX-formatted header naming the copyright holder (Palo Alto Networks, Inc., 2026) and the SPDX license identifier (MIT). The format follows the REUSE specification so license scanners (REUSE, ScanCode, ClearlyDefined, SonarCloud) read it without per-project rules. The literal header text is centralized in `sonar-project.properties` (`sonar.html.fileHeader`) and `LICENSE`; per-language comment syntax wraps the same payload (e.g. `# ` for Python/shell, `{# #}` for Django templates, `// ` for JS/CSS). Django HTML templates use Django server-side comments rather than HTML `<!-- -->` so the header never appears in rendered responses. Adoption is enforced on HTML templates via SonarCloud's `Web:HeaderCheck`; other languages adopt the convention for new files immediately, with batched cleanups for legacy files as tooling catches up.",
+    "rules": [
+      {
+        "id": "ADR-015-R1",
+        "description": "Project source files use the SPDX REUSE header form: `SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc.` followed by `SPDX-License-Identifier: MIT`. Per-language comment syntax wraps the lines (Python `# `, Django `{# #}`, JS/CSS `// `, shell `# `, etc.). The canonical header text and per-language examples live in `docs/architecture/file-headers.md`.",
+        "checks": []
+      },
+      {
+        "id": "ADR-015-R2",
+        "description": "Django HTML templates use `{# ... #}` server-side comments for the header. HTML `<!-- -->` comments are NOT acceptable because they render to the client and leak the copyright payload into every served response body.",
+        "checks": []
+      },
+      {
+        "id": "ADR-015-R3",
+        "description": "SonarCloud's `Web:HeaderCheck` rule is configured via `sonar.html.fileHeader` in `sonar-project.properties` with the canonical two-line Django-comment header text. The configured value is the single source of enforcement for HTML templates; new templates without the header fail the SonarCloud quality gate.",
+        "checks": []
+      },
+      {
+        "id": "ADR-015-R4",
+        "description": "Year and license text are maintained in exactly two places: `LICENSE` (legal artifact) and `sonar-project.properties` (enforcement). Roll-forward edits (new year, license switch, organization rename) update both files and then mechanically propagate to all source files in a single change. The header is not duplicated in per-file ADRs or per-package READMEs.",
+        "checks": []
+      }
+    ],
+    "exceptions": [],
+    "enforcement": ["ci", "sonarcloud", "agent-policy"],
+    "evidence": [
+      "LICENSE",
+      "docs/architecture/file-headers.md",
+      "sonar-project.properties"
+    ]
   }
 ]

--- a/docs/architecture/file-headers.md
+++ b/docs/architecture/file-headers.md
@@ -1,0 +1,97 @@
+# File Headers (ADR-015)
+
+Source files in this repository carry an SPDX-formatted file header
+identifying copyright and license. The format is the
+[SPDX REUSE specification](https://reuse.software/spec-3.3/), which is
+machine-parsable and language-neutral.
+
+## Canonical header text
+
+Two lines, in order:
+
+```
+SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc.
+SPDX-License-Identifier: MIT
+```
+
+Year on the `SPDX-FileCopyrightText` line is the calendar year of the
+first publication of the work. It does not advance every year; the
+license itself in `LICENSE` is the authoritative legal artifact.
+
+## Per-language comment syntax
+
+Each language uses its own comment form so the header is inert at
+runtime / render time.
+
+| Language / format | Comment shape |
+|---|---|
+| Python | `# ` line prefix |
+| JavaScript / TypeScript / CSS | `// ` line prefix (or `/* ... */` block) |
+| Shell (`.sh`) | `# ` line prefix, AFTER the `#!/usr/bin/env bash` shebang |
+| PowerShell (`.ps1`) | `# ` line prefix |
+| Django HTML templates | `{# ... #}` server-side comment (NOT `<!-- -->`, which leaks to the client) |
+| YAML / TOML | `# ` line prefix |
+| Terraform (`.tf`) | `# ` line prefix |
+| Dockerfile | `# ` line prefix |
+| Markdown | Not required (prose, not source) |
+
+## Examples
+
+Python:
+```python
+# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc.
+# SPDX-License-Identifier: MIT
+
+from foo import bar
+```
+
+Django template:
+```
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
+{% extends "base.html" %}
+...
+```
+
+Shell script with shebang:
+```bash
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc.
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+```
+
+## Enforcement
+
+| Surface | Mechanism |
+|---|---|
+| Django HTML templates (`shifter/shifter_platform/templates/**/*.html`) | `sonar.html.fileHeader` in `sonar-project.properties` drives SonarCloud's `Web:HeaderCheck` rule. The configured value is the literal two-line header. |
+| Other languages | Adopted incrementally per language as the repository's tooling catches up. New files MUST carry the header; legacy files are updated in batched cleanups. |
+
+The literal header text lives in exactly two places:
+
+- `LICENSE` (the legal artifact)
+- `sonar-project.properties` (`sonar.html.fileHeader`)
+
+Changes to the header — copyright year roll-forward, organization
+rename, license switch — are made in those two places and then
+mechanically applied across affected source files in a single change.
+
+## Why SPDX
+
+- Machine-readable. Tools like REUSE, ScanCode, and ClearlyDefined
+  consume SPDX headers directly without per-project rules.
+- Single source of license truth. The `SPDX-License-Identifier` line
+  matches a [SPDX license identifier](https://spdx.org/licenses/);
+  legal review can verify with one comparison.
+- Stable across decades of OSS practice; not specific to any one
+  ecosystem.
+
+## Why Django `{# #}` for HTML
+
+`<!-- -->` HTML comments render to the client in the response body.
+Django's `{# ... #}` is stripped at template-compile time and never
+reaches the user-agent. Server-side templates therefore use Django
+comments so the copyright statement remains a development-time
+artifact and does not bloat every HTML response.

--- a/mcp/ops/policy.test.js
+++ b/mcp/ops/policy.test.js
@@ -722,8 +722,7 @@ function _extractApexToken(stderrBuffer) {
  * SonarCloud's new-duplicated-lines metric above the 3% threshold.
  */
 const _DEFAULT_AUDIT_POLICY_OPTS = Object.freeze({ profile: "destructive" });
-function policyWithAudit(auditPath, extra = {}, opts) {
-  const effectiveOpts = opts ?? _DEFAULT_AUDIT_POLICY_OPTS;
+function policyWithAudit(auditPath, extra = {}, opts = _DEFAULT_AUDIT_POLICY_OPTS) {
   const { redact, ...rest } = extra;
   return parsePolicy(
     {
@@ -731,7 +730,7 @@ function policyWithAudit(auditPath, extra = {}, opts) {
       audit: { enabled: true, path: auditPath, redact: redact ?? [] },
       ...rest,
     },
-    effectiveOpts,
+    opts,
   );
 }
 
@@ -827,25 +826,25 @@ function setupTrackedTool(server, policy, name, klass, body) {
   return () => state.called;
 }
 
+function setupOkTool(server, policy, name, klass, opts = {}) {
+  const state = { called: false };
+  setupTool(server, policy, {
+    name,
+    klass,
+    handler: async () => {
+      state.called = true;
+      return opts.empty ? { content: [] } : textResponse("ok");
+    },
+  });
+  return () => state.called;
+}
+
 describe("registerTool gates (Phase 2): env policy", () => {
   let server;
   beforeEach(() => {
     server = new FakeServer();
     _resetGateCachesForTests();
   });
-
-  function setupOkTool(server, policy, name, klass, opts = {}) {
-    const state = { called: false };
-    setupTool(server, policy, {
-      name,
-      klass,
-      handler: async () => {
-        state.called = true;
-        return opts.empty ? { content: [] } : textResponse("ok");
-      },
-    });
-    return () => state.called;
-  }
 
   it("refuses prod calls without confirm_env=prod for prod-touching classes", async () => {
     // infra_mutation is two-phase, so the env-policy check fires on
@@ -1089,23 +1088,23 @@ describe("registerTool gates (Phase 2): idempotency keys", () => {
   });
 });
 
+function policyWithOverride(toolName, overrides, opts = {}) {
+  return parsePolicy(
+    {
+      ...BASE_POLICY,
+      audit: { enabled: true, path: _SHARED_AUDIT_PATH, redact: [] },
+      tools: { [toolName]: { overrides } },
+    },
+    opts,
+  );
+}
+
 describe("registerTool gates (Phase 2): per-tool overrides", () => {
   let server;
   beforeEach(() => {
     server = new FakeServer();
     _resetGateCachesForTests();
   });
-
-  function policyWithOverride(toolName, overrides, opts = {}) {
-    return parsePolicy(
-      {
-        ...BASE_POLICY,
-        audit: { enabled: true, path: _SHARED_AUDIT_PATH, redact: [] },
-        tools: { [toolName]: { overrides } },
-      },
-      opts,
-    );
-  }
 
   it("per-tool overrides flow into the resolved tool policy for non-two-phase classes", async () => {
     // Codex review #1180 cycle 1 finding 3: gates must consume the
@@ -1138,20 +1137,20 @@ describe("registerTool gates (Phase 2): per-tool overrides", () => {
   });
 });
 
+function setupSecretTool(server, policy, name, value) {
+  setupTool(server, policy, {
+    name,
+    klass: "secret_handle",
+    handler: async () => textResponse(value),
+  });
+}
+
 describe("registerTool gates (Phase 2): secret handles", () => {
   let server;
   beforeEach(() => {
     server = new FakeServer();
     _resetGateCachesForTests();
   });
-
-  function setupSecretTool(server, policy, name, value) {
-    setupTool(server, policy, {
-      name,
-      klass: "secret_handle",
-      handler: async () => textResponse(value),
-    });
-  }
 
   it("wraps secret_handle return values into shf-secret:<uuid> handles", async () => {
     const policy = buildPolicyAuditOff();

--- a/scripts/adr_guard/adr_guard.py
+++ b/scripts/adr_guard/adr_guard.py
@@ -1246,7 +1246,7 @@ def _scan_targets(repo_root: Path, files: list[str] | None) -> tuple[bool, bool,
     scan_chart = False
     base_files: list[Path] = []
     for f in files:
-        if f.startswith(K8S_BASE_DEPLOYMENT_DIR + "/") and (f.endswith(".yaml") or f.endswith(".yml")):
+        if f.startswith(K8S_BASE_DEPLOYMENT_DIR + "/") and f.endswith((".yaml", ".yml")):
             scan_base = True
             full = repo_root / f
             if full.exists():
@@ -1586,7 +1586,7 @@ def _strip_hcl_comments(text: str) -> str:
 
 def _is_line_commented(line: str) -> bool:
     stripped = line.lstrip()
-    return stripped.startswith("#") or stripped.startswith("//")
+    return stripped.startswith(("#", "//"))
 
 
 def _strip_trailing_line_comment(line: str) -> str:

--- a/scripts/polaris-aws-range/a2_cold_bootstrap.sh
+++ b/scripts/polaris-aws-range/a2_cold_bootstrap.sh
@@ -22,6 +22,10 @@ AWS_REGION="${AWS_REGION:-us-east-2}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 A2_ID="${1:-}"
 
+readonly SSM_PS_DOC="AWS-RunPowerShellScript"
+readonly SSM_QUERY_COMMAND_ID="Command.CommandId"
+readonly SSM_QUERY_STDOUT="StandardOutputContent"
+
 if [[ -z "$A2_ID" ]]; then
     A2_ID="$(terraform -chdir="${SCRIPT_DIR}" output -raw a2_dc_instance_id 2>/dev/null || true)"
 fi
@@ -85,10 +89,8 @@ wait_for_ssm() {
             # point, this is the post-reboot recovery — return.
             # If we never saw stale (caller invoked wait_for_ssm without
             # an outstanding reboot), still return — bootstrap entry path.
-            if [[ "$age" -lt 30 ]]; then
-                if [[ -n "$prev_last" && "$prev_last" != "$last" ]] || [[ "$saw_stale" -eq 0 ]]; then
-                    return 0
-                fi
+            if [[ "$age" -lt 30 && ( ( -n "$prev_last" && "$prev_last" != "$last" ) || "$saw_stale" -eq 0 ) ]]; then
+                return 0
             fi
             prev_last="$last"
         fi
@@ -141,10 +143,10 @@ PY
     local command_id
     command_id="$(aws_ssm ssm send-command \
         --instance-ids "$target" \
-        --document-name "AWS-RunPowerShellScript" \
+        --document-name "$SSM_PS_DOC" \
         --parameters "file://${params_json}" \
         --timeout-seconds "$timeout" \
-        --query 'Command.CommandId' --output text)"
+        --query "$SSM_QUERY_COMMAND_ID" --output text)"
     rm -f "$params_json"
 
     log "${description}: command_id=${command_id}, polling..."
@@ -160,7 +162,7 @@ PY
                 log "${description}: SUCCESS"
                 aws_ssm ssm get-command-invocation \
                     --command-id "$command_id" --instance-id "$target" \
-                    --query 'StandardOutputContent' --output text | tail -30
+                    --query "$SSM_QUERY_STDOUT" --output text | tail -30
                 return 0
                 ;;
             Failed|Cancelled|TimedOut)
@@ -211,10 +213,10 @@ log "SSM agent online on ${A2_ID}"
 # reliable bring-up.
 log "phase 1.5/4: DISM restorehealth + reboot to clear pending sysprep state"
 RESTORE_CMD_ID="$(aws_ssm ssm send-command --instance-ids "$A2_ID" \
-    --document-name "AWS-RunPowerShellScript" \
+    --document-name "$SSM_PS_DOC" \
     --parameters 'commands=["dism.exe /online /cleanup-image /restorehealth /english 2>&1 | Select-Object -Last 5; shutdown /r /t 5 /f /d p:0:0"]' \
     --timeout-seconds 1200 \
-    --query 'Command.CommandId' --output text)"
+    --query "$SSM_QUERY_COMMAND_ID" --output text)"
 log "phase 1.5/4: DISM cmd ${RESTORE_CMD_ID}, polling..."
 deadline=$((SECONDS + 1200))
 while (( SECONDS < deadline )); do
@@ -403,34 +405,34 @@ set -e
 # present = wrapper got past install (good), absent = real bug.
 log "phase 2/4: validating wrapper progress markers"
 MARKER_CMD_ID="$(aws_ssm ssm send-command --instance-ids "$A2_ID" \
-    --document-name "AWS-RunPowerShellScript" \
+    --document-name "$SSM_PS_DOC" \
     --parameters 'commands=["Test-Path C:\\polaris-markers\\02-features-installed; Test-Path C:\\polaris-markers\\03-task-scheduled"]' \
-    --query 'Command.CommandId' --output text)"
+    --query "$SSM_QUERY_COMMAND_ID" --output text)"
 sleep 6
 marker_out="$(aws_ssm ssm get-command-invocation \
     --command-id "$MARKER_CMD_ID" --instance-id "$A2_ID" \
-    --query 'StandardOutputContent' --output text 2>/dev/null || echo missing)"
+    --query "$SSM_QUERY_STDOUT" --output text 2>/dev/null || echo missing)"
 log "phase 2/4: markers: ${marker_out//$'\n'/ }"
 if [[ "$marker_out" != *"True"*"True"* ]]; then
     log "[FATAL] phase 2 features-installed and/or task-scheduled markers missing — wrapper run silently failed"
     log "[FATAL] wrapper SSM exit code was: $WRAPPER_EXIT"
     log "[FATAL] dumping install-adds.log:"
     DUMP_CMD_ID="$(aws_ssm ssm send-command --instance-ids "$A2_ID" \
-        --document-name "AWS-RunPowerShellScript" \
+        --document-name "$SSM_PS_DOC" \
         --parameters 'commands=["Get-Content C:\\polaris-install-adds.log -Tail 80"]' \
-        --query 'Command.CommandId' --output text)"
+        --query "$SSM_QUERY_COMMAND_ID" --output text)"
     sleep 5
     aws_ssm ssm get-command-invocation \
         --command-id "$DUMP_CMD_ID" --instance-id "$A2_ID" \
-        --query 'StandardOutputContent' --output text 2>&1 | tail -80
+        --query "$SSM_QUERY_STDOUT" --output text 2>&1 | tail -80
     exit 1
 fi
 
 log "phase 2/4: reboot to apply computer rename"
 aws_ssm ssm send-command --instance-ids "$A2_ID" \
-    --document-name "AWS-RunPowerShellScript" \
+    --document-name "$SSM_PS_DOC" \
     --parameters 'commands=["Restart-Computer -Force"]' \
-    --query 'Command.CommandId' --output text >/dev/null
+    --query "$SSM_QUERY_COMMAND_ID" --output text >/dev/null
 
 sleep 60
 wait_for_ssm "$A2_ID"
@@ -445,13 +447,13 @@ log "SSM agent back online after rename reboot"
 log "phase 3/4: assert hostname == DC01 before promote"
 # shellcheck disable=SC2016  # $env:COMPUTERNAME is PowerShell, not bash
 NAME_CMD_ID="$(aws_ssm ssm send-command --instance-ids "$A2_ID" \
-    --document-name "AWS-RunPowerShellScript" \
+    --document-name "$SSM_PS_DOC" \
     --parameters 'commands=["$env:COMPUTERNAME"]' \
-    --query 'Command.CommandId' --output text)"
+    --query "$SSM_QUERY_COMMAND_ID" --output text)"
 sleep 5
 hostname_now="$(aws_ssm ssm get-command-invocation \
     --command-id "$NAME_CMD_ID" --instance-id "$A2_ID" \
-    --query 'StandardOutputContent' --output text 2>/dev/null | tr -d '[:space:]')"
+    --query "$SSM_QUERY_STDOUT" --output text 2>/dev/null | tr -d '[:space:]')"
 log "phase 3/4: hostname=${hostname_now}"
 if [[ "$hostname_now" != "DC01" ]]; then
     log "[FATAL] hostname is '${hostname_now}', expected 'DC01' — rename reboot didn't take. Cannot promote."
@@ -521,13 +523,13 @@ ad_ready=0
 while (( SECONDS < deadline )); do
     # shellcheck disable=SC2016  # PowerShell expressions, not bash
     AD_CMD_ID="$(aws_ssm ssm send-command --instance-ids "$A2_ID" \
-        --document-name "AWS-RunPowerShellScript" \
+        --document-name "$SSM_PS_DOC" \
         --parameters 'commands=["(Get-Service ADWS,KDC,NTDS | Where-Object {$_.Status -ne \"Running\"} | Measure-Object).Count"]' \
-        --query 'Command.CommandId' --output text)"
+        --query "$SSM_QUERY_COMMAND_ID" --output text)"
     sleep 5
     ad_status="$(aws_ssm ssm get-command-invocation \
         --command-id "$AD_CMD_ID" --instance-id "$A2_ID" \
-        --query 'StandardOutputContent' --output text 2>/dev/null | tr -d '[:space:]')"
+        --query "$SSM_QUERY_STDOUT" --output text 2>/dev/null | tr -d '[:space:]')"
     if [[ "$ad_status" == "0" ]]; then
         log "phase 3/4: AD services running (ADWS+KDC+NTDS)"
         ad_ready=1
@@ -540,13 +542,13 @@ if (( ad_ready == 0 )); then
     log "[FATAL] AD services did not start within 10 minutes after Install-ADDSForest reboot"
     log "[FATAL] dumping promote.log:"
     DUMP_CMD_ID="$(aws_ssm ssm send-command --instance-ids "$A2_ID" \
-        --document-name "AWS-RunPowerShellScript" \
+        --document-name "$SSM_PS_DOC" \
         --parameters 'commands=["Get-Content C:\\polaris-promote.log -Tail 40 -ErrorAction SilentlyContinue"]' \
-        --query 'Command.CommandId' --output text)"
+        --query "$SSM_QUERY_COMMAND_ID" --output text)"
     sleep 5
     aws_ssm ssm get-command-invocation \
         --command-id "$DUMP_CMD_ID" --instance-id "$A2_ID" \
-        --query 'StandardOutputContent' --output text 2>&1 | tail -40
+        --query "$SSM_QUERY_STDOUT" --output text 2>&1 | tail -40
     exit 1
 fi
 
@@ -560,13 +562,13 @@ run_powershell_file "$A2_ID" "$SETUP_PS1" "a2_setup.ps1" 900
 # Verify a2_setup actually populated the domain by counting users.
 # shellcheck disable=SC2016  # PowerShell expression
 SETUP_CMD_ID="$(aws_ssm ssm send-command --instance-ids "$A2_ID" \
-    --document-name "AWS-RunPowerShellScript" \
+    --document-name "$SSM_PS_DOC" \
     --parameters 'commands=["try { (Get-ADUser -Filter * | Measure-Object).Count } catch { 0 }"]' \
-    --query 'Command.CommandId' --output text)"
+    --query "$SSM_QUERY_COMMAND_ID" --output text)"
 sleep 5
 user_count="$(aws_ssm ssm get-command-invocation \
     --command-id "$SETUP_CMD_ID" --instance-id "$A2_ID" \
-    --query 'StandardOutputContent' --output text 2>/dev/null | tr -d '[:space:]')"
+    --query "$SSM_QUERY_STDOUT" --output text 2>/dev/null | tr -d '[:space:]')"
 log "phase 4/4: domain user count=${user_count}"
 # 17 = 15 a2_setup users + Administrator + Guest + krbtgt = 18; tolerate >=15
 if [[ -z "$user_count" ]] || (( user_count < 15 )); then

--- a/scripts/polaris-aws-range/a2_setup.ps1
+++ b/scripts/polaris-aws-range/a2_setup.ps1
@@ -150,10 +150,10 @@ function Add-GroupMemberIdempotent {
     foreach ($m in $Members) {
         try {
             Add-ADGroupMember -Identity $Group -Members $m -ErrorAction Stop
-            Write-Host "    $Group + $m"
+            Write-Output "    $Group + $m"
         } catch {
             if ($_.Exception.Message -match "already a member") {
-                Write-Host "    $Group already has $m"
+                Write-Output "    $Group already has $m"
             } else {
                 throw
             }

--- a/shifter/engine/provisioner/ngfw_terraform.py
+++ b/shifter/engine/provisioner/ngfw_terraform.py
@@ -233,7 +233,12 @@ def _cleanup_ngfw_bootstrap_objects(instance_id: str) -> None:
         try:
             storage.delete_object(bucket=bootstrap_bucket, key=key)
         except Exception as e:
-            logger.error("Failed to delete NGFW bootstrap object: bucket=%s key=%s error=%s", bootstrap_bucket, key, e)
+            logger.exception(
+                "Failed to delete NGFW bootstrap object: bucket=%s key=%s error=%s",
+                bootstrap_bucket,
+                key,
+                e,
+            )
             failures.append((key, e))
 
     if failures:

--- a/shifter/engine/provisioner/orchestrators/setup_orchestrator.py
+++ b/shifter/engine/provisioner/orchestrators/setup_orchestrator.py
@@ -54,13 +54,19 @@ class SetupResult:
 # Internal discriminated outcome of a single attempt inside `_execute_step`.
 # The retry loop dispatches on these; this keeps per-attempt control flow
 # out of the loop body so the loop itself stays trivially readable.
+class _AttemptOutcomeBase:
+    """Sealed base for the three `_execute_step` per-attempt outcomes."""
+
+
 @dataclass(frozen=True)
-class _AttemptSuccess:
+class _AttemptSuccess(_AttemptOutcomeBase):
+    """Attempt succeeded; the carried `CommandResult` flows back to the caller."""
+
     result: CommandResult
 
 
 @dataclass(frozen=True)
-class _AttemptRetry:
+class _AttemptRetry(_AttemptOutcomeBase):
     """Attempt should be retried (or, if retries exhausted, fall through to
     a failed StepResult). `last_result` carries the most recent CommandResult
     if one was produced (None for pre-execution transport errors)."""
@@ -69,7 +75,7 @@ class _AttemptRetry:
 
 
 @dataclass(frozen=True)
-class _AttemptFailHard:
+class _AttemptFailHard(_AttemptOutcomeBase):
     """Attempt failure that must propagate as `SetupError` (no fallthrough)."""
 
     error: "SetupError"
@@ -302,13 +308,15 @@ class SetupOrchestrator:
                 attempt + 1,
                 e,
             )
-            if attempt < max_retries:
-                return _AttemptRetry(last_result=None)
-            return _AttemptFailHard(
-                SetupError(
-                    f"Step '{step.name}' failed: transport error after {max_retries + 1} attempts: {e}",
-                    step_name=step.name,
-                    cause=e,
+            return (
+                _AttemptRetry(last_result=None)
+                if attempt < max_retries
+                else _AttemptFailHard(
+                    SetupError(
+                        f"Step '{step.name}' failed: transport error after {max_retries + 1} attempts: {e}",
+                        step_name=step.name,
+                        cause=e,
+                    )
                 )
             )
 
@@ -365,12 +373,14 @@ class SetupOrchestrator:
                     step.name,
                     self._mask_sensitive_output(result.stdout, context),
                 )
-            if attempt < max_retries:
-                return _AttemptRetry(last_result=result)
-            return _AttemptFailHard(
-                SetupError(
-                    f"Step '{step.name}' failed: PAN-OS commit failed after {max_retries + 1} attempts",
-                    step_name=step.name,
+            return (
+                _AttemptRetry(last_result=result)
+                if attempt < max_retries
+                else _AttemptFailHard(
+                    SetupError(
+                        f"Step '{step.name}' failed: PAN-OS commit failed after {max_retries + 1} attempts",
+                        step_name=step.name,
+                    )
                 )
             )
 
@@ -399,12 +409,14 @@ class SetupOrchestrator:
             document_name,
         )
         if not poll_success:
-            if attempt < max_retries:
-                return _AttemptRetry(last_result=result)
-            return _AttemptFailHard(
-                SetupError(
-                    f"Step '{step.name}' failed: PAN-OS job {job_id} did not complete successfully",
-                    step_name=step.name,
+            return (
+                _AttemptRetry(last_result=result)
+                if attempt < max_retries
+                else _AttemptFailHard(
+                    SetupError(
+                        f"Step '{step.name}' failed: PAN-OS job {job_id} did not complete successfully",
+                        step_name=step.name,
+                    )
                 )
             )
 

--- a/shifter/engine/provisioner/orchestrators/setup_orchestrator.py
+++ b/shifter/engine/provisioner/orchestrators/setup_orchestrator.py
@@ -51,6 +51,33 @@ class SetupResult:
     error: str | None = None
 
 
+# Internal discriminated outcome of a single attempt inside `_execute_step`.
+# The retry loop dispatches on these; this keeps per-attempt control flow
+# out of the loop body so the loop itself stays trivially readable.
+@dataclass(frozen=True)
+class _AttemptSuccess:
+    result: CommandResult
+
+
+@dataclass(frozen=True)
+class _AttemptRetry:
+    """Attempt should be retried (or, if retries exhausted, fall through to
+    a failed StepResult). `last_result` carries the most recent CommandResult
+    if one was produced (None for pre-execution transport errors)."""
+
+    last_result: CommandResult | None
+
+
+@dataclass(frozen=True)
+class _AttemptFailHard:
+    """Attempt failure that must propagate as `SetupError` (no fallthrough)."""
+
+    error: "SetupError"
+
+
+_AttemptOutcome = _AttemptSuccess | _AttemptRetry | _AttemptFailHard
+
+
 class SetupOrchestrator:
     """Orchestrates setup plan execution.
 
@@ -185,7 +212,7 @@ class SetupOrchestrator:
             verification_result=verify_result,
         )
 
-    def _execute_step(  # noqa: C901
+    def _execute_step(
         self,
         instance_id: str,
         step: SetupStep,
@@ -195,175 +222,268 @@ class SetupOrchestrator:
     ) -> StepResult:
         """Execute a single step with retry support.
 
-        Args:
-            instance_id: Target instance
-            step: Step to execute
-            context: Template variables
-            document_name: SSM document to use
-            max_retries: Number of retry attempts on failure (default 1)
-
-        Returns:
-            StepResult with step output
+        Per-attempt logic lives in `_run_one_attempt`, which returns an
+        `_AttemptOutcome` so this loop only has to dispatch on three cases:
+        success (return), hard failure (raise), retry (loop or fall through).
 
         Raises:
-            CommandError, TimeoutError, SetupError: On failure after retries
+            SetupError: transport-error / PAN-OS poll-fail / silent-commit-fail
+                after retries are exhausted.
         """
         import time
 
         logger.info("_execute_step: starting step=%s", step.name)
-        # Render the script and stdin_input with context variables
         rendered_script = self._render_script(step.script, context, step.name)
-        rendered_stdin = self._render_script(getattr(step, "stdin_input", "") or "", context, step.name)
+        rendered_stdin = self._render_script(step.stdin_input or "", context, step.name)
 
-        last_result = None
+        last_result: CommandResult | None = None
         for attempt in range(max_retries + 1):
             if attempt > 0:
                 logger.info("_execute_step: retry %d/%d for step=%s", attempt, max_retries, step.name)
-                time.sleep(15)  # Pause before retry
+                time.sleep(15)
 
-            # Execute via executor (SSM or SSH)
-            try:
-                result = self.executor.run_command(
-                    instance_id=instance_id,
-                    script=rendered_script,
-                    timeout_seconds=step.timeout_seconds,
-                    document_name=document_name,
-                    stdin_input=rendered_stdin if rendered_stdin else None,
-                )
-            except (ExecutorConnectionError, ExecutorTimeoutError) as e:
-                logger.warning(
-                    "_execute_step: transport error step=%s attempt=%d: %s",
-                    step.name,
-                    attempt + 1,
-                    e,
-                )
-                if attempt < max_retries:
-                    continue  # Retry
-                raise SetupError(
-                    f"Step '{step.name}' failed: transport error after {max_retries + 1} attempts: {e}",
-                    step_name=step.name,
-                    cause=e,
-                ) from e
-            last_result = result
-
-            if result.success:
-                if result.stdout and "commit" in result.stdout.lower():
-                    output_lower = result.stdout.lower()
-                    if "configuration committed successfully" in output_lower:
-                        logger.info("_execute_step: step=%s commit=immediate_success", step.name)
-                    elif "there are no changes to commit" in output_lower:
-                        logger.info("_execute_step: step=%s commit=no_changes", step.name)
-                    elif "jobid" in output_lower:
-                        logger.info("_execute_step: step=%s commit=job_enqueued", step.name)
-                    else:
-                        logger.info("_execute_step: step=%s commit=unknown_output", step.name)
-
-                # If poll_for_job is enabled, parse job ID and poll until complete
-                if getattr(step, "poll_for_job", False):
-                    job_id = self._parse_panos_job_id(result.stdout)
-                    if job_id:
-                        logger.info("_execute_step: polling for job %s completion", job_id)
-                        poll_success, poll_output = self._poll_panos_job(
-                            instance_id, job_id, step.timeout_seconds, document_name
-                        )
-                        if not poll_success:
-                            if attempt < max_retries:
-                                continue  # Retry
-                            raise SetupError(
-                                f"Step '{step.name}' failed: PAN-OS job {job_id} did not complete successfully",
-                                step_name=step.name,
-                            )
-                        # Append poll output to result
-                        result = CommandResult(
-                            success=True,
-                            exit_code=0,
-                            stdout=result.stdout + "\n" + poll_output,
-                            stderr=result.stderr,
-                        )
-                    else:
-                        logger.warning("_execute_step: poll_for_job enabled but no job ID found in output")
-
-                # Check for PAN-OS commit failures (SSH sessions return success even when commit fails)
-                if not self._check_commit_success(result.stdout):
-                    logger.warning(
-                        "_execute_step: PAN-OS commit failed step=%s attempt=%d/%d",
-                        step.name,
-                        attempt + 1,
-                        max_retries + 1,
-                    )
-                    if result.stdout:
-                        masked_stdout = self._mask_sensitive_output(result.stdout, context)
-                        logger.warning(
-                            "_execute_step: step=%s COMMIT FAILED STDOUT:\n%s",
-                            step.name,
-                            masked_stdout,
-                        )
-                    if attempt < max_retries:
-                        continue  # Retry
-                    raise SetupError(
-                        f"Step '{step.name}' failed: PAN-OS commit failed after {max_retries + 1} attempts",
-                        step_name=step.name,
-                    )
-
-                # Log success with full output for visibility
-                logger.info(
-                    "_execute_step: completed step=%s exit_code=%d",
-                    step.name,
-                    result.exit_code,
-                )
-                if result.stdout:
-                    masked_stdout = self._mask_sensitive_output(result.stdout, context)
-                    # Log full output - critical for debugging setup issues
-                    logger.info(
-                        "_execute_step: step=%s STDOUT:\n%s",
-                        step.name,
-                        masked_stdout,
-                    )
-                if result.stderr:
-                    masked_stderr = self._mask_sensitive_output(result.stderr, context)
-                    logger.info(
-                        "_execute_step: step=%s STDERR:\n%s",
-                        step.name,
-                        masked_stderr,
-                    )
+            outcome = self._run_one_attempt(
+                instance_id,
+                step,
+                rendered_script,
+                rendered_stdin,
+                context,
+                document_name,
+                attempt,
+                max_retries,
+            )
+            if isinstance(outcome, _AttemptSuccess):
+                self._log_step_success(step, outcome.result, context)
                 return StepResult(
                     step_name=step.name,
                     success=True,
-                    stdout=result.stdout,
-                    stderr=result.stderr,
+                    stdout=outcome.result.stdout,
+                    stderr=outcome.result.stderr,
                 )
-            else:
-                logger.warning(
-                    "_execute_step: FAILED step=%s attempt=%d/%d exit_code=%d",
-                    step.name,
-                    attempt + 1,
-                    max_retries + 1,
-                    result.exit_code,
-                )
-                if result.stdout:
-                    masked_stdout = self._mask_sensitive_output(result.stdout, context)
-                    logger.warning(
-                        "_execute_step: step=%s FAILED STDOUT:\n%s",
-                        step.name,
-                        masked_stdout,
-                    )
-                if result.stderr:
-                    masked_stderr = self._mask_sensitive_output(result.stderr, context)
-                    logger.warning(
-                        "_execute_step: step=%s FAILED STDERR:\n%s",
-                        step.name,
-                        masked_stderr,
-                    )
-                if attempt < max_retries:
-                    continue  # Retry
+            if isinstance(outcome, _AttemptFailHard):
+                raise outcome.error
+            # _AttemptRetry: remember last result, loop again
+            last_result = outcome.last_result
 
-        # All retries exhausted
+        # All retries exhausted on the soft-failure path (exit-nonzero).
+        # Asymmetry preserved: this path RETURNS a failed StepResult; the
+        # hard-failure paths above RAISE via _AttemptFailHard.
         return StepResult(
             step_name=step.name,
             success=False,
             stdout=last_result.stdout if last_result else "",
             stderr=last_result.stderr if last_result else "",
         )
+
+    def _run_one_attempt(
+        self,
+        instance_id: str,
+        step: SetupStep,
+        rendered_script: str,
+        rendered_stdin: str,
+        context: dict[str, Any],
+        document_name: str,
+        attempt: int,
+        max_retries: int,
+    ) -> _AttemptOutcome:
+        """Execute one attempt and classify the outcome."""
+        try:
+            result = self.executor.run_command(
+                instance_id=instance_id,
+                script=rendered_script,
+                timeout_seconds=step.timeout_seconds,
+                document_name=document_name,
+                stdin_input=rendered_stdin if rendered_stdin else None,
+            )
+        except (ExecutorConnectionError, ExecutorTimeoutError) as e:
+            logger.warning(
+                "_execute_step: transport error step=%s attempt=%d: %s",
+                step.name,
+                attempt + 1,
+                e,
+            )
+            if attempt < max_retries:
+                return _AttemptRetry(last_result=None)
+            return _AttemptFailHard(
+                SetupError(
+                    f"Step '{step.name}' failed: transport error after {max_retries + 1} attempts: {e}",
+                    step_name=step.name,
+                    cause=e,
+                )
+            )
+
+        if not result.success:
+            self._log_step_failure(step, result, attempt, max_retries, context)
+            return _AttemptRetry(last_result=result)
+
+        return self._classify_successful_attempt(
+            instance_id,
+            step,
+            result,
+            context,
+            document_name,
+            attempt,
+            max_retries,
+        )
+
+    def _classify_successful_attempt(
+        self,
+        instance_id: str,
+        step: SetupStep,
+        result: CommandResult,
+        context: dict[str, Any],
+        document_name: str,
+        attempt: int,
+        max_retries: int,
+    ) -> _AttemptOutcome:
+        """Post-process an exit-0 CommandResult with PAN-OS-specific checks."""
+        self._log_panos_commit_outcome(step.name, result.stdout)
+
+        if step.poll_for_job:
+            poll_outcome = self._handle_panos_poll(
+                instance_id,
+                step,
+                result,
+                document_name,
+                attempt,
+                max_retries,
+            )
+            if not isinstance(poll_outcome, _AttemptSuccess):
+                return poll_outcome
+            result = poll_outcome.result
+
+        if not self._check_commit_success(result.stdout):
+            logger.warning(
+                "_execute_step: PAN-OS commit failed step=%s attempt=%d/%d",
+                step.name,
+                attempt + 1,
+                max_retries + 1,
+            )
+            if result.stdout:
+                logger.warning(
+                    "_execute_step: step=%s COMMIT FAILED STDOUT:\n%s",
+                    step.name,
+                    self._mask_sensitive_output(result.stdout, context),
+                )
+            if attempt < max_retries:
+                return _AttemptRetry(last_result=result)
+            return _AttemptFailHard(
+                SetupError(
+                    f"Step '{step.name}' failed: PAN-OS commit failed after {max_retries + 1} attempts",
+                    step_name=step.name,
+                )
+            )
+
+        return _AttemptSuccess(result=result)
+
+    def _handle_panos_poll(
+        self,
+        instance_id: str,
+        step: SetupStep,
+        result: CommandResult,
+        document_name: str,
+        attempt: int,
+        max_retries: int,
+    ) -> _AttemptOutcome:
+        """Resolve a `poll_for_job` step: parse job id, poll, augment result."""
+        job_id = self._parse_panos_job_id(result.stdout)
+        if not job_id:
+            logger.warning("_execute_step: poll_for_job enabled but no job ID found in output")
+            return _AttemptSuccess(result=result)
+
+        logger.info("_execute_step: polling for job %s completion", job_id)
+        poll_success, poll_output = self._poll_panos_job(
+            instance_id,
+            job_id,
+            step.timeout_seconds,
+            document_name,
+        )
+        if not poll_success:
+            if attempt < max_retries:
+                return _AttemptRetry(last_result=result)
+            return _AttemptFailHard(
+                SetupError(
+                    f"Step '{step.name}' failed: PAN-OS job {job_id} did not complete successfully",
+                    step_name=step.name,
+                )
+            )
+
+        return _AttemptSuccess(
+            result=CommandResult(
+                success=True,
+                exit_code=0,
+                stdout=result.stdout + "\n" + poll_output,
+                stderr=result.stderr,
+            )
+        )
+
+    @staticmethod
+    def _log_panos_commit_outcome(step_name: str, stdout: str) -> None:
+        """Classify and log a PAN-OS commit line if present in stdout."""
+        if not stdout or "commit" not in stdout.lower():
+            return
+        output_lower = stdout.lower()
+        if "configuration committed successfully" in output_lower:
+            outcome = "immediate_success"
+        elif "there are no changes to commit" in output_lower:
+            outcome = "no_changes"
+        elif "jobid" in output_lower:
+            outcome = "job_enqueued"
+        else:
+            outcome = "unknown_output"
+        logger.info("_execute_step: step=%s commit=%s", step_name, outcome)
+
+    def _log_step_success(
+        self,
+        step: SetupStep,
+        result: CommandResult,
+        context: dict[str, Any],
+    ) -> None:
+        logger.info(
+            "_execute_step: completed step=%s exit_code=%d",
+            step.name,
+            result.exit_code,
+        )
+        if result.stdout:
+            logger.info(
+                "_execute_step: step=%s STDOUT:\n%s",
+                step.name,
+                self._mask_sensitive_output(result.stdout, context),
+            )
+        if result.stderr:
+            logger.info(
+                "_execute_step: step=%s STDERR:\n%s",
+                step.name,
+                self._mask_sensitive_output(result.stderr, context),
+            )
+
+    def _log_step_failure(
+        self,
+        step: SetupStep,
+        result: CommandResult,
+        attempt: int,
+        max_retries: int,
+        context: dict[str, Any],
+    ) -> None:
+        logger.warning(
+            "_execute_step: FAILED step=%s attempt=%d/%d exit_code=%d",
+            step.name,
+            attempt + 1,
+            max_retries + 1,
+            result.exit_code,
+        )
+        if result.stdout:
+            logger.warning(
+                "_execute_step: step=%s FAILED STDOUT:\n%s",
+                step.name,
+                self._mask_sensitive_output(result.stdout, context),
+            )
+        if result.stderr:
+            logger.warning(
+                "_execute_step: step=%s FAILED STDERR:\n%s",
+                step.name,
+                self._mask_sensitive_output(result.stderr, context),
+            )
 
     @classmethod
     def _mask_sensitive_output(cls, output: str, context: dict[str, Any] | None = None) -> str:

--- a/shifter/engine/provisioner/tests/test_setup_orchestrator.py
+++ b/shifter/engine/provisioner/tests/test_setup_orchestrator.py
@@ -10,7 +10,11 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from executors.base import CommandResult
+from executors.base import (
+    CommandResult,
+    ExecutorConnectionError,
+    ExecutorTimeoutError,
+)
 from executors.ssm_executor import (
     CommandError,
     SSMExecutor,
@@ -390,6 +394,120 @@ class TestSensitiveOutputMasking:
         assert result.success is False
         assert secret not in caplog.text
         assert "[REDACTED]" in caplog.text
+
+
+class TestExecuteStepRetryAsymmetry:
+    """Pin asymmetric exit paths in `_execute_step` so any refactor preserves them.
+
+    The function has three retry-exhaustion outcomes that MUST stay distinct:
+    1. Transport error exhausted -> raise SetupError
+    2. Exit-nonzero exhausted    -> return failed StepResult (NO raise)
+    3. PAN-OS commit-fail / poll-fail exhausted -> raise SetupError
+
+    Mixing these up (e.g. raising on exit-nonzero exhaustion, or returning on
+    transport-error exhaustion) would change the contract the outer
+    `orchestrate()` method depends on.
+    """
+
+    def _step(self, **overrides) -> SetupStep:
+        return SetupStep(
+            name=overrides.pop("name", "s"),
+            script=overrides.pop("script", "echo hi"),
+            timeout_seconds=overrides.pop("timeout_seconds", 10),
+            **overrides,
+        )
+
+    def test_transport_error_retries_then_succeeds(self, monkeypatch):
+        """Transport error on first attempt + success on second -> success."""
+        monkeypatch.setattr("time.sleep", lambda *_a, **_k: None)
+        executor = MagicMock(spec=SSMExecutor)
+        executor.run_command.side_effect = [
+            ExecutorConnectionError("conn reset"),
+            CommandResult(success=True, exit_code=0, stdout="ok", stderr=""),
+        ]
+        orch = SetupOrchestrator(executor=executor)
+
+        result = orch._execute_step("i-1", self._step(), {}, "AWS-RunPowerShellScript", max_retries=1)
+
+        assert result.success is True
+        assert executor.run_command.call_count == 2
+
+    def test_transport_error_exhausted_raises_setup_error(self, monkeypatch):
+        """All attempts hit transport errors -> SetupError raised (not returned)."""
+        monkeypatch.setattr("time.sleep", lambda *_a, **_k: None)
+        executor = MagicMock(spec=SSMExecutor)
+        executor.run_command.side_effect = ExecutorTimeoutError("timeout")
+        orch = SetupOrchestrator(executor=executor)
+
+        with pytest.raises(SetupError) as exc:
+            orch._execute_step("i-1", self._step(), {}, "AWS-RunPowerShellScript", max_retries=2)
+
+        assert "transport error" in str(exc.value).lower()
+        assert exc.value.step_name == "s"
+        # max_retries=2 means 3 attempts (initial + 2 retries)
+        assert executor.run_command.call_count == 3
+
+    def test_exit_nonzero_exhausted_returns_failed_step_result(self, monkeypatch):
+        """All attempts exit non-zero -> failed StepResult returned (NOT raised).
+
+        This asymmetry matters: `orchestrate()` distinguishes the two by
+        checking `result.success` and raising itself. A refactor that raises
+        from `_execute_step` on exit-nonzero exhaustion would double-wrap
+        the error and could change exception types observed downstream.
+        """
+        monkeypatch.setattr("time.sleep", lambda *_a, **_k: None)
+        executor = MagicMock(spec=SSMExecutor)
+        executor.run_command.return_value = CommandResult(success=False, exit_code=2, stdout="boom", stderr="err")
+        orch = SetupOrchestrator(executor=executor)
+
+        result = orch._execute_step("i-1", self._step(), {}, "AWS-RunPowerShellScript", max_retries=2)
+
+        assert result.success is False
+        assert result.stdout == "boom"
+        assert result.stderr == "err"
+        assert executor.run_command.call_count == 3
+
+    def test_panos_poll_failure_exhausted_raises(self, monkeypatch):
+        """`poll_for_job` with persistent poll failure -> SetupError raised."""
+        monkeypatch.setattr("time.sleep", lambda *_a, **_k: None)
+        executor = MagicMock(spec=SSMExecutor)
+        executor.run_command.return_value = CommandResult(
+            success=True, exit_code=0, stdout="job enqueued with jobid 42", stderr=""
+        )
+        orch = SetupOrchestrator(executor=executor)
+        # Stub the poll to always say the job failed; counts as exhaustion.
+        monkeypatch.setattr(orch, "_poll_panos_job", lambda *_a, **_k: (False, "FIN err"))
+        step = self._step(poll_for_job=True)
+
+        with pytest.raises(SetupError) as exc:
+            orch._execute_step("i-1", step, {}, "AWS-RunPowerShellScript", max_retries=1)
+
+        assert "job 42" in str(exc.value)
+        assert exc.value.step_name == "s"
+
+    def test_panos_silent_commit_failure_exhausted_raises(self, monkeypatch):
+        """Exit-0 with `commit` in stdout but no success marker -> SetupError after retries.
+
+        SSH commit sessions return success even when the commit failed; the
+        orchestrator detects this via `_check_commit_success` and treats it
+        as a hard failure when retries are exhausted. The asymmetry vs. plain
+        exit-nonzero is intentional: a "silent failure" SHOULD raise.
+        """
+        monkeypatch.setattr("time.sleep", lambda *_a, **_k: None)
+        executor = MagicMock(spec=SSMExecutor)
+        executor.run_command.return_value = CommandResult(
+            success=True,
+            exit_code=0,
+            stdout="commit issued but rejected by device",
+            stderr="",
+        )
+        orch = SetupOrchestrator(executor=executor)
+
+        with pytest.raises(SetupError) as exc:
+            orch._execute_step("i-1", self._step(), {}, "AWS-RunPowerShellScript", max_retries=1)
+
+        assert "commit failed" in str(exc.value).lower()
+        assert exc.value.step_name == "s"
 
 
 class TestRebootTimeout:

--- a/shifter/shifter_platform/cms/assets/s3.py
+++ b/shifter/shifter_platform/cms/assets/s3.py
@@ -208,7 +208,7 @@ def read_agent_header(s3_key: str, max_bytes: int) -> bytes:
             max_bytes=max_bytes,
         )
     except CloudStorageError as e:
-        logger.error("read_agent_header: failed s3_key=%s error=%s", s3_key, e)
+        logger.exception("read_agent_header: failed s3_key=%s error=%s", s3_key, e)
         raise S3Error(str(e)) from e
 
 

--- a/shifter/shifter_platform/cms/experiments/s3.py
+++ b/shifter/shifter_platform/cms/experiments/s3.py
@@ -201,7 +201,7 @@ def read_script_header(s3_key: str, max_bytes: int) -> bytes:
             max_bytes=max_bytes,
         )
     except CloudStorageError as e:
-        logger.error(
+        logger.exception(
             "read_script_header: failed s3_key=%s error=%s",
             safe_log(s3_key),
             safe_log(str(e)),

--- a/shifter/shifter_platform/cms/experiments/services.py
+++ b/shifter/shifter_platform/cms/experiments/services.py
@@ -221,7 +221,7 @@ def complete_script_upload(user: User, upload_token: str) -> ScriptAsset:
         try:
             body = read_script_header(s3_key, max_size)
         except S3Error as e:
-            logger.error(
+            logger.exception(
                 "complete_script_upload: body read failed s3_key=%s: %s",
                 safe_log(s3_key),
                 safe_log(str(e)),
@@ -240,7 +240,7 @@ def complete_script_upload(user: User, upload_token: str) -> ScriptAsset:
             try:
                 delete_s3_object(s3_key)
             except S3Error as delete_exc:
-                logger.error(
+                logger.exception(
                     "complete_script_upload: delete after inspection failure also failed s3_key=%s: %s",
                     safe_log(s3_key),
                     safe_log(str(delete_exc)),

--- a/shifter/shifter_platform/cms/services.py
+++ b/shifter/shifter_platform/cms/services.py
@@ -2689,6 +2689,104 @@ def _validate_initiate_upload_inputs(
     return name, filename
 
 
+def _initiate_upload_inner(
+    user: User,
+    name: str,
+    filename: str,
+    file_size: int,
+    agent_type: str,
+) -> dict[str, Any]:
+    """Quota check, extension validation, presigned-URL + upload-token issuance.
+
+    Split out of `initiate_upload` so that function carries only input
+    validation and exception-translation, keeping each below the per-function
+    complexity ceiling.
+    """
+    from django.conf import settings
+
+    from cms.assets.s3 import S3Error, generate_presigned_upload_url
+    from cms.assets.services import get_storage_used
+    from cms.assets.upload_token import generate_upload_token
+    from cms.assets.validation import ValidationError, validate_file_extension
+    from cms.exceptions import CMSError
+
+    current_usage = get_storage_used(user)
+    quota_bytes = settings.AGENT_USER_STORAGE_QUOTA_MB * 1024 * 1024
+    if current_usage + file_size > quota_bytes:
+        available_mb = (quota_bytes - current_usage) / 1024 / 1024
+        logger.error(
+            "initiate_upload: quota exceeded for user_id=%s - current=%s, requested=%s, quota=%s",
+            user.id,
+            current_usage,
+            file_size,
+            quota_bytes,
+        )
+        msg = (
+            f"Storage quota exceeded. You have {available_mb:.1f} MB "
+            f"available of {settings.AGENT_USER_STORAGE_QUOTA_MB} "
+            f"MB total."
+        )
+        raise CMSError(msg)
+
+    try:
+        file_format = validate_file_extension(filename)
+    except ValidationError as e:
+        logger.error(
+            "initiate_upload: validation error for user_id=%s - %s",
+            user.id,
+            str(e),
+        )
+        raise CMSError(str(e)) from e
+
+    try:
+        presigned_url, s3_key = generate_presigned_upload_url(
+            user_id=user.id,
+            filename=filename,
+        )
+    except S3Error as e:
+        logger.error(
+            "initiate_upload: S3 error for user_id=%s - %s",
+            user.id,
+            str(e),
+        )
+        raise CMSError("Failed to initiate upload") from e
+
+    # Agent installer formats always carry an os_slug — the shared FileFormat
+    # dataclass makes the field Optional for non-installer consumers (CTF),
+    # so narrow here.
+    os_slug = file_format.os_slug
+    if os_slug is None:
+        logger.error(
+            "initiate_upload: installer format missing os_slug for filename=%s",
+            filename,
+        )
+        raise CMSError("Internal error: installer format misconfigured")
+
+    upload_token = generate_upload_token(
+        user_id=user.id,
+        s3_key=s3_key,
+        name=name,
+        filename=filename,
+        os_slug=os_slug,
+        file_size=file_size,
+        agent_type=agent_type,
+    )
+
+    logger.debug(
+        "initiate_upload completed for user_id=%s, filename=%s, s3_key=%s",
+        user.id,
+        filename,
+        s3_key,
+    )
+
+    return {
+        "presigned_url": presigned_url,
+        "s3_key": s3_key,
+        "upload_token": upload_token,
+        "expected_os": file_format.os_slug,
+    }
+
+
 def initiate_upload(
     user: User,
     name: str,
@@ -2722,12 +2820,6 @@ def initiate_upload(
             file_size is invalid
         CMSError: If quota exceeded, invalid extension, or S3 error
     """
-    from django.conf import settings
-
-    from cms.assets.s3 import S3Error, generate_presigned_upload_url
-    from cms.assets.services import get_storage_used
-    from cms.assets.upload_token import generate_upload_token
-    from cms.assets.validation import ValidationError, validate_file_extension
     from cms.exceptions import CMSError
 
     name, filename = _validate_initiate_upload_inputs(user, name, filename, file_size)
@@ -2740,86 +2832,8 @@ def initiate_upload(
     )
 
     try:
-        # Check storage quota
-        current_usage = get_storage_used(user)
-        quota_bytes = settings.AGENT_USER_STORAGE_QUOTA_MB * 1024 * 1024
-        if current_usage + file_size > quota_bytes:
-            available_mb = (quota_bytes - current_usage) / 1024 / 1024
-            logger.error(
-                "initiate_upload: quota exceeded for user_id=%s - current=%s, requested=%s, quota=%s",
-                user.id,
-                current_usage,
-                file_size,
-                quota_bytes,
-            )
-            msg = (
-                f"Storage quota exceeded. You have {available_mb:.1f} MB "
-                f"available of {settings.AGENT_USER_STORAGE_QUOTA_MB} "
-                f"MB total."
-            )
-            raise CMSError(msg)
-
-        # Validate file extension
-        try:
-            file_format = validate_file_extension(filename)
-        except ValidationError as e:
-            logger.error(
-                "initiate_upload: validation error for user_id=%s - %s",
-                user.id,
-                str(e),
-            )
-            raise CMSError(str(e)) from e
-
-        # Generate presigned URL
-        try:
-            presigned_url, s3_key = generate_presigned_upload_url(
-                user_id=user.id,
-                filename=filename,
-            )
-        except S3Error as e:
-            logger.error(
-                "initiate_upload: S3 error for user_id=%s - %s",
-                user.id,
-                str(e),
-            )
-            raise CMSError("Failed to initiate upload") from e
-
-        # Generate upload token. Agent installer formats always carry an
-        # os_slug — the shared FileFormat dataclass makes the field Optional
-        # for non-installer consumers (CTF), so narrow here.
-        os_slug = file_format.os_slug
-        if os_slug is None:
-            logger.error(
-                "initiate_upload: installer format missing os_slug for filename=%s",
-                filename,
-            )
-            raise CMSError("Internal error: installer format misconfigured")
-        upload_token = generate_upload_token(
-            user_id=user.id,
-            s3_key=s3_key,
-            name=name,
-            filename=filename,
-            os_slug=os_slug,
-            file_size=file_size,
-            agent_type=agent_type,
-        )
-
-        logger.debug(
-            "initiate_upload completed for user_id=%s, filename=%s, s3_key=%s",
-            user.id,
-            filename,
-            s3_key,
-        )
-
-        return {
-            "presigned_url": presigned_url,
-            "s3_key": s3_key,
-            "upload_token": upload_token,
-            "expected_os": file_format.os_slug,
-        }
-
+        return _initiate_upload_inner(user, name, filename, file_size, agent_type)
     except (TypeError, ValueError, CMSError):
-        # Re-raise known errors
         raise
     except Exception:
         logger.exception("Error in initiate_upload for user_id=%s", user.id)

--- a/shifter/shifter_platform/cms/services.py
+++ b/shifter/shifter_platform/cms/services.py
@@ -2635,7 +2635,61 @@ def resume_range_by_request_id(user: User, request_id: str) -> None:
 # =============================================================================
 
 
-def initiate_upload(  # noqa: C901
+def _validate_initiate_upload_inputs(
+    user: User,
+    name: str,
+    filename: str,
+    file_size: int,
+) -> tuple[str, str]:
+    """Validate inputs for `initiate_upload` and return normalized (name, filename)."""
+    if user is None:
+        logger.error("initiate_upload called with None user")
+        raise TypeError(USER_CANNOT_BE_NONE)
+    if not hasattr(user, "id"):
+        logger.error(
+            "initiate_upload called with invalid user type: %s",
+            type(user).__name__,
+        )
+        msg = f"user must be a User instance, got {type(user).__name__}"
+        raise TypeError(msg)
+    if user.id is None:
+        logger.error("initiate_upload called with unsaved user (id=None)")
+        raise ValueError(USER_MUST_BE_SAVED)
+    if name is None:
+        logger.error("initiate_upload called with None name for user_id=%s", user.id)
+        raise ValueError("name cannot be None")
+    name = name.strip()
+    if not name:
+        logger.error("initiate_upload called with empty name for user_id=%s", user.id)
+        raise ValueError("name cannot be empty")
+    if filename is None:
+        logger.error("initiate_upload called with None filename for user_id=%s", user.id)
+        raise ValueError("filename cannot be None")
+    filename = filename.strip()
+    if not filename:
+        logger.error("initiate_upload called with empty filename for user_id=%s", user.id)
+        raise ValueError("filename cannot be empty")
+    if file_size is None:
+        logger.error("initiate_upload called with None file_size for user_id=%s", user.id)
+        raise TypeError("file_size cannot be None")
+    if not isinstance(file_size, int):
+        logger.error(
+            "initiate_upload called with invalid file_size type: %s",
+            type(file_size).__name__,
+        )
+        msg = f"file_size must be an int, got {type(file_size).__name__}"
+        raise TypeError(msg)
+    if file_size <= 0:
+        logger.error(
+            "initiate_upload called with invalid file_size=%s for user_id=%s",
+            file_size,
+            user.id,
+        )
+        raise ValueError("file_size must be positive")
+    return name, filename
+
+
+def initiate_upload(
     user: User,
     name: str,
     filename: str,
@@ -2676,78 +2730,7 @@ def initiate_upload(  # noqa: C901
     from cms.assets.validation import ValidationError, validate_file_extension
     from cms.exceptions import CMSError
 
-    # Input validation - user
-    if user is None:
-        logger.error("initiate_upload called with None user")
-        raise TypeError(USER_CANNOT_BE_NONE)
-
-    if not hasattr(user, "id"):
-        logger.error(
-            "initiate_upload called with invalid user type: %s",
-            type(user).__name__,
-        )
-        msg = f"user must be a User instance, got {type(user).__name__}"
-        raise TypeError(msg)
-
-    if user.id is None:
-        logger.error("initiate_upload called with unsaved user (id=None)")
-        raise ValueError(USER_MUST_BE_SAVED)
-
-    # Input validation - name
-    if name is None:
-        logger.error(
-            "initiate_upload called with None name for user_id=%s",
-            user.id,
-        )
-        raise ValueError("name cannot be None")
-
-    name = name.strip()
-    if not name:
-        logger.error(
-            "initiate_upload called with empty name for user_id=%s",
-            user.id,
-        )
-        raise ValueError("name cannot be empty")
-
-    # Input validation - filename
-    if filename is None:
-        logger.error(
-            "initiate_upload called with None filename for user_id=%s",
-            user.id,
-        )
-        raise ValueError("filename cannot be None")
-
-    filename = filename.strip()
-    if not filename:
-        logger.error(
-            "initiate_upload called with empty filename for user_id=%s",
-            user.id,
-        )
-        raise ValueError("filename cannot be empty")
-
-    # Input validation - file_size
-    if file_size is None:
-        logger.error(
-            "initiate_upload called with None file_size for user_id=%s",
-            user.id,
-        )
-        raise TypeError("file_size cannot be None")
-
-    if not isinstance(file_size, int):
-        logger.error(
-            "initiate_upload called with invalid file_size type: %s",
-            type(file_size).__name__,
-        )
-        msg = f"file_size must be an int, got {type(file_size).__name__}"
-        raise TypeError(msg)
-
-    if file_size <= 0:
-        logger.error(
-            "initiate_upload called with invalid file_size=%s for user_id=%s",
-            file_size,
-            user.id,
-        )
-        raise ValueError("file_size must be positive")
+    name, filename = _validate_initiate_upload_inputs(user, name, filename, file_size)
 
     logger.debug(
         "initiate_upload called for user_id=%s, filename=%s, file_size=%s",
@@ -3099,7 +3082,7 @@ def cancel_upload(user: User, upload_token: str) -> None:
         try:
             payload = verify_upload_token(upload_token, user.id)
         except ValueError as e:
-            logger.error(
+            logger.exception(
                 "cancel_upload: token verification failed for user_id=%s - %s",
                 user.id,
                 str(e),

--- a/shifter/shifter_platform/ctf/inspection.py
+++ b/shifter/shifter_platform/ctf/inspection.py
@@ -87,7 +87,8 @@ _ZIP_ALTERNATIVES = (
 )
 _BZIP2 = _fmt("bzip2", (MagicSignature(0, b"BZh"),))
 _7Z = _fmt("7-Zip", (MagicSignature(0, b"\x37\x7a\xbc\xaf\x27\x1c"),))
-_SQLITE = _fmt("SQLite database", (MagicSignature(0, b"SQLite format 3\x00"),))
+_SQLITE_DESC = "SQLite database"
+_SQLITE = _fmt(_SQLITE_DESC, (MagicSignature(0, b"SQLite format 3\x00"),))
 _PCAP_ALTERNATIVES = (
     _fmt("libpcap (LE, microseconds)", (MagicSignature(0, b"\xd4\xc3\xb2\xa1"),)),
     _fmt("libpcap (BE, microseconds)", (MagicSignature(0, b"\xa1\xb2\xc3\xd4"),)),
@@ -159,8 +160,8 @@ _RULES: dict[str, _CTFRule] = {
     ".pcapng": _CTFRule(_Category.MAGIC, "pcapng capture", (_PCAPNG,)),
     ".cap": _CTFRule(_Category.MAGIC, "packet capture", (*_PCAP_ALTERNATIVES, _PCAPNG)),
     # Databases
-    ".sqlite": _CTFRule(_Category.MAGIC, "SQLite database", (_SQLITE,)),
-    ".db": _CTFRule(_Category.MAGIC, "SQLite database", (_SQLITE,)),
+    ".sqlite": _CTFRule(_Category.MAGIC, _SQLITE_DESC, (_SQLITE,)),
+    ".db": _CTFRule(_Category.MAGIC, _SQLITE_DESC, (_SQLITE,)),
     ".sql": _CTFRule(_Category.TEXT, "SQL script"),
     # Crypto / certs — PKCS#12 archives are DER binary; .crt and .key
     # legitimately ship in either PEM or DER encoding.

--- a/shifter/shifter_platform/ctf/services/attachment.py
+++ b/shifter/shifter_platform/ctf/services/attachment.py
@@ -37,6 +37,49 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _run_text_stream_validation(
+    file_obj,
+    ext: str,
+    challenge_id: UUID,
+    actor_id: int,
+    filename: str,
+) -> None:
+    """Full-body text validation for TEXT-category extensions.
+
+    Feeds the whole file through a UTF-8 incremental decoder so any binary
+    bytes in the tail of an otherwise-text-looking upload are rejected before
+    S3.
+    """
+    from shared.uploads.inspection import InspectionError as _Inspect
+
+    stream_validator = new_text_stream_validator()
+    try:
+        file_obj.seek(0)
+        while True:
+            chunk = file_obj.read(8192)
+            if not chunk:
+                break
+            stream_validator.feed(chunk)
+        stream_validator.finalize()
+    except _Inspect as exc:
+        # `feed`/`finalize` raise InspectionError on bad bytes; surface as
+        # CTFValidationError so the API contract matches the bounded
+        # rejection path above.
+        logger.warning(
+            "add_challenge_file: streaming text inspection rejected challenge=%s ext=%s actor=%s reason=%s",
+            challenge_id,
+            ext,
+            actor_id,
+            exc,
+        )
+        raise CTFValidationError(
+            f"File content inspection failed: {exc}",
+            details={"filename": filename, "extension": ext},
+        ) from exc
+    finally:
+        file_obj.seek(0)
+
+
 def add_challenge_file(
     challenge_id: UUID,
     file_obj,
@@ -129,40 +172,8 @@ def add_challenge_file(
             details={"filename": filename, "extension": ext},
         ) from exc
 
-    # Full-body text validation for TEXT-category extensions. We feed the
-    # whole file through a UTF-8 incremental decoder so any binary bytes in
-    # the tail of an otherwise-text-looking upload are rejected before S3.
     if is_text_extension(ext):
-        stream_validator = new_text_stream_validator()
-        try:
-            file_obj.seek(0)
-            while True:
-                chunk = file_obj.read(8192)
-                if not chunk:
-                    break
-                stream_validator.feed(chunk)
-            stream_validator.finalize()
-        except Exception as exc:
-            # `feed`/`finalize` raise InspectionError on bad bytes; surface
-            # as CTFValidationError so the API contract matches the bounded
-            # rejection path above.
-            from shared.uploads.inspection import InspectionError as _Inspect
-
-            if not isinstance(exc, _Inspect):
-                raise
-            logger.warning(
-                "add_challenge_file: streaming text inspection rejected challenge=%s ext=%s actor=%s reason=%s",
-                challenge_id,
-                ext,
-                actor_id,
-                exc,
-            )
-            raise CTFValidationError(
-                f"File content inspection failed: {exc}",
-                details={"filename": filename, "extension": ext},
-            ) from exc
-        finally:
-            file_obj.seek(0)
+        _run_text_stream_validation(file_obj, ext, challenge_id, actor_id, filename)
 
     # Check file count limit
     current_count = CTFChallengeFile.objects.filter(challenge=challenge).count()

--- a/shifter/shifter_platform/ctf/services/attachment.py
+++ b/shifter/shifter_platform/ctf/services/attachment.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 from uuid import UUID
 
 from django.conf import settings
+from django.core.files.base import File
 from django.db.models import QuerySet
 
 from ctf.exceptions import CTFNotFoundError, CTFStateError, CTFValidationError
@@ -38,7 +39,7 @@ logger = logging.getLogger(__name__)
 
 
 def _run_text_stream_validation(
-    file_obj,
+    file_obj: File,
     ext: str,
     challenge_id: UUID,
     actor_id: int,
@@ -82,7 +83,7 @@ def _run_text_stream_validation(
 
 def add_challenge_file(
     challenge_id: UUID,
-    file_obj,
+    file_obj: File,
     filename: str,
     display_name: str = "",
     content_type: str = "application/octet-stream",

--- a/shifter/shifter_platform/ctf/services/challenge.py
+++ b/shifter/shifter_platform/ctf/services/challenge.py
@@ -18,7 +18,15 @@ from django.db.models import QuerySet
 from django.utils import timezone
 
 from ctf.exceptions import CTFNotFoundError, CTFStateError, CTFValidationError
-from ctf.models import CTFChallenge, CTFChallengePrerequisite, CTFChallengeTag, CTFEvent, CTFFlag, CTFTopic
+from ctf.models import (
+    CTFChallenge,
+    CTFChallengePrerequisite,
+    CTFChallengeTag,
+    CTFEvent,
+    CTFFlag,
+    CTFParticipant,
+    CTFTopic,
+)
 
 if TYPE_CHECKING:
     pass
@@ -967,7 +975,7 @@ from ctf.services.authorization import assert_actor_owns_event as _assert_actor_
 
 
 def assert_challenge_available_for_participant(
-    participant: CTFParticipant,  # type: ignore[name-defined]  # noqa: F821 — forward-ref docs only
+    participant: CTFParticipant,
     challenge: CTFChallenge,
 ) -> None:
     """Raise if `participant` cannot legitimately interact with `challenge`.
@@ -1056,7 +1064,7 @@ def assert_challenge_available_for_participant(
 
 
 def assert_challenge_readable_for_participant(
-    participant: CTFParticipant,  # type: ignore[name-defined]  # noqa: F821 — forward-ref docs only
+    participant: CTFParticipant,
     challenge: CTFChallenge,
 ) -> None:
     """Raise if `participant` cannot READ this challenge's content.
@@ -1116,7 +1124,7 @@ def assert_challenge_readable_for_participant(
 
 def _assert_prerequisites_met(
     challenge: CTFChallenge,
-    participant,  # CTFParticipant — typing as Any to avoid the import dance in this module
+    participant: CTFParticipant,
 ) -> None:
     """Raise CTFStateError if any of `challenge`'s prerequisites are unmet."""
     prereqs_met, unmet_challenges = check_prerequisites_met(challenge.id, participant.id)

--- a/shifter/shifter_platform/shared/cloud/aws/storage.py
+++ b/shifter/shifter_platform/shared/cloud/aws/storage.py
@@ -128,7 +128,7 @@ class AWSObjectStorage:
             finally:
                 stream.close()
         except (ClientError, BotoCoreError) as e:
-            logger.error(
+            logger.exception(
                 "read_object_header: failed bucket=%s key=%s error=%s",
                 bucket,
                 key,

--- a/shifter/shifter_platform/shared/cloud/gcp/storage.py
+++ b/shifter/shifter_platform/shared/cloud/gcp/storage.py
@@ -115,7 +115,7 @@ class GCPObjectStorage:
             blob = client.bucket(bucket).blob(key)
             body = blob.download_as_bytes(start=0, end=max_bytes - 1)
         except Exception as e:
-            logger.error(
+            logger.exception(
                 "read_object_header: failed bucket=%s key=%s error=%s",
                 bucket,
                 key,

--- a/shifter/shifter_platform/shared/uploads/inspection.py
+++ b/shifter/shifter_platform/shared/uploads/inspection.py
@@ -25,6 +25,9 @@ import codecs
 import re
 from dataclasses import dataclass
 
+_EMPTY_CONTENT_MSG = "Uploaded content is empty"
+_INVALID_UTF8_MSG = "Uploaded content is not valid UTF-8 text."
+
 
 class InspectionError(Exception):
     """Raised when an uploaded file's header fails server-side inspection."""
@@ -256,7 +259,7 @@ def validate_text_header(header: bytes, *, complete: bool = False) -> None:
     full file may complete it.
     """
     if not header:
-        raise InspectionError("Uploaded content is empty")
+        raise InspectionError(_EMPTY_CONTENT_MSG)
 
     body = header[len(_UTF8_BOM) :] if header.startswith(_UTF8_BOM) else header
 
@@ -267,7 +270,7 @@ def validate_text_header(header: bytes, *, complete: bool = False) -> None:
     try:
         decoder.decode(body, final=complete)
     except UnicodeDecodeError as exc:
-        raise InspectionError("Uploaded content is not valid UTF-8 text.") from exc
+        raise InspectionError(_INVALID_UTF8_MSG) from exc
 
 
 def make_text_stream_validator() -> TextStreamValidator:
@@ -315,21 +318,21 @@ class TextStreamValidator:
             try:
                 self._decoder.decode(body, final=False)
             except UnicodeDecodeError as exc:
-                raise InspectionError("Uploaded content is not valid UTF-8 text.") from exc
+                raise InspectionError(_INVALID_UTF8_MSG) from exc
             return
         assert self._decoder is not None
         try:
             self._decoder.decode(chunk, final=False)
         except UnicodeDecodeError as exc:
-            raise InspectionError("Uploaded content is not valid UTF-8 text.") from exc
+            raise InspectionError(_INVALID_UTF8_MSG) from exc
 
     def finalize(self) -> None:
         if not self._seen_first_chunk or self._decoder is None:
-            raise InspectionError("Uploaded content is empty")
+            raise InspectionError(_EMPTY_CONTENT_MSG)
         try:
             self._decoder.decode(b"", final=True)
         except UnicodeDecodeError as exc:
-            raise InspectionError("Uploaded content is not valid UTF-8 text.") from exc
+            raise InspectionError(_INVALID_UTF8_MSG) from exc
 
 
 def validate_pem_or_der_header(header: bytes) -> None:
@@ -343,7 +346,7 @@ def validate_pem_or_der_header(header: bytes) -> None:
     ASN.1 SEQUENCE prefix.
     """
     if not header:
-        raise InspectionError("Uploaded content is empty")
+        raise InspectionError(_EMPTY_CONTENT_MSG)
 
     # PEM branch: anchored armor at the start of normalized text.
     body = header[len(_UTF8_BOM) :] if header.startswith(_UTF8_BOM) else header

--- a/shifter/shifter_platform/templates/coming_soon.html
+++ b/shifter/shifter_platform/templates/coming_soon.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% load static %}
 <!DOCTYPE html>
 <html lang="en">

--- a/shifter/shifter_platform/templates/ctf/admin/analytics.html
+++ b/shifter/shifter_platform/templates/ctf/admin/analytics.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "mission_control/base.html" %}
 {% block title %}Analytics - {{ event.name }}{% endblock %}
 

--- a/shifter/shifter_platform/templates/ctf/admin/bracket_form.html
+++ b/shifter/shifter_platform/templates/ctf/admin/bracket_form.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "mission_control/base.html" %}
 {% block title %}{% if editing %}Edit Bracket{% else %}Create Bracket{% endif %}{% endblock %}
 

--- a/shifter/shifter_platform/templates/ctf/admin/bracket_list.html
+++ b/shifter/shifter_platform/templates/ctf/admin/bracket_list.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "mission_control/base.html" %}
 {% block title %}Brackets - {{ event.name }}{% endblock %}
 

--- a/shifter/shifter_platform/templates/ctf/admin/challenge_detail.html
+++ b/shifter/shifter_platform/templates/ctf/admin/challenge_detail.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "mission_control/base.html" %}
 {% block title %}{{ challenge.name }}{% endblock %}
 

--- a/shifter/shifter_platform/templates/ctf/admin/challenge_form.html
+++ b/shifter/shifter_platform/templates/ctf/admin/challenge_form.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "mission_control/base.html" %}
 {% block title %}{% if is_edit %}Edit Challenge{% else %}Create Challenge{% endif %}{% endblock %}
 

--- a/shifter/shifter_platform/templates/ctf/admin/challenge_list.html
+++ b/shifter/shifter_platform/templates/ctf/admin/challenge_list.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "mission_control/base.html" %}
 {% block title %}Challenges - {{ event.name }}{% endblock %}
 

--- a/shifter/shifter_platform/templates/ctf/admin/dashboard.html
+++ b/shifter/shifter_platform/templates/ctf/admin/dashboard.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "mission_control/base.html" %}
 {% block title %}CTF Admin Dashboard{% endblock %}
 

--- a/shifter/shifter_platform/templates/ctf/admin/email_templates.html
+++ b/shifter/shifter_platform/templates/ctf/admin/email_templates.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "mission_control/base.html" %}
 {% block title %}Email Templates - {{ event.name }}{% endblock %}
 

--- a/shifter/shifter_platform/templates/ctf/admin/event_detail.html
+++ b/shifter/shifter_platform/templates/ctf/admin/event_detail.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "mission_control/base.html" %}
 {% block title %}{{ event.name }}{% endblock %}
 

--- a/shifter/shifter_platform/templates/ctf/admin/event_force_delete.html
+++ b/shifter/shifter_platform/templates/ctf/admin/event_force_delete.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "mission_control/base.html" %}
 {% block title %}Force Delete - {{ event.name }}{% endblock %}
 

--- a/shifter/shifter_platform/templates/ctf/admin/event_form.html
+++ b/shifter/shifter_platform/templates/ctf/admin/event_form.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "mission_control/base.html" %}
 {% load static %}
 

--- a/shifter/shifter_platform/templates/ctf/admin/event_list.html
+++ b/shifter/shifter_platform/templates/ctf/admin/event_list.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "mission_control/base.html" %}
 {% block title %}CTF Events{% endblock %}
 

--- a/shifter/shifter_platform/templates/ctf/admin/notification_form.html
+++ b/shifter/shifter_platform/templates/ctf/admin/notification_form.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "mission_control/base.html" %}
 {% block title %}New Notification - {{ event.name }}{% endblock %}
 

--- a/shifter/shifter_platform/templates/ctf/admin/notification_list.html
+++ b/shifter/shifter_platform/templates/ctf/admin/notification_list.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "mission_control/base.html" %}
 {% block title %}Notifications - {{ event.name }}{% endblock %}
 

--- a/shifter/shifter_platform/templates/ctf/admin/participant_detail.html
+++ b/shifter/shifter_platform/templates/ctf/admin/participant_detail.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "mission_control/base.html" %}
 {% load static %}
 {% block title %}{{ participant.name }} - {{ event.name }}{% endblock %}

--- a/shifter/shifter_platform/templates/ctf/admin/participant_form.html
+++ b/shifter/shifter_platform/templates/ctf/admin/participant_form.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "mission_control/base.html" %}
 {% block title %}{% if is_add %}Add{% else %}Edit{% endif %} Participant - {{ event.name }}{% endblock %}
 

--- a/shifter/shifter_platform/templates/ctf/admin/participant_import.html
+++ b/shifter/shifter_platform/templates/ctf/admin/participant_import.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "mission_control/base.html" %}
 {% block title %}Import Participants - {{ event.name }}{% endblock %}
 

--- a/shifter/shifter_platform/templates/ctf/admin/participant_list.html
+++ b/shifter/shifter_platform/templates/ctf/admin/participant_list.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "mission_control/base.html" %}
 {% block title %}Participants - {{ event.name }}{% endblock %}
 

--- a/shifter/shifter_platform/templates/ctf/admin/range_list.html
+++ b/shifter/shifter_platform/templates/ctf/admin/range_list.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "mission_control/base.html" %}
 {% load static %}
 {% block title %}Ranges - {{ event.name }}{% endblock %}

--- a/shifter/shifter_platform/templates/ctf/admin/scoreboard.html
+++ b/shifter/shifter_platform/templates/ctf/admin/scoreboard.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "mission_control/base.html" %}
 {% block title %}Scoreboard - {{ event.name }}{% endblock %}
 

--- a/shifter/shifter_platform/templates/ctf/admin/team_list.html
+++ b/shifter/shifter_platform/templates/ctf/admin/team_list.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "mission_control/base.html" %}
 {% block title %}Teams - {{ event.name }}{% endblock %}
 

--- a/shifter/shifter_platform/templates/ctf/base.html
+++ b/shifter/shifter_platform/templates/ctf/base.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% load static user_extras %}
 {# CTF base template - standalone layout with CTF-specific sidebar #}
 <!DOCTYPE html>

--- a/shifter/shifter_platform/templates/ctf/email/announcement.html
+++ b/shifter/shifter_platform/templates/ctf/email/announcement.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/shifter/shifter_platform/templates/ctf/email/credentials.html
+++ b/shifter/shifter_platform/templates/ctf/email/credentials.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/shifter/shifter_platform/templates/ctf/email/event_end.html
+++ b/shifter/shifter_platform/templates/ctf/email/event_end.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 <!DOCTYPE html>
 <html lang="en">
 <head><title>Event Ended</title></head>

--- a/shifter/shifter_platform/templates/ctf/email/event_start.html
+++ b/shifter/shifter_platform/templates/ctf/email/event_start.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 <!DOCTYPE html>
 <html lang="en">
 <head><title>Event Started</title></head>

--- a/shifter/shifter_platform/templates/ctf/email/invitation.html
+++ b/shifter/shifter_platform/templates/ctf/email/invitation.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/shifter/shifter_platform/templates/ctf/email/provision_failure.html
+++ b/shifter/shifter_platform/templates/ctf/email/provision_failure.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 <!DOCTYPE html>
 <html lang="en">
 <head><title>Range Provisioning Failures</title></head>

--- a/shifter/shifter_platform/templates/ctf/email/reminder.html
+++ b/shifter/shifter_platform/templates/ctf/email/reminder.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/shifter/shifter_platform/templates/ctf/help.html
+++ b/shifter/shifter_platform/templates/ctf/help.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "ctf/base.html" %}
 {% block ctf_title %}Help{% endblock %}
 

--- a/shifter/shifter_platform/templates/ctf/includes/admin_scoreboard_rows.html
+++ b/shifter/shifter_platform/templates/ctf/includes/admin_scoreboard_rows.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% comment %}
 Reusable admin scoreboard ranking table rows.
 

--- a/shifter/shifter_platform/templates/ctf/includes/event_status_badge.html
+++ b/shifter/shifter_platform/templates/ctf/includes/event_status_badge.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% comment %}Event status badge. Expects `event` in context.{% endcomment %}
 {% if event.status == 'draft' %}
 <span class="status status-provisioning"><span class="status-dot"></span> Draft</span>

--- a/shifter/shifter_platform/templates/ctf/includes/scoreboard_table.html
+++ b/shifter/shifter_platform/templates/ctf/includes/scoreboard_table.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% comment %}
 Reusable scoreboard ranking table rows.
 

--- a/shifter/shifter_platform/templates/ctf/participant/challenge_detail.html
+++ b/shifter/shifter_platform/templates/ctf/participant/challenge_detail.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "ctf/base.html" %}
 {% block ctf_title %}{{ challenge.name }}{% endblock %}
 

--- a/shifter/shifter_platform/templates/ctf/participant/challenges.html
+++ b/shifter/shifter_platform/templates/ctf/participant/challenges.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "ctf/base.html" %}
 {% block ctf_title %}Challenges{% endblock %}
 

--- a/shifter/shifter_platform/templates/ctf/participant/dashboard.html
+++ b/shifter/shifter_platform/templates/ctf/participant/dashboard.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "ctf/base.html" %}
 {% block ctf_title %}Dashboard{% endblock %}
 

--- a/shifter/shifter_platform/templates/ctf/participant/event.html
+++ b/shifter/shifter_platform/templates/ctf/participant/event.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "ctf/base.html" %}
 {% block ctf_title %}{{ event.name }}{% endblock %}
 

--- a/shifter/shifter_platform/templates/ctf/participant/range.html
+++ b/shifter/shifter_platform/templates/ctf/participant/range.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "ctf/base.html" %}
 {% block ctf_title %}Range{% endblock %}
 

--- a/shifter/shifter_platform/templates/ctf/participant/scoreboard.html
+++ b/shifter/shifter_platform/templates/ctf/participant/scoreboard.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "ctf/base.html" %}
 {% load static %}
 {% block ctf_title %}Scoreboard{% endblock %}

--- a/shifter/shifter_platform/templates/ctf/participant/team.html
+++ b/shifter/shifter_platform/templates/ctf/participant/team.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "ctf/base.html" %}
 {% block ctf_title %}Team{% endblock %}
 

--- a/shifter/shifter_platform/templates/ctf/participant/team_join.html
+++ b/shifter/shifter_platform/templates/ctf/participant/team_join.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "ctf/base.html" %}
 {% block ctf_title %}Join Team{% endblock %}
 

--- a/shifter/shifter_platform/templates/ctf/participant/walkthrough.html
+++ b/shifter/shifter_platform/templates/ctf/participant/walkthrough.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "ctf/base.html" %}
 {% block ctf_title %}Walkthrough{% endblock %}
 

--- a/shifter/shifter_platform/templates/dev_login.html
+++ b/shifter/shifter_platform/templates/dev_login.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% load static %}
 <!DOCTYPE html>
 <html lang="en">

--- a/shifter/shifter_platform/templates/documentation/_nav_tree.html
+++ b/shifter/shifter_platform/templates/documentation/_nav_tree.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 <ul class="nav-tree-list">
 {% for item in items %}
     <li class="nav-tree-item {% if item.is_folder %}nav-tree-folder{% endif %}">

--- a/shifter/shifter_platform/templates/documentation/base.html
+++ b/shifter/shifter_platform/templates/documentation/base.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% load static user_extras %}
 <!DOCTYPE html>
 <html lang="en" class="theme-dark">

--- a/shifter/shifter_platform/templates/documentation/doc_page.html
+++ b/shifter/shifter_platform/templates/documentation/doc_page.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "documentation/base.html" %}
 
 {% block title %}{{ page_title }}{% endblock %}

--- a/shifter/shifter_platform/templates/identity_platform_login.html
+++ b/shifter/shifter_platform/templates/identity_platform_login.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% load static %}
 <!DOCTYPE html>
 <html lang="en">

--- a/shifter/shifter_platform/templates/identity_platform_logout.html
+++ b/shifter/shifter_platform/templates/identity_platform_logout.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% load static %}
 <!DOCTYPE html>
 <html lang="en">

--- a/shifter/shifter_platform/templates/mission_control/agents.html
+++ b/shifter/shifter_platform/templates/mission_control/agents.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "mission_control/base.html" %}
 {% load static %}
 

--- a/shifter/shifter_platform/templates/mission_control/base.html
+++ b/shifter/shifter_platform/templates/mission_control/base.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% load static user_extras %}
 <!DOCTYPE html>
 <html lang="en" class="theme-dark">

--- a/shifter/shifter_platform/templates/mission_control/credentials/add.html
+++ b/shifter/shifter_platform/templates/mission_control/credentials/add.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "mission_control/base.html" %}
 {% load static %}
 

--- a/shifter/shifter_platform/templates/mission_control/credentials/detail.html
+++ b/shifter/shifter_platform/templates/mission_control/credentials/detail.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "mission_control/base.html" %}
 {% load static %}
 

--- a/shifter/shifter_platform/templates/mission_control/credentials/list.html
+++ b/shifter/shifter_platform/templates/mission_control/credentials/list.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "mission_control/base.html" %}
 {% load static %}
 

--- a/shifter/shifter_platform/templates/mission_control/dashboard.html
+++ b/shifter/shifter_platform/templates/mission_control/dashboard.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "mission_control/base.html" %}
 {% load static %}
 

--- a/shifter/shifter_platform/templates/mission_control/files.html
+++ b/shifter/shifter_platform/templates/mission_control/files.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "mission_control/base.html" %}
 {% load static %}
 

--- a/shifter/shifter_platform/templates/mission_control/help.html
+++ b/shifter/shifter_platform/templates/mission_control/help.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "mission_control/base.html" %}
 
 {% block content %}

--- a/shifter/shifter_platform/templates/mission_control/ngfw/deprovision.html
+++ b/shifter/shifter_platform/templates/mission_control/ngfw/deprovision.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "mission_control/base.html" %}
 {% load static %}
 

--- a/shifter/shifter_platform/templates/mission_control/ngfw/detail.html
+++ b/shifter/shifter_platform/templates/mission_control/ngfw/detail.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "mission_control/base.html" %}
 {% load static %}
 

--- a/shifter/shifter_platform/templates/mission_control/ngfw/list.html
+++ b/shifter/shifter_platform/templates/mission_control/ngfw/list.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "mission_control/base.html" %}
 {% load static %}
 

--- a/shifter/shifter_platform/templates/mission_control/ngfw/wizard.html
+++ b/shifter/shifter_platform/templates/mission_control/ngfw/wizard.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "mission_control/base.html" %}
 {% load static %}
 

--- a/shifter/shifter_platform/templates/mission_control/settings.html
+++ b/shifter/shifter_platform/templates/mission_control/settings.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "mission_control/base.html" %}
 
 {% block content %}

--- a/shifter/shifter_platform/templates/mission_control/terminal.html
+++ b/shifter/shifter_platform/templates/mission_control/terminal.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "mission_control/base.html" %}
 {% load static %}
 

--- a/shifter/shifter_platform/templates/mission_control/walkthrough.html
+++ b/shifter/shifter_platform/templates/mission_control/walkthrough.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "mission_control/base.html" %}
 
 {% block extra_css %}

--- a/shifter/shifter_platform/templates/partials/ctf_participant_sidebar.html
+++ b/shifter/shifter_platform/templates/partials/ctf_participant_sidebar.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% load static user_extras %}
 {# CTF Participant Left Navigation - Customized for CTF participants #}
 

--- a/shifter/shifter_platform/templates/partials/icon_sidebar.html
+++ b/shifter/shifter_platform/templates/partials/icon_sidebar.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% load static user_extras %}
 {# Left navigation chrome — minimized + submenu panel layout. #}
 

--- a/shifter/shifter_platform/templates/risk_register/apikey_list.html
+++ b/shifter/shifter_platform/templates/risk_register/apikey_list.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "risk_register/base.html" %}
 
 {% block content %}

--- a/shifter/shifter_platform/templates/risk_register/base.html
+++ b/shifter/shifter_platform/templates/risk_register/base.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% load static user_extras %}
 <!DOCTYPE html>
 <html lang="en" class="theme-dark">

--- a/shifter/shifter_platform/templates/risk_register/risk_detail.html
+++ b/shifter/shifter_platform/templates/risk_register/risk_detail.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "risk_register/base.html" %}
 
 {% block content %}

--- a/shifter/shifter_platform/templates/risk_register/risk_form.html
+++ b/shifter/shifter_platform/templates/risk_register/risk_form.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "risk_register/base.html" %}
 
 {% block content %}

--- a/shifter/shifter_platform/templates/risk_register/risk_list.html
+++ b/shifter/shifter_platform/templates/risk_register/risk_list.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "risk_register/base.html" %}
 
 {% block content %}

--- a/shifter/shifter_platform/templates/scenario_editor/base.html
+++ b/shifter/shifter_platform/templates/scenario_editor/base.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% load static %}
 <!DOCTYPE html>
 <html lang="en" class="theme-dark">

--- a/shifter/shifter_platform/templates/scenario_editor/clone.html
+++ b/shifter/shifter_platform/templates/scenario_editor/clone.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "scenario_editor/base.html" %}
 
 {% block title %}Clone: {{ source.name }}{% endblock %}

--- a/shifter/shifter_platform/templates/scenario_editor/detail.html
+++ b/shifter/shifter_platform/templates/scenario_editor/detail.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "scenario_editor/base.html" %}
 
 {% block title %}{{ scenario.name }}{% endblock %}

--- a/shifter/shifter_platform/templates/scenario_editor/error.html
+++ b/shifter/shifter_platform/templates/scenario_editor/error.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "scenario_editor/base.html" %}
 
 {% block title %}Error{% endblock %}

--- a/shifter/shifter_platform/templates/scenario_editor/form.html
+++ b/shifter/shifter_platform/templates/scenario_editor/form.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "scenario_editor/base.html" %}
 {% load static %}
 

--- a/shifter/shifter_platform/templates/scenario_editor/list.html
+++ b/shifter/shifter_platform/templates/scenario_editor/list.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "scenario_editor/base.html" %}
 
 {% block title %}Scenarios{% endblock %}

--- a/shifter/shifter_platform/templates/scenario_editor/not_found.html
+++ b/shifter/shifter_platform/templates/scenario_editor/not_found.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "scenario_editor/base.html" %}
 
 {% block title %}Scenario Not Found{% endblock %}

--- a/shifter/shifter_platform/templates/scenario_editor/yaml_create.html
+++ b/shifter/shifter_platform/templates/scenario_editor/yaml_create.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "scenario_editor/base.html" %}
 
 {% block title %}Import from YAML{% endblock %}

--- a/shifter/shifter_platform/templates/scenario_editor/yaml_editor.html
+++ b/shifter/shifter_platform/templates/scenario_editor/yaml_editor.html
@@ -1,3 +1,5 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
 {% extends "scenario_editor/base.html" %}
 
 {% block title %}YAML Editor: {{ scenario.name }}{% endblock %}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -32,3 +32,8 @@ sonar.javascript.lcov.reportPaths=coverage/js/lcov.info
 
 # Encoding
 sonar.sourceEncoding=UTF-8
+
+# File-header enforcement (ADR-015). Web:HeaderCheck compares the start of every
+# HTML file against this literal block. Django `{# #}` comment syntax is used so
+# the header is stripped at template-compile time and never reaches clients.
+sonar.html.fileHeader={# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}\n{# SPDX-License-Identifier: MIT #}


### PR DESCRIPTION
## Summary
- Relicense to MIT, Copyright (c) 2026 Palo Alto Networks, Inc.
- Add ADR-015 (SPDX file-header convention) with `docs/architecture/file-headers.md`
- Configure SonarCloud `Web:HeaderCheck` via `sonar.html.fileHeader` so the rule has the canonical header text to enforce (previously it was firing on every HTML file because the quality profile had it on with no header configured — root cause of the 50 BLOCKER findings on PR #1234)
- Apply the SPDX header to all 80 `shifter_platform/templates/**/*.html` files using Django `{# #}` server-side comments (does not render to clients)
- Resolve the 1 substantive BLOCKER on PR #1234: `python:S5953` undefined `CTFParticipant` in `ctf/services/challenge.py` — import it from `ctf.models` (already imported in the same module; the workaround comments were unnecessary)

## ADR-015 — what it locks in
- Format: SPDX REUSE (`SPDX-FileCopyrightText:` + `SPDX-License-Identifier:`)
- Per-language comment syntax wraps the same payload (Python `# `, JS/CSS `// `, shell `# `, Django templates `{# #}`)
- Canonical header text lives in exactly two places: `LICENSE` (legal) and `sonar-project.properties` (enforcement). Year roll-forward edits both and propagates.
- Django HTML templates use `{# #}` server-side comments specifically so the copyright string does not appear in rendered HTML responses.

## Test plan
- [x] `shifter_platform` pytest: 3185 passed (template rendering unaffected)
- [x] `ctf` pytest: 709 passed (CTFParticipant import is non-breaking)
- [x] `adr_guard` pytest: 170 passed (ADR-015 entry parses)
- [x] Pre-commit hooks pass locally
- [ ] SonarCloud reports 0 `Web:HeaderCheck` BLOCKERs on this PR's analysis
- [ ] SonarCloud reports 0 `python:S5953` findings on this PR's analysis
