### PR TITLE
refactor: clear 50 SonarCloud HIGH findings (S8554 + S134 tier)

### DIFF
--- a/scripts/bootstrap/deploy.py
+++ b/scripts/bootstrap/deploy.py
@@ -3888,6 +3888,23 @@ def walkthrough_git_commit(bootstrap_result: dict, dry_run: bool = False) -> Non
         warn(f"Skipping push — run 'git push origin {branch}' manually when ready")
 
 
+def _capture_terraform_outputs() -> dict:
+    """Return parsed `terraform output -json`, or empty dict on failure.
+
+    Used by the post-apply portal step; isolated from the deploy loop so
+    the loop body stays at a reasonable nesting depth.
+    """
+    result = subprocess.run(  # nosec B603 B607
+        ["terraform", "output", "-json"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return {}
+    return json.loads(result.stdout)
+
+
 def terraform_deploy(env: str, profile: str, dry_run: bool = False) -> dict:
     """Deploy all Terraform components in order."""
     header(f"Deploying {env.upper()} Infrastructure")
@@ -3974,11 +3991,7 @@ def terraform_deploy(env: str, profile: str, dry_run: bool = False) -> dict:
 
                 # Capture outputs for portal
                 if component == "portal":
-                    result = subprocess.run(  # nosec B603 B607
-                        ["terraform", "output", "-json"], capture_output=True, text=True, check=False
-                    )
-                    if result.returncode == 0:
-                        outputs = json.loads(result.stdout)
+                    outputs = _capture_terraform_outputs()
         finally:
             os.chdir(original_dir)
 

--- a/scripts/polaris-aws-range/apply_splice_watcher.py
+++ b/scripts/polaris-aws-range/apply_splice_watcher.py
@@ -244,6 +244,14 @@ def resolve_polaris_ami_id(ssm_client) -> str:
     return resp["Parameter"]["Value"]
 
 
+def _extract_name_tag(inst: dict) -> str:
+    """Return the `Name` tag value for an EC2 instance, or empty string."""
+    for tag in inst.get("Tags") or []:
+        if tag["Key"] == "Name":
+            return tag["Value"]
+    return ""
+
+
 def discover_targets(ec2_client, ami_id: str, vpc_id: str | None) -> list[Target]:
     """List all running instances matching the polaris-vm AMI (and VPC)."""
     filters = [
@@ -258,16 +266,11 @@ def discover_targets(ec2_client, ami_id: str, vpc_id: str | None) -> list[Target
     for page in paginator.paginate(Filters=filters):
         for reservation in page["Reservations"]:
             for inst in reservation["Instances"]:
-                name = ""
-                for tag in inst.get("Tags") or []:
-                    if tag["Key"] == "Name":
-                        name = tag["Value"]
-                        break
                 targets.append(
                     Target(
                         instance_id=inst["InstanceId"],
                         vpc_id=inst["VpcId"],
-                        name=name,
+                        name=_extract_name_tag(inst),
                     )
                 )
     return targets

--- a/shifter/engine/provisioner/executors/ssh_executor.py
+++ b/shifter/engine/provisioner/executors/ssh_executor.py
@@ -139,7 +139,7 @@ class SSHExecutor:
             commands = f"{commands}\n{stdin_input}"
 
         try:
-            logger.info(f"Connecting to {host}:{self._port} as {self._username}")
+            logger.info("Connecting to %s:%s as %s", host, self._port, self._username)
             client.connect(
                 hostname=host,
                 port=self._port,
@@ -150,13 +150,13 @@ class SSHExecutor:
                 look_for_keys=False,
             )
 
-            logger.info(f"Executing command: {commands[:100]}...")
+            logger.info("Executing command: %s...", commands[:100])
             logger.info("Opening interactive shell with invoke_shell()")
             channel = client.invoke_shell()
             channel.settimeout(timeout_seconds)
 
             # Send commands
-            logger.info(f"Sending command: {commands[:100]}")
+            logger.info("Sending command: %s", commands[:100])
             channel.send("set cli pager off\n")  # nosec B601  # NOSONAR — hardcoded operational command
             channel.send(commands + "\n")  # nosec B601  # NOSONAR — operational data, not user input
             channel.send("exit\n")
@@ -182,36 +182,27 @@ class SSHExecutor:
                 if channel.recv_ready():
                     chunk = channel.recv(4096).decode("utf-8", errors="replace")
                     chunk_count += 1
-                    logger.info(f"Chunk {chunk_count}: {len(chunk)} bytes")
-                    logger.debug(f"Chunk {chunk_count} content: {chunk!r}")
+                    logger.info("Chunk %d: %d bytes", chunk_count, len(chunk))
+                    logger.debug("Chunk %d content: %r", chunk_count, chunk)
                     output += chunk
 
                 # Check if channel EOF (server finished sending all data)
                 # This is the ONLY reliable way to know all output has been received
                 if channel.eof_received:
                     logger.info("Channel EOF received - draining remaining data")
-                    # Use blocking recv() to drain ALL remaining data
-                    # recv_ready() only checks Paramiko's buffer, not kernel TCP buffer
-                    # Set short timeout for drain phase
-                    channel.settimeout(2)
-                    while True:
-                        try:
-                            chunk = channel.recv(4096)
-                            if not chunk:  # Empty bytes = channel closed, no more data
-                                break
-                            chunk_count += 1
-                            logger.info(f"Drain chunk {chunk_count}: {len(chunk)} bytes")
-                            output += chunk.decode("utf-8", errors="replace")
-                        except builtins.TimeoutError:
-                            logger.info("Drain timeout - no more data")
-                            break
+                    drained, drain_chunks = self._drain_channel(channel, chunk_count)
+                    output += drained
+                    chunk_count += drain_chunks
                     break
 
                 # Overall timeout check
                 elapsed = time.time() - start_time
                 if elapsed > timeout_seconds:
                     logger.error(
-                        f"Command timed out after {elapsed:.1f}s (received {chunk_count} chunks, {len(output)} bytes)"
+                        "Command timed out after %.1fs (received %d chunks, %d bytes)",
+                        elapsed,
+                        chunk_count,
+                        len(output),
                     )
                     raise TimeoutError(f"Command timed out after {timeout_seconds}s")
 
@@ -223,20 +214,25 @@ class SSHExecutor:
             for _ in range(10):  # Wait up to 1 second
                 if channel.exit_status_ready():
                     exit_code = channel.recv_exit_status()
-                    logger.info(f"Exit code: {exit_code}")
+                    logger.info("Exit code: %s", exit_code)
                     break
                 time.sleep(0.1)
             else:
                 logger.info("Exit status not ready after 1s - using -1")
 
             elapsed = time.time() - start_time
-            logger.info(f"Command completed in {elapsed:.1f}s, received {len(output)} bytes in {chunk_count} chunks")
-            logger.info(f"Raw output (first 1000 chars): {output[:1000]!r}")
+            logger.info(
+                "Command completed in %.1fs, received %d bytes in %d chunks",
+                elapsed,
+                len(output),
+                chunk_count,
+            )
+            logger.info("Raw output (first 1000 chars): %r", output[:1000])
 
             # Clean output
             cleaned = self._clean_output(output, commands)
-            logger.info(f"Cleaned output: {len(cleaned)} bytes")
-            logger.info(f"Cleaned output (first 500 chars): {cleaned[:500]}")
+            logger.info("Cleaned output: %d bytes", len(cleaned))
+            logger.info("Cleaned output (first 500 chars): %s", cleaned[:500])
 
             return CommandResult(
                 success=True,
@@ -253,6 +249,37 @@ class SSHExecutor:
             raise TimeoutError(f"SSH command timed out on {host}: {e}") from e
         finally:
             client.close()
+
+    def _drain_channel(self, channel, prior_chunk_count: int) -> tuple[str, int]:
+        """Drain remaining data from an EOF'd channel until close or timeout.
+
+        Use blocking recv() rather than recv_ready(): recv_ready() only
+        inspects Paramiko's buffer, not the kernel TCP buffer, so it can
+        underreport. A short timeout bounds the drain phase.
+
+        Returns:
+            (decoded_output, chunks_drained)
+        """
+        channel.settimeout(2)
+        drained = ""
+        chunks_drained = 0
+        while True:
+            try:
+                chunk = channel.recv(4096)
+            except builtins.TimeoutError:
+                logger.info("Drain timeout - no more data")
+                break
+            if not chunk:
+                # Empty bytes = channel closed, no more data
+                break
+            chunks_drained += 1
+            logger.info(
+                "Drain chunk %d: %d bytes",
+                prior_chunk_count + chunks_drained,
+                len(chunk),
+            )
+            drained += chunk.decode("utf-8", errors="replace")
+        return drained, chunks_drained
 
     def _clean_output(self, output: str, commands: str) -> str:
         """Clean output by removing prompts and command echo."""
@@ -299,10 +326,15 @@ class SSHExecutor:
                 raise TimeoutError(f"SSH on {host} did not become available within {timeout_seconds}s")
 
             if self._check_ssh_available(host):
-                logger.info(f"SSH available on {host} after {elapsed:.1f}s")
+                logger.info("SSH available on %s after %.1fs", host, elapsed)
                 return True
 
-            logger.info(f"Waiting for SSH on {host}... ({elapsed:.1f}s / {timeout_seconds}s)")
+            logger.info(
+                "Waiting for SSH on %s... (%.1fs / %ss)",
+                host,
+                elapsed,
+                timeout_seconds,
+            )
             time.sleep(self._poll_interval)
 
     def wait_for_ready(
@@ -336,7 +368,7 @@ class SSHExecutor:
                 allow_agent=False,
                 look_for_keys=False,
             )
-            logger.info(f"SSH readiness check: connected to {host}")
+            logger.info("SSH readiness check: connected to %s", host)
 
             # Use interactive shell - PAN-OS does not support SSH exec channel
             channel = client.invoke_shell()
@@ -360,17 +392,23 @@ class SSHExecutor:
             is_ready = has_hostname and has_ip and has_netmask
 
             if is_ready:
-                logger.info(f"SSH readiness check passed for {host}")
+                logger.info("SSH readiness check passed for %s", host)
             else:
                 logger.info(
-                    f"SSH readiness check failed for {host}: "
-                    f"hostname={has_hostname} ip-address={has_ip} netmask={has_netmask} "
-                    f"output_length={len(output)} output={output!r:.500}"
+                    "SSH readiness check failed for %s: "
+                    "hostname=%s ip-address=%s netmask=%s "
+                    "output_length=%d output=%s",
+                    host,
+                    has_hostname,
+                    has_ip,
+                    has_netmask,
+                    len(output),
+                    repr(output)[:500],
                 )
 
             return is_ready
         except Exception as exc:
-            logger.info(f"SSH readiness check exception for {host}: {exc}")
+            logger.info("SSH readiness check exception for %s: %s", host, exc)
             return False
 
     def reboot_and_wait(
@@ -393,7 +431,7 @@ class SSHExecutor:
             TimeoutError: If device doesn't come back in time
         """
         host = instance_id
-        logger.info(f"Rebooting {host}...")
+        logger.info("Rebooting %s...", host)
 
         # Issue reboot command
         try:

--- a/shifter/engine/provisioner/main.py
+++ b/shifter/engine/provisioner/main.py
@@ -243,6 +243,20 @@ def get_db_connection() -> psycopg.Connection:
     )
 
 
+def _append_kwarg_assignment(assignments: list, values: list, key: str, value) -> None:
+    """Append one SET-clause fragment for an UPDATE, handling NOW() specially.
+
+    `value is None` is filtered by the caller; this helper expects a
+    real value. Splits the loop body out so `update_range_status` stays
+    within the nesting-depth budget.
+    """
+    if value == "NOW()":
+        assignments.append(sql.SQL("{} = NOW()").format(sql.Identifier(key)))
+        return
+    assignments.append(sql.SQL("{} = %s").format(sql.Identifier(key)))
+    values.append(value)
+
+
 def update_range_status(range_id: int, status: str, **kwargs: str | int | None) -> None:
     """Update range status in database.
 
@@ -261,13 +275,9 @@ def update_range_status(range_id: int, status: str, **kwargs: str | int | None) 
             values: list = [status]
 
             for key, value in kwargs.items():
-                if value is not None:
-                    # Handle special SQL expressions
-                    if value == "NOW()":
-                        assignments.append(sql.SQL("{} = NOW()").format(sql.Identifier(key)))
-                    else:
-                        assignments.append(sql.SQL("{} = %s").format(sql.Identifier(key)))
-                        values.append(value)
+                if value is None:
+                    continue
+                _append_kwarg_assignment(assignments, values, key, value)
 
             values.append(range_id)
             query = sql.SQL("UPDATE mission_control_range SET {} WHERE id = %s").format(sql.SQL(", ").join(assignments))
@@ -3390,8 +3400,8 @@ if __name__ == "__main__":
 
     # Handle resource-based dispatch
     if args.resource == "ngfw":
-        logger.info(f"Starting NGFW {args.operation} for request_id={args.request_id}")
-        logger.info(f"Environment: {os.environ.get('ENVIRONMENT', 'unknown')}")
+        logger.info("Starting NGFW %s for request_id=%s", args.operation, args.request_id)
+        logger.info("Environment: %s", os.environ.get("ENVIRONMENT", "unknown"))
 
         # Infrastructure operations use Terraform, runtime operations use boto3
         if args.operation in ("provision", "deprovision"):
@@ -3405,14 +3415,14 @@ if __name__ == "__main__":
 
             run_ngfw_operation(args.operation, args.request_id, **kwargs)
 
-        logger.info(f"Completed NGFW {args.operation} for request_id={args.request_id}")
+        logger.info("Completed NGFW %s for request_id=%s", args.operation, args.request_id)
 
     elif args.resource == "range":
         request_id = args.request_id
         tf_op = "up" if args.operation == "provision" else "destroy"
 
-        logger.info(f"Starting range {args.operation} for request_id={request_id}")
-        logger.info(f"Environment: {os.environ.get('ENVIRONMENT', 'unknown')}")
+        logger.info("Starting range %s for request_id=%s", args.operation, request_id)
+        logger.info("Environment: %s", os.environ.get("ENVIRONMENT", "unknown"))
 
         if args.operation in ("provision", "destroy"):
             # Use Terraform for ranges
@@ -3426,4 +3436,4 @@ if __name__ == "__main__":
 
             run_range_resume(request_id)
 
-        logger.info(f"Completed range {args.operation} for request_id={request_id}")
+        logger.info("Completed range %s for request_id=%s", args.operation, request_id)

--- a/shifter/shifter_platform/cms/services.py
+++ b/shifter/shifter_platform/cms/services.py
@@ -1183,6 +1183,40 @@ def get_range(user: User, range_id: int) -> RangeInstance:
         raise
 
 
+def _instance_contexts_from_range_spec(
+    range_spec: dict[str, Any] | None,
+    instance_context_cls: type,
+) -> list[Any]:
+    """Flatten a stored range_spec into a list of `InstanceContext` rows.
+
+    Accepts two on-disk shapes:
+    - Current: instances nested under subnets (`range_spec["subnets"][*]["instances"]`)
+    - Legacy: a flat `range_spec["instances"]` list (preserved for backward
+      compatibility with existing prod rows)
+
+    The `instance_context_cls` is passed in so this helper has no
+    cross-layer model import; the caller already imports it from
+    `shared.schemas`.
+    """
+    if not range_spec:
+        return []
+
+    def to_context(spec: dict[str, Any]) -> Any:
+        return instance_context_cls(
+            uuid=spec.get("uuid"),
+            name=spec.get("name", ""),
+            role=spec["role"],
+            os_type=spec["os_type"],
+            join_domain=spec.get("join_domain", False),
+        )
+
+    if "subnets" in range_spec:
+        return [to_context(spec) for subnet in range_spec["subnets"] for spec in subnet.get("instances", [])]
+    if "instances" in range_spec:
+        return [to_context(spec) for spec in range_spec["instances"]]
+    return []
+
+
 def get_active_range(user: User) -> RangeContext | None:
     """Get user's active (non-deleted) range as a RangeContext projection.
 
@@ -1258,32 +1292,7 @@ def get_active_range(user: User) -> RangeContext | None:
         # Get instance data from stored range_spec
         # New format: instances nested under subnets: range_spec["subnets"][*]["instances"]
         # Legacy format: instances directly at range_spec["instances"]
-        instance_contexts = []
-        if instance.range_spec:
-            if "subnets" in instance.range_spec:
-                for subnet in instance.range_spec["subnets"]:
-                    for spec in subnet.get("instances", []):
-                        instance_contexts.append(
-                            InstanceContext(
-                                uuid=spec.get("uuid"),
-                                name=spec.get("name", ""),
-                                role=spec["role"],
-                                os_type=spec["os_type"],
-                                join_domain=spec.get("join_domain", False),
-                            )
-                        )
-            elif "instances" in instance.range_spec:
-                # Legacy flat format for backward compatibility with existing prod data
-                for spec in instance.range_spec["instances"]:
-                    instance_contexts.append(
-                        InstanceContext(
-                            uuid=spec.get("uuid"),
-                            name=spec.get("name", ""),
-                            role=spec["role"],
-                            os_type=spec["os_type"],
-                            join_domain=spec.get("join_domain", False),
-                        )
-                    )
+        instance_contexts = _instance_contexts_from_range_spec(instance.range_spec, InstanceContext)
 
         # Get agent_name from FK if exists
         agent_name = instance.agent.name if instance.agent else None

--- a/shifter/shifter_platform/engine/ecs.py
+++ b/shifter/shifter_platform/engine/ecs.py
@@ -128,7 +128,7 @@ def _run_local_provisioner(command: list[str]) -> str | None:
 
     main_py = os.path.join(provisioner_path, "main.py")
     if not os.path.exists(main_py):
-        logger.error(f"Provisioner not found at {main_py}")
+        logger.error("Provisioner not found at %s", main_py)
         return None
 
     # Build environment for provisioner
@@ -164,7 +164,7 @@ def _run_local_provisioner(command: list[str]) -> str | None:
         env.setdefault("AWS_ENDPOINT_URL", aws_endpoint)
 
     full_command = ["python", main_py, *command]
-    logger.info(f"Starting local provisioner: {' '.join(full_command)}")
+    logger.info("Starting local provisioner: %s", " ".join(full_command))
 
     try:
         # Run in background (non-blocking)
@@ -176,11 +176,11 @@ def _run_local_provisioner(command: list[str]) -> str | None:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
-        logger.info(f"Local provisioner started with PID {process.pid}")
+        logger.info("Local provisioner started with PID %s", process.pid)
         return f"local-{process.pid}"
 
     except Exception as e:
-        logger.error(f"Failed to start local provisioner: {e}")
+        logger.error("Failed to start local provisioner: %s", e)
         raise RuntimeError(f"Local provisioner failed: {e}") from e
 
 
@@ -312,7 +312,7 @@ def _start_ecs_task(range_id: int, user_id: int, command: str) -> str | None:
 
     cluster, task_definition, network_config = task_config
 
-    logger.info(f"Starting ECS task for range_id={range_id} command={command}")
+    logger.info("Starting ECS task for range_id=%s command=%s", range_id, command)
 
     command_list = [
         ResourceType.RANGE.value,
@@ -333,10 +333,15 @@ def _start_ecs_task(range_id: int, user_id: int, command: str) -> str | None:
             env_overrides=_get_gcp_provisioner_env_overrides(),
             network_config=network_config,
         )
-        logger.info(f"Started ECS task: range_id={range_id} command={command} task_arn={task_arn}")
+        logger.info(
+            "Started ECS task: range_id=%s command=%s task_arn=%s",
+            range_id,
+            command,
+            task_arn,
+        )
         return task_arn
     except CloudTaskError as e:
-        logger.error(f"Failed to start ECS task for range_id={range_id}: {e}")
+        logger.error("Failed to start ECS task for range_id=%s: %s", range_id, e)
         raise
 
 
@@ -410,7 +415,11 @@ def _start_range_ecs_task(request_id: UUID, command: str) -> str | None:
 
     # Check for local provisioner mode first
     if _is_local_provisioner_enabled():
-        logger.info(f"Using local provisioner for Range request_id={request_id} command={command}")
+        logger.info(
+            "Using local provisioner for Range request_id=%s command=%s",
+            request_id,
+            command,
+        )
         command_list = ["range", command, "--request-id", str(request_id)]
         return _run_local_provisioner(command_list)
 
@@ -421,7 +430,7 @@ def _start_range_ecs_task(request_id: UUID, command: str) -> str | None:
     cluster, task_definition, network_config = task_config
 
     command_list = ["range", command, "--request-id", str(request_id)]
-    logger.info(f"Starting Range ECS task for request_id={request_id} command={command}")
+    logger.info("Starting Range ECS task for request_id=%s command=%s", request_id, command)
 
     try:
         runner = get_task_runner()
@@ -433,10 +442,10 @@ def _start_range_ecs_task(request_id: UUID, command: str) -> str | None:
             env_overrides=_get_gcp_provisioner_env_overrides(),
             network_config=network_config,
         )
-        logger.info(f"Started Range ECS task: request_id={request_id} task_arn={task_arn}")
+        logger.info("Started Range ECS task: request_id=%s task_arn=%s", request_id, task_arn)
         return task_arn
     except CloudTaskError as e:
-        logger.error(f"Failed to start Range ECS task for request_id={request_id}: {e}")
+        logger.error("Failed to start Range ECS task for request_id=%s: %s", request_id, e)
         raise
 
 
@@ -527,7 +536,11 @@ def _start_ngfw_ecs_task(request_id: UUID, command: list[str]) -> str | None:
 
     # Check for local provisioner mode first
     if _is_local_provisioner_enabled():
-        logger.info(f"Using local provisioner for NGFW request_id={request_id} command={command}")
+        logger.info(
+            "Using local provisioner for NGFW request_id=%s command=%s",
+            request_id,
+            command,
+        )
         return _run_local_provisioner(command)
 
     task_config = _get_engine_task_config()
@@ -536,7 +549,7 @@ def _start_ngfw_ecs_task(request_id: UUID, command: list[str]) -> str | None:
 
     cluster, task_definition, network_config = task_config
 
-    logger.info(f"Starting NGFW ECS task for request_id={request_id} command={command}")
+    logger.info("Starting NGFW ECS task for request_id=%s command=%s", request_id, command)
 
     try:
         runner = get_task_runner()
@@ -548,10 +561,10 @@ def _start_ngfw_ecs_task(request_id: UUID, command: list[str]) -> str | None:
             env_overrides=_get_gcp_provisioner_env_overrides(),
             network_config=network_config,
         )
-        logger.info(f"Started NGFW ECS task: request_id={request_id} task_arn={task_arn}")
+        logger.info("Started NGFW ECS task: request_id=%s task_arn=%s", request_id, task_arn)
         return task_arn
     except CloudTaskError as e:
-        logger.error(f"Failed to start NGFW ECS task for request_id={request_id}: {e}")
+        logger.error("Failed to start NGFW ECS task for request_id=%s: %s", request_id, e)
         raise
 
 
@@ -650,5 +663,5 @@ def get_task_status(task_arn: str) -> dict | None:
             "stopped_reason": result.get("stopped_reason"),
         }
     except CloudTaskError as e:
-        logger.error(f"Failed to get task status: {e}")
+        logger.error("Failed to get task status: %s", e)
         return None

--- a/shifter/shifter_platform/mission_control/guacamole.py
+++ b/shifter/shifter_platform/mission_control/guacamole.py
@@ -201,13 +201,13 @@ def get_guacamole_auth_token(base_url: str, encrypted_data: str) -> str:
             result = json.loads(response.read().decode("utf-8"))
             return result["authToken"]
     except urllib.error.HTTPError as e:
-        logger.error(f"Guacamole token request failed: {e.code} {e.reason}")
+        logger.error("Guacamole token request failed: %s %s", e.code, e.reason)
         raise ValueError(f"Failed to get Guacamole auth token: {e.reason}") from e
     except urllib.error.URLError as e:
-        logger.error(f"Guacamole token request failed: {e.reason}")
+        logger.error("Guacamole token request failed: %s", e.reason)
         raise ValueError(f"Failed to connect to Guacamole: {e.reason}") from e
     except (KeyError, json.JSONDecodeError) as e:
-        logger.error(f"Invalid Guacamole token response: {e}")
+        logger.error("Invalid Guacamole token response: %s", e)
         raise ValueError("Invalid response from Guacamole") from e
 
 

--- a/shifter/shifter_platform/mission_control/views.py
+++ b/shifter/shifter_platform/mission_control/views.py
@@ -256,7 +256,7 @@ def guacamole_rdp_url(request):
             sftp_private_key=conn_info.get("ssh_key"),
         )
     except ValueError as e:
-        logger.error(f"Failed to generate Guacamole URL: {e}")
+        logger.error("Failed to generate Guacamole URL: %s", e)
         return JsonResponse({"error": "Failed to generate RDP URL"}, status=500)
 
     logger.info(


### PR DESCRIPTION
## Summary

First milestone on #1236 (HIGH-impact burn-down on the dev → main analysis surface). Clears 50 of the 112 HIGH findings — the mechanical and surgical tiers.

- **45 `python:S8554`**: every `logger.info(f"foo={x}")` (or `%`/`+`/string concat) call converted to `logger.info("foo=%s", x)`. Preserves the loggers' lazy-formatting contract and the structured-args path used by `SetupOrchestrator._mask_sensitive_output`.
- **5 `python:S134`**: nesting depth >4 fixed by extracting the deepest sub-block in each call site into a private helper. Behavior unchanged.

## Files touched

| File | S8554 sites | S134 extractions |
|---|---:|---|
| `shifter/engine/provisioner/executors/ssh_executor.py` | 19 | `_drain_channel(channel, prior_chunk_count)` |
| `shifter/shifter_platform/engine/ecs.py` | 16 | — |
| `shifter/engine/provisioner/main.py` | 6 | `_append_kwarg_assignment(...)` |
| `shifter/shifter_platform/mission_control/guacamole.py` | 3 | — |
| `shifter/shifter_platform/mission_control/views.py` | 1 | — |
| `scripts/polaris-aws-range/apply_splice_watcher.py` | — | `_extract_name_tag(inst)` |
| `shifter/shifter_platform/cms/services.py` | — | `_instance_contexts_from_range_spec(...)` (handles both subnets/instances and legacy flat range_spec shapes) |
| `scripts/bootstrap/deploy.py` | — | `_capture_terraform_outputs()` |

## Notes on edge cases

- `ssh_executor.py:366` originally used `{output!r:.500}` (truncate the *escaped* form to 500 chars). Preserved exactly by passing `repr(output)[:500]` as a `%s` arg.
- `_instance_contexts_from_range_spec` accepts the `InstanceContext` class as a parameter so the helper carries no cross-layer model import; the caller (`get_active_range`) already locally imports it from `shared.schemas`.

## Test plan

- [x] provisioner full suite: 688 passed, 8 skipped
- [x] shifter_platform engine + mission_control: 681 passed
- [x] shifter_platform cms + management: 1002 passed
- [x] Pre-commit hooks pass locally (ruff, ruff-format, mypy, full pytest)
- [ ] SonarCloud analysis confirms `impactSeverities=HIGH` count drops by 50 on the next analysis cycle (down from 112)

No Sonar finding suppressed. None marked false-positive.
