### PR TITLE
refactor: clear 35 SonarCloud HIGH FunctionComplexity findings

### DIFF
--- a/docs/adr/complexity-backlog.md
+++ b/docs/adr/complexity-backlog.md
@@ -81,3 +81,12 @@ The `python-complexity-gate` adr_guard check parses this table cell-by-cell
 is intact, so the table can grow new columns without code edits to the
 parser. The file and function cells must be backtick-fenced; the
 complexity cell must be a positive integer.
+
+`check_adr_registry` in `scripts/adr_guard/adr_guard.py` was refactored
+below the ruff McCabe-10 threshold during the SonarCloud HIGH burn-down
+(issue #1236): per-entry validation moved into
+`_check_adr_entry(entry, adr_ids, rule_ids, violations)`, and the
+repeated `Violation("adr-registry", "ADR-REGISTRY", path, msg)`
+constructor calls were collapsed into a `_registry_violation` shorthand.
+The check's behavior — what it rejects and what it emits — is unchanged;
+the adr_guard test suite (`scripts/adr_guard/tests/`) is the guard.

--- a/scripts/adr_guard/adr_guard.py
+++ b/scripts/adr_guard/adr_guard.py
@@ -265,6 +265,60 @@ def get_changed_files(repo_root: Path) -> list[str]:
     return []
 
 
+def _registry_violation(path: str, message: str) -> Violation:
+    """Shorthand: build an adr-registry / ADR-REGISTRY Violation at `path`."""
+    return Violation("adr-registry", "ADR-REGISTRY", path, message)
+
+
+def _check_adr_entry(
+    entry: dict,
+    adr_ids: set[str],
+    rule_ids: set[str],
+    violations: list[Violation],
+) -> None:
+    """Validate one registry entry; append any per-entry violations.
+
+    Also mutates `adr_ids` / `rule_ids` with the names this entry contributes
+    so later entries can detect duplicates.
+    """
+    missing = REQUIRED_ADR_KEYS - set(entry)
+    if missing:
+        violations.append(
+            _registry_violation(
+                "docs/adr/index.yaml",
+                f"ADR entry {entry.get('id', '<missing-id>')} is missing keys: {sorted(missing)}",
+            )
+        )
+        return
+
+    adr_id = entry["id"]
+    if adr_id in adr_ids:
+        violations.append(_registry_violation("docs/adr/index.yaml", f"Duplicate ADR id: {adr_id}"))
+    adr_ids.add(adr_id)
+
+    rules = entry.get("rules", [])
+    if not isinstance(rules, list):
+        violations.append(
+            _registry_violation("docs/adr/index.yaml", f"{adr_id} rules must be a list")
+        )
+        return
+
+    for rule in rules:
+        rule_id = rule.get("id")
+        if not rule_id:
+            violations.append(
+                _registry_violation(
+                    "docs/adr/index.yaml", f"{adr_id} has a rule without an id"
+                )
+            )
+            continue
+        if rule_id in rule_ids:
+            violations.append(
+                _registry_violation("docs/adr/index.yaml", f"Duplicate rule id: {rule_id}")
+            )
+        rule_ids.add(rule_id)
+
+
 def check_adr_registry(repo_root: Path, files: list[str] | None) -> list[Violation]:
     """Validate the ADR registry and exception references."""
     violations: list[Violation] = []
@@ -276,84 +330,18 @@ def check_adr_registry(repo_root: Path, files: list[str] | None) -> list[Violati
         return [Violation("adr-registry", "ADR-REGISTRY", "docs/adr", str(err))]
 
     for error in validate_adr_exceptions(exceptions):
-        violations.append(
-            Violation(
-                "adr-registry",
-                "ADR-REGISTRY",
-                "docs/adr/exceptions.yaml",
-                error,
-            )
-        )
+        violations.append(_registry_violation("docs/adr/exceptions.yaml", error))
 
     adr_ids: set[str] = set()
     rule_ids: set[str] = set()
     for entry in registry:
-        missing = REQUIRED_ADR_KEYS - set(entry)
-        if missing:
-            violations.append(
-                Violation(
-                    "adr-registry",
-                    "ADR-REGISTRY",
-                    "docs/adr/index.yaml",
-                    f"ADR entry {entry.get('id', '<missing-id>')} is missing keys: {sorted(missing)}",
-                )
-            )
-            continue
-
-        adr_id = entry["id"]
-        if adr_id in adr_ids:
-            violations.append(
-                Violation(
-                    "adr-registry",
-                    "ADR-REGISTRY",
-                    "docs/adr/index.yaml",
-                    f"Duplicate ADR id: {adr_id}",
-                )
-            )
-        adr_ids.add(adr_id)
-
-        rules = entry.get("rules", [])
-        if not isinstance(rules, list):
-            violations.append(
-                Violation(
-                    "adr-registry",
-                    "ADR-REGISTRY",
-                    "docs/adr/index.yaml",
-                    f"{adr_id} rules must be a list",
-                )
-            )
-            continue
-
-        for rule in rules:
-            rule_id = rule.get("id")
-            if not rule_id:
-                violations.append(
-                    Violation(
-                        "adr-registry",
-                        "ADR-REGISTRY",
-                        "docs/adr/index.yaml",
-                        f"{adr_id} has a rule without an id",
-                    )
-                )
-                continue
-            if rule_id in rule_ids:
-                violations.append(
-                    Violation(
-                        "adr-registry",
-                        "ADR-REGISTRY",
-                        "docs/adr/index.yaml",
-                        f"Duplicate rule id: {rule_id}",
-                    )
-                )
-            rule_ids.add(rule_id)
+        _check_adr_entry(entry, adr_ids, rule_ids, violations)
 
     for exception in exceptions:
         rule_id = exception.get("rule_id")
         if not rule_id or rule_id not in rule_ids:
             violations.append(
-                Violation(
-                    "adr-registry",
-                    "ADR-REGISTRY",
+                _registry_violation(
                     "docs/adr/exceptions.yaml",
                     f"Exception references unknown rule id: {rule_id!r}",
                 )

--- a/scripts/check_tf_sg_cidrs/check_tf_sg_cidrs.py
+++ b/scripts/check_tf_sg_cidrs/check_tf_sg_cidrs.py
@@ -115,67 +115,79 @@ def _check_cidr(value: str) -> str | None:
     return None
 
 
+def _collect_cidr_violations_on_line(path: Path, idx: int, raw: str) -> list[Violation]:
+    """Return any CIDR-block violations found on a single ingress line."""
+    out: list[Violation] = []
+    m = _CIDR_BLOCKS_RE.match(raw)
+    if not m:
+        return out
+    for item in _parse_cidr_block_items(m.group("items")):
+        reason = _check_cidr(item)
+        if reason is not None:
+            out.append(Violation(path, idx, item, reason))
+    return out
+
+
+class _ParserState:
+    """Mutable per-file scan state for `check_file`'s line walker."""
+
+    def __init__(self) -> None:
+        self.in_resource: str | None = None
+        self.resource_brace_depth = 0
+        self.in_inline_ingress_block = False
+        self.ingress_brace_depth = 0
+        self.is_security_group_rule_ingress = False
+
+    def reset_resource(self) -> None:
+        self.in_resource = None
+        self.in_inline_ingress_block = False
+        self.is_security_group_rule_ingress = False
+
+
+def _enter_resource_if_match(state: _ParserState, raw: str) -> bool:
+    """If `raw` opens a new resource block, record it. Return True iff so."""
+    m = _RESOURCE_RE.match(raw)
+    if not m:
+        return False
+    state.in_resource = m.group(1)
+    state.resource_brace_depth = raw.count("{") - raw.count("}")
+    state.is_security_group_rule_ingress = False
+    return True
+
+
 def check_file(path: Path) -> list[Violation]:
     violations: list[Violation] = []
     text = path.read_text()
-    lines = text.splitlines()
+    state = _ParserState()
 
-    in_resource: str | None = None
-    resource_brace_depth = 0
-
-    in_ingress = False
-    ingress_brace_depth = 0
-    in_inline_ingress_block = False
-    is_security_group_rule_ingress = False
-
-    for idx, raw in enumerate(lines, start=1):
-        if in_resource is None:
-            m = _RESOURCE_RE.match(raw)
-            if m:
-                in_resource = m.group(1)
-                resource_brace_depth = raw.count("{") - raw.count("}")
-                in_ingress = False
-                is_security_group_rule_ingress = False
+    for idx, raw in enumerate(text.splitlines(), start=1):
+        if state.in_resource is None:
+            _enter_resource_if_match(state, raw)
             continue
 
-        resource_brace_depth += raw.count("{") - raw.count("}")
-        if resource_brace_depth <= 0:
-            in_resource = None
-            in_ingress = False
-            in_inline_ingress_block = False
-            is_security_group_rule_ingress = False
+        state.resource_brace_depth += raw.count("{") - raw.count("}")
+        if state.resource_brace_depth <= 0:
+            state.reset_resource()
             continue
 
-        if in_resource == "aws_security_group_rule":
+        if state.in_resource == "aws_security_group_rule":
             if _TYPE_INGRESS_RE.match(raw):
-                is_security_group_rule_ingress = True
-            if is_security_group_rule_ingress:
-                m = _CIDR_BLOCKS_RE.match(raw)
-                if m:
-                    for item in _parse_cidr_block_items(m.group("items")):
-                        reason = _check_cidr(item)
-                        if reason is not None:
-                            violations.append(
-                                Violation(path, idx, item, reason)
-                            )
+                state.is_security_group_rule_ingress = True
+            if state.is_security_group_rule_ingress:
+                violations.extend(_collect_cidr_violations_on_line(path, idx, raw))
             continue
 
         # aws_security_group: only check inside `ingress { ... }` inline blocks.
-        if not in_inline_ingress_block and _INGRESS_BLOCK_RE.match(raw):
-            in_inline_ingress_block = True
-            ingress_brace_depth = raw.count("{") - raw.count("}")
+        if not state.in_inline_ingress_block and _INGRESS_BLOCK_RE.match(raw):
+            state.in_inline_ingress_block = True
+            state.ingress_brace_depth = raw.count("{") - raw.count("}")
             continue
 
-        if in_inline_ingress_block:
-            ingress_brace_depth += raw.count("{") - raw.count("}")
-            m = _CIDR_BLOCKS_RE.match(raw)
-            if m:
-                for item in _parse_cidr_block_items(m.group("items")):
-                    reason = _check_cidr(item)
-                    if reason is not None:
-                        violations.append(Violation(path, idx, item, reason))
-            if ingress_brace_depth <= 0:
-                in_inline_ingress_block = False
+        if state.in_inline_ingress_block:
+            state.ingress_brace_depth += raw.count("{") - raw.count("}")
+            violations.extend(_collect_cidr_violations_on_line(path, idx, raw))
+            if state.ingress_brace_depth <= 0:
+                state.in_inline_ingress_block = False
 
     return violations
 

--- a/scripts/polaris-aws-range/apply_kali_bedrock_shard.py
+++ b/scripts/polaris-aws-range/apply_kali_bedrock_shard.py
@@ -426,55 +426,45 @@ def parse_args() -> argparse.Namespace:
     return p.parse_args()
 
 
-def main() -> int:
-    args = parse_args()
-    if args.batch_size < 1 or args.batch_size > 50:
-        print("--batch-size must be 1..50", file=sys.stderr)
-        return 2
-    if args.force_shard is not None and not (0 <= args.force_shard < len(SHARD_TABLE)):
-        print(f"--force-shard must be 0..{len(SHARD_TABLE)-1}", file=sys.stderr)
-        return 2
-
-    session = boto3.Session(region_name=args.region, profile_name=args.profile)
-    ec2 = session.client("ec2")
-    ssm = session.client("ssm")
-
-    # --- Resolve targets ---
+def _resolve_targets(args, ec2, ssm) -> list[Target]:
+    """Resolve --instance-ids/--ami-id args into the list of Target rows."""
     if args.instance_ids:
         ids = [s.strip() for s in args.instance_ids.split(",") if s.strip()]
         targets = [Target(instance_id=i, vpc_id="?", name="?", user_id="") for i in ids]
         if args.force_shard is None:
-            # need user_id to shard; look up tags
             targets = hydrate_user_ids(ec2, targets)
-    else:
-        ami_id = args.ami_id or resolve_polaris_ami_id(ssm)
-        print(f"discovering instances: ami_id={ami_id} vpc_id={args.vpc_id or '(any)'}")
-        targets = discover_targets(ec2, ami_id, args.vpc_id)
+        return targets
+    ami_id = args.ami_id or resolve_polaris_ami_id(ssm)
+    print(f"discovering instances: ami_id={ami_id} vpc_id={args.vpc_id or '(any)'}")
+    return discover_targets(ec2, ami_id, args.vpc_id)
 
-    if not targets:
-        print("no targets found.")
-        return 0
 
-    # --- Assign shards + group ---
+def _group_by_shard(
+    targets: list[Target], *, force_shard: int | None, account_b_only: bool
+) -> dict[int, list[Target]]:
+    """Group targets by their assigned shard; print and skip targets that fail to assign."""
     grouped: dict[int, list[Target]] = {}
     assign_errors: list[str] = []
     for t in targets:
         try:
-            shard = assign_shard(t.user_id, args.force_shard, args.account_b_only)
+            shard = assign_shard(t.user_id, force_shard, account_b_only)
         except ValueError as e:
             assign_errors.append(f"  {t.instance_id} name={t.name!r} user_id={t.user_id!r}: {e}")
             continue
         grouped.setdefault(shard, []).append(t)
-
     if assign_errors:
         print("shard-assignment errors (these targets will be skipped):")
         for line in assign_errors:
             print(line)
+    return grouped
 
+
+def _print_shard_layout(grouped: dict[int, list[Target]]) -> None:
+    """Echo a per-shard preview of the grouped targets."""
     total_assigned = sum(len(v) for v in grouped.values())
     print(f"\n{total_assigned} target(s) across {len(grouped)} shard(s):\n")
     for shard_idx in sorted(grouped):
-        account_id, model, fast_model = SHARD_TABLE[shard_idx]
+        account_id, model, _fast_model = SHARD_TABLE[shard_idx]
         acct = "A" if account_id == ACCOUNT_A_ID else "B"
         print(f"  shard {shard_idx} [{acct} {model}]  -> {len(grouped[shard_idx])} range(s)")
         for t in grouped[shard_idx][:5]:
@@ -482,38 +472,34 @@ def main() -> int:
         if len(grouped[shard_idx]) > 5:
             print(f"      ... +{len(grouped[shard_idx]) - 5} more")
 
-    if args.dry_run:
-        print("\n--dry-run: no commands sent.")
-        return 0
 
-    if not args.yes:
-        ans = input(f"\napply kali bedrock shard to {total_assigned} range(s)? [yes/NO] ").strip()
-        if ans.lower() not in {"yes", "y"}:
-            print("aborted.")
-            return 1
+def _bump_imds_hop_limit(ec2, all_ids: list[str]) -> None:
+    """Raise IMDSv2 hop limit on every target so Docker-bridge IMDS calls succeed.
 
-    # --- Raise IMDSv2 hop limit to 3 on every target before SSM ---
-    # Account A shards use the EC2 instance profile via IMDS; Docker
-    # bridge adds one hop, so the default EC2 hop_limit=1 blocks token
-    # PUTs and Claude Code silently has no creds. 3 gives one extra
-    # hop of insurance over the proven minimum (2). Idempotent.
-    all_ids = [t.instance_id for shard in grouped.values() for t in shard]
+    Account A shards use the EC2 instance profile via IMDS; Docker bridge adds
+    one hop, so the default hop_limit=1 blocks token PUTs and Claude Code
+    silently has no creds. 3 gives one extra hop of insurance over the proven
+    minimum (2). Idempotent.
+    """
     print(f"\nbumping IMDSv2 hop limit to 3 on {len(all_ids)} instance(s)...")
     imds_errors = ensure_imds_hop_limit(ec2, all_ids)
-    if imds_errors:
-        print(f"  {len(imds_errors)} instance(s) failed IMDS modify:")
-        for iid, err in list(imds_errors.items())[:10]:
-            print(f"    {iid}: {err}")
-    else:
+    if not imds_errors:
         print("  done.")
+        return
+    print(f"  {len(imds_errors)} instance(s) failed IMDS modify:")
+    for iid, err in list(imds_errors.items())[:10]:
+        print(f"    {iid}: {err}")
 
-    # --- Send per-shard batches ---
+
+def _send_shard_batches(
+    ssm, grouped: dict[int, list[Target]], *, batch_size: int, max_concurrency: int, timeout_s: int
+) -> dict[str, dict]:
+    """Send the per-shard SSM batches and collect per-instance results."""
     overall: dict[str, dict] = {}
     for shard_idx in sorted(grouped):
-        shard_targets = grouped[shard_idx]
         script = render_script(shard_idx)
-        instance_ids = [t.instance_id for t in shard_targets]
-        for batch_num, chunk in enumerate(batched(instance_ids, args.batch_size), start=1):
+        instance_ids = [t.instance_id for t in grouped[shard_idx]]
+        for batch_num, chunk in enumerate(batched(instance_ids, batch_size), start=1):
             comment = f"kali bedrock shard {shard_idx} batch {batch_num}"
             print(f"\n{comment}: {len(chunk)} instance(s) -> SendCommand")
             try:
@@ -521,8 +507,8 @@ def main() -> int:
                     ssm,
                     instance_ids=chunk,
                     script=script,
-                    max_concurrency=args.max_concurrency,
-                    timeout_s=args.timeout,
+                    max_concurrency=max_concurrency,
+                    timeout_s=timeout_s,
                     comment=comment,
                 )
             except ClientError as e:
@@ -536,21 +522,70 @@ def main() -> int:
             succ = sum(1 for r in results.values() if r["Status"] == "Success")
             fail = sum(1 for r in results.values() if r["Status"] != "Success")
             print(f"  shard {shard_idx} batch {batch_num} done: {succ} ok, {fail} non-success")
+    return overall
 
-    # --- Summary ---
+
+def _print_summary(overall: dict[str, dict]) -> int:
     print("\n=== summary ===")
     ok = [iid for iid, r in overall.items() if r["Status"] == "Success"]
     fail = {iid: r for iid, r in overall.items() if r["Status"] != "Success"}
     print(f"success: {len(ok)} / {len(overall)}")
-    if fail:
-        print("\nfailures:")
-        for iid, r in fail.items():
-            print(f"  {iid}: {r['Status']} / {r.get('StatusDetails','')}")
-            err = (r.get("StandardErrorContent") or "").strip()
-            if err:
-                print(f"    stderr (last 1k): {err[-500:]}")
+    if not fail:
+        return 0
+    print("\nfailures:")
+    for iid, r in fail.items():
+        print(f"  {iid}: {r['Status']} / {r.get('StatusDetails', '')}")
+        err = (r.get("StandardErrorContent") or "").strip()
+        if err:
+            print(f"    stderr (last 1k): {err[-500:]}")
+    return 1
 
-    return 0 if not fail else 1
+
+def main() -> int:
+    args = parse_args()
+    if args.batch_size < 1 or args.batch_size > 50:
+        print("--batch-size must be 1..50", file=sys.stderr)
+        return 2
+    if args.force_shard is not None and not (0 <= args.force_shard < len(SHARD_TABLE)):
+        print(f"--force-shard must be 0..{len(SHARD_TABLE) - 1}", file=sys.stderr)
+        return 2
+
+    session = boto3.Session(region_name=args.region, profile_name=args.profile)
+    ec2 = session.client("ec2")
+    ssm = session.client("ssm")
+
+    targets = _resolve_targets(args, ec2, ssm)
+    if not targets:
+        print("no targets found.")
+        return 0
+
+    grouped = _group_by_shard(
+        targets, force_shard=args.force_shard, account_b_only=args.account_b_only
+    )
+    _print_shard_layout(grouped)
+
+    if args.dry_run:
+        print("\n--dry-run: no commands sent.")
+        return 0
+
+    if not args.yes:
+        total_assigned = sum(len(v) for v in grouped.values())
+        ans = input(f"\napply kali bedrock shard to {total_assigned} range(s)? [yes/NO] ").strip()
+        if ans.lower() not in {"yes", "y"}:
+            print("aborted.")
+            return 1
+
+    all_ids = [t.instance_id for shard in grouped.values() for t in shard]
+    _bump_imds_hop_limit(ec2, all_ids)
+
+    overall = _send_shard_batches(
+        ssm,
+        grouped,
+        batch_size=args.batch_size,
+        max_concurrency=args.max_concurrency,
+        timeout_s=args.timeout,
+    )
+    return _print_summary(overall)
 
 
 if __name__ == "__main__":

--- a/scripts/polaris-aws-range/check_range_health.py
+++ b/scripts/polaris-aws-range/check_range_health.py
@@ -163,40 +163,40 @@ class RangeReport:
 
     @property
     def ok(self) -> bool:
-        if self.fields.get("container_count") != str(EXPECTED_CONTAINER_COUNT):
-            return False
-        if self.fields.get("exited_containers", "none") not in ("none", ""):
-            return False
-        if self.fields.get("a14_state") != "running":
-            return False
-        if self.fields.get("a14_on_splice") != "0":
-            return False
-        if self.fields.get("bedrock_profile") != "1":
-            return False
-        for k in KALI_ENV_KEYS:
-            if self.fields.get(f"env_{k}") != "1":
-                return False
-        if self.fields.get("hosts_override") != "1":
-            return False
-        if self.fields.get("splice_watcher") != "active":
-            return False
-        for name in ("a5_scada_state", "a9_splice_state", "a0_website_state"):
-            if self.fields.get(name) != "running":
-                return False
-        return True
+        return not self.issues()
 
     def issues(self) -> list[str]:
         probs: list[str] = []
+        probs.extend(self._container_count_issue())
+        probs.extend(self._exited_containers_issue())
+        probs.extend(self._a14_kali_issues())
+        probs.extend(self._bedrock_env_issues())
+        probs.extend(self._splice_watcher_issue())
+        probs.extend(self._other_container_state_issues())
+        return probs
+
+    def _container_count_issue(self) -> list[str]:
         cc = self.fields.get("container_count", "?")
         if cc != str(EXPECTED_CONTAINER_COUNT):
-            probs.append(f"container_count={cc}/{EXPECTED_CONTAINER_COUNT}")
+            return [f"container_count={cc}/{EXPECTED_CONTAINER_COUNT}"]
+        return []
+
+    def _exited_containers_issue(self) -> list[str]:
         ex = self.fields.get("exited_containers", "")
         if ex and ex != "none":
-            probs.append(f"exited=[{ex}]")
+            return [f"exited=[{ex}]"]
+        return []
+
+    def _a14_kali_issues(self) -> list[str]:
+        probs: list[str] = []
         if self.fields.get("a14_state") != "running":
             probs.append(f"a14-kali={self.fields.get('a14_state')}")
         if self.fields.get("a14_on_splice") == "1":
             probs.append("a14 still on splice-link (watcher didn't disconnect)")
+        return probs
+
+    def _bedrock_env_issues(self) -> list[str]:
+        probs: list[str] = []
         if self.fields.get("bedrock_profile") != "1":
             probs.append("missing /etc/profile.d/claude-bedrock.sh")
         for k in KALI_ENV_KEYS:
@@ -204,12 +204,19 @@ class RangeReport:
                 probs.append(f"missing env {k}")
         if self.fields.get("hosts_override") != "1":
             probs.append("missing /etc/hosts bedrock-runtime entry")
+        return probs
+
+    def _splice_watcher_issue(self) -> list[str]:
         sw = self.fields.get("splice_watcher")
         if sw != "active":
-            probs.append(f"splice-watcher={sw}")
+            return [f"splice-watcher={sw}"]
+        return []
+
+    def _other_container_state_issues(self) -> list[str]:
+        probs: list[str] = []
         for name in ("a5_scada_state", "a9_splice_state", "a0_website_state"):
             if self.fields.get(name) != "running":
-                probs.append(f"{name.replace('_state','')}={self.fields.get(name)}")
+                probs.append(f"{name.replace('_state', '')}={self.fields.get(name)}")
         return probs
 
 

--- a/scripts/polaris-aws-range/cleanup_non_keepers.py
+++ b/scripts/polaris-aws-range/cleanup_non_keepers.py
@@ -214,36 +214,26 @@ def main() -> int:
     stdout, stderr = run_in_portal(ssm, portal, inner)
     events = parse_events(stdout)
 
-    # Summarize
-    start = next((e for e in events if e["kind"] == "start"), None)
-    plan = next((e for e in events if e["kind"] == "plan"), None)
-    done = next((e for e in events if e["kind"] == "done"), None)
-    abort = next((e for e in events if e["kind"] == "abort"), None)
-    fatal = next((e for e in events if e["kind"] == "fatal"), None)
+    return _summarize_events(events, execute=args.execute)
 
-    if fatal:
+
+def _summarize_events(events: list[dict], *, execute: bool) -> int:
+    """Print a per-event-kind summary and return the appropriate exit code."""
+    by_kind = {kind: next((e for e in events if e["kind"] == kind), None)
+               for kind in ("start", "plan", "done", "abort", "fatal")}
+
+    if by_kind["fatal"]:
         print("FATAL:")
-        print(fatal.get("error", ""))
+        print(by_kind["fatal"].get("error", ""))
         return 2
-    if abort:
-        print(f"ABORTED: {abort.get('reason')}")
-        print(json.dumps(abort, indent=2))
+    if by_kind["abort"]:
+        print(f"ABORTED: {by_kind['abort'].get('reason')}")
+        print(json.dumps(by_kind["abort"], indent=2))
         return 3
 
-    if start:
-        print(f"event: {start['event_name']}")
-        print(f"participants in DB: {start['participant_count']}")
-        n = start["participant_count"]
-        if not (EXPECTED_TOTAL_MIN <= n <= EXPECTED_TOTAL_MAX):
-            print(f"SANITY ABORT: participant count {n} outside "
-                  f"[{EXPECTED_TOTAL_MIN}, {EXPECTED_TOTAL_MAX}]")
-            return 4
-    if plan:
-        print(f"  keepers found: {plan['keepers']}")
-        print(f"  destroyers:    {plan['destroyers']}")
-        if plan["keepers"] != len(KEEP_EMAILS):
-            print(f"SANITY ABORT: found {plan['keepers']} keepers, expected {len(KEEP_EMAILS)}")
-            return 5
+    sanity_code = _check_event_sanity(by_kind["start"], by_kind["plan"])
+    if sanity_code:
+        return sanity_code
 
     to_destroy = [e for e in events if e["kind"] == "would_destroy"]
     print(f"\nranges marked for destroy: {len(to_destroy)}")
@@ -254,18 +244,41 @@ def main() -> int:
         print(f"  {e['email']:<45s} participant={e['participant_id']} "
               f"range_instance={e['range_instance_id']} status={e['range_status']}")
 
-    if args.execute:
-        destroyed = [e for e in events if e["kind"] == "destroyed"]
-        failed = [e for e in events if e["kind"] == "destroy_failed"]
-        print(f"\ndestroyed: {len(destroyed)}")
-        print(f"failed:    {len(failed)}")
-        for f in failed:
-            print(f"  FAIL {f['email']}  {f['error']}")
-        print(f"\n{done}")
-        return 0 if len(failed) == 0 else 7
-    else:
-        print(f"\nDRY-RUN complete. No changes made. Re-run with --execute to destroy.")
+    if not execute:
+        print("\nDRY-RUN complete. No changes made. Re-run with --execute to destroy.")
         return 0
+
+    destroyed = [e for e in events if e["kind"] == "destroyed"]
+    failed = [e for e in events if e["kind"] == "destroy_failed"]
+    print(f"\ndestroyed: {len(destroyed)}")
+    print(f"failed:    {len(failed)}")
+    for f in failed:
+        print(f"  FAIL {f['email']}  {f['error']}")
+    print(f"\n{by_kind['done']}")
+    return 0 if not failed else 7
+
+
+def _check_event_sanity(start: dict | None, plan: dict | None) -> int:
+    """Verify participant_count + keepers fall within configured bounds; return exit code or 0."""
+    if start:
+        print(f"event: {start['event_name']}")
+        print(f"participants in DB: {start['participant_count']}")
+        n = start["participant_count"]
+        if not (EXPECTED_TOTAL_MIN <= n <= EXPECTED_TOTAL_MAX):
+            print(
+                f"SANITY ABORT: participant count {n} outside "
+                f"[{EXPECTED_TOTAL_MIN}, {EXPECTED_TOTAL_MAX}]"
+            )
+            return 4
+    if plan:
+        print(f"  keepers found: {plan['keepers']}")
+        print(f"  destroyers:    {plan['destroyers']}")
+        if plan["keepers"] != len(KEEP_EMAILS):
+            print(
+                f"SANITY ABORT: found {plan['keepers']} keepers, expected {len(KEEP_EMAILS)}"
+            )
+            return 5
+    return 0
 
 
 if __name__ == "__main__":

--- a/scripts/polaris-aws-range/orchestrate_provisioning.py
+++ b/scripts/polaris-aws-range/orchestrate_provisioning.py
@@ -409,25 +409,8 @@ def wait_for_ec2_launch(
     return counts
 
 
-def run_one_batch(
-    ssm, ec2, instance_id: str, state: State, batch_num: int, args: argparse.Namespace
-) -> tuple[int, int]:
-    """Trigger the next batch, wait for terminal state, record outcomes.
-
-    Returns (successes, failures) for this batch.
-    """
-    current: list[str] = []
-    log_line(current, f"=== batch {batch_num}: fetch up to {args.batch_size} unprovisioned ===")
-
-    fetched = fetch_unprovisioned(ssm, instance_id, args.event_id, args.batch_size, args.email_regex)
-    batch = fetched["batch"]
-    remaining = fetched["total_unprovisioned"]
-    log_line(current, f"unprovisioned remaining: {remaining}; batch size: {len(batch)}")
-
-    if not batch:
-        return (0, 0)
-
-    # Register outcomes
+def _register_initial_outcomes(state: State, batch: list[dict], batch_num: int) -> None:
+    """Record per-participant `triggered` outcomes before the trigger call."""
     started = now_iso()
     for p in batch:
         pid = p["participant_id"]
@@ -439,14 +422,10 @@ def run_one_batch(
             batch_num=batch_num,
             started_at=started,
         )
-    save_state(state)
-    write_status_doc(state, current)
 
-    # Trigger
-    pids = [p["participant_id"] for p in batch]
-    log_line(current, f"triggering provision for pids: {pids}")
-    trig = trigger_batch(ssm, instance_id, pids)
 
+def _record_trigger_results(state: State, batch: list[dict], trig: dict, current: list[str]) -> list[str]:
+    """Stamp trigger outcomes onto state; return the list of successful range ids."""
     range_ids: list[str] = []
     for p in batch:
         pid = p["participant_id"]
@@ -456,99 +435,24 @@ def run_one_batch(
             state.outcomes[pid].error = tres["error"]
             state.outcomes[pid].finished_at = now_iso()
             log_line(current, f"  [TRIGGER FAIL] {p['email']}: {tres['error']}")
-        else:
-            rid = tres.get("range_instance_id")
-            if rid is None:
-                state.outcomes[pid].status = "trigger_error"
-                state.outcomes[pid].error = "no range_instance_id returned"
-                state.outcomes[pid].finished_at = now_iso()
-                log_line(current, f"  [TRIGGER FAIL] {p['email']}: no range_id")
-            else:
-                state.outcomes[pid].range_instance_id = str(rid)
-                range_ids.append(str(rid))
-                log_line(current, f"  [TRIGGERED] {p['email']}: range={rid}")
-    save_state(state)
-    write_status_doc(state, current)
+            continue
+        rid = tres.get("range_instance_id")
+        if rid is None:
+            state.outcomes[pid].status = "trigger_error"
+            state.outcomes[pid].error = "no range_instance_id returned"
+            state.outcomes[pid].finished_at = now_iso()
+            log_line(current, f"  [TRIGGER FAIL] {p['email']}: no range_id")
+            continue
+        state.outcomes[pid].range_instance_id = str(rid)
+        range_ids.append(str(rid))
+        log_line(current, f"  [TRIGGERED] {p['email']}: range={rid}")
+    return range_ids
 
-    if not range_ids:
-        log_line(current, "no ranges triggered successfully; skipping wait")
-        return (0, sum(1 for p in batch if state.outcomes[p["participant_id"]].status == "trigger_error"))
 
-    # Wave mode: trigger, wait until EC2 launched for this wave, then return so
-    # the next wave can be triggered. The actual provisioning completion is
-    # validated at end-of-run by a separate tool, not per-batch.
-    if args.wave_ec2_gate:
-        log_line(current, f"wave mode: waiting up to {args.wave_gate_timeout}s for {len(range_ids)} ranges to launch EC2")
-        counts = wait_for_ec2_launch(
-            ec2,
-            range_ids,
-            current,
-            timeout_s=args.wave_gate_timeout,
-            poll_interval_s=args.wave_gate_poll,
-        )
-        successes = 0
-        failures = 0
-        for p in batch:
-            pid = p["participant_id"]
-            o = state.outcomes[pid]
-            if o.status == "trigger_error":
-                failures += 1
-                continue
-            # Consider triggered; final verification happens at end of run
-            o.status = "triggered"
-            o.finished_at = now_iso()
-            successes += 1
-        save_state(state)
-        write_status_doc(state, current)
-        log_line(current, f"wave {batch_num} EC2-gated: triggered={successes} trigger_errors={failures}")
-        return (successes, failures)
-
-    # Sleep-only mode: trust the observed provisioning time, skip DB polling
-    if args.sleep_only > 0:
-        wait_s = args.sleep_only * 60
-        log_line(current, f"sleep-only mode: waiting {args.sleep_only} min before next batch")
-        time.sleep(wait_s)
-        successes = 0
-        failures = 0
-        for p in batch:
-            pid = p["participant_id"]
-            o = state.outcomes[pid]
-            if o.status == "trigger_error":
-                failures += 1
-                continue
-            # Treat as ready (will be verified end-to-end at summary)
-            o.status = "ready"
-            o.finished_at = now_iso()
-            successes += 1
-        save_state(state)
-        write_status_doc(state, current)
-        log_line(current, f"batch {batch_num} assumed-ready: successes={successes} failures={failures}")
-        return (successes, failures)
-
-    # Wait for terminal
-    log_line(current, f"waiting for {len(range_ids)} range(s) to reach terminal state...")
-    deadline = time.monotonic() + args.batch_timeout * 60
-    terminal: dict[str, str] = {}
-    while range_ids and time.monotonic() < deadline:
-        time.sleep(args.poll_interval)
-        statuses = check_range_status(ssm, instance_id, range_ids)
-        still_pending: list[str] = []
-        for rid in range_ids:
-            s = statuses.get(rid, {}).get("status", "?")
-            if s in ("ready", "failed", "destroyed", "missing"):
-                terminal[rid] = s
-                log_line(current, f"  [{s.upper():8}] range={rid}")
-            else:
-                still_pending.append(rid)
-        range_ids = still_pending
-        if range_ids:
-            log_line(current, f"  still pending: {len(range_ids)}")
-
-    # Any remaining are timeouts
-    for rid in range_ids:
-        terminal[rid] = "timeout"
-
-    # Update outcomes based on range status
+def _finalize_batch_outcomes(
+    state: State, batch: list[dict], terminal: dict[str, str]
+) -> tuple[int, int]:
+    """Translate per-range terminal statuses into outcome counts (successes, failures)."""
     successes = failures = 0
     for p in batch:
         pid = p["participant_id"]
@@ -568,10 +472,192 @@ def run_one_batch(
             o.status = "failed"
             o.error = f"terminal range status={s}"
             failures += 1
+    return successes, failures
+
+
+def _run_wave_ec2_mode(
+    state: State,
+    batch: list[dict],
+    range_ids: list[str],
+    args: argparse.Namespace,
+    ec2,
+    current: list[str],
+    batch_num: int,
+) -> tuple[int, int]:
+    """Wave mode: trigger, wait for EC2 launch, return so the next wave can trigger."""
+    log_line(
+        current,
+        f"wave mode: waiting up to {args.wave_gate_timeout}s for {len(range_ids)} ranges to launch EC2",
+    )
+    wait_for_ec2_launch(
+        ec2,
+        range_ids,
+        current,
+        timeout_s=args.wave_gate_timeout,
+        poll_interval_s=args.wave_gate_poll,
+    )
+    successes = failures = 0
+    for p in batch:
+        o = state.outcomes[p["participant_id"]]
+        if o.status == "trigger_error":
+            failures += 1
+            continue
+        o.status = "triggered"
+        o.finished_at = now_iso()
+        successes += 1
+    save_state(state)
+    write_status_doc(state, current)
+    log_line(
+        current, f"wave {batch_num} EC2-gated: triggered={successes} trigger_errors={failures}"
+    )
+    return successes, failures
+
+
+def _run_sleep_only_mode(
+    state: State,
+    batch: list[dict],
+    args: argparse.Namespace,
+    current: list[str],
+    batch_num: int,
+) -> tuple[int, int]:
+    """Sleep-only mode: trust observed provisioning time, skip DB polling."""
+    wait_s = args.sleep_only * 60
+    log_line(current, f"sleep-only mode: waiting {args.sleep_only} min before next batch")
+    time.sleep(wait_s)
+    successes = failures = 0
+    for p in batch:
+        o = state.outcomes[p["participant_id"]]
+        if o.status == "trigger_error":
+            failures += 1
+            continue
+        o.status = "ready"
+        o.finished_at = now_iso()
+        successes += 1
+    save_state(state)
+    write_status_doc(state, current)
+    log_line(
+        current, f"batch {batch_num} assumed-ready: successes={successes} failures={failures}"
+    )
+    return successes, failures
+
+
+def _wait_for_terminal(
+    ssm, instance_id: str, range_ids: list[str], args: argparse.Namespace, current: list[str]
+) -> dict[str, str]:
+    """Poll until every range reaches a terminal state or batch_timeout elapses."""
+    log_line(current, f"waiting for {len(range_ids)} range(s) to reach terminal state...")
+    deadline = time.monotonic() + args.batch_timeout * 60
+    terminal: dict[str, str] = {}
+    pending = list(range_ids)
+    while pending and time.monotonic() < deadline:
+        time.sleep(args.poll_interval)
+        statuses = check_range_status(ssm, instance_id, pending)
+        still_pending: list[str] = []
+        for rid in pending:
+            s = statuses.get(rid, {}).get("status", "?")
+            if s in ("ready", "failed", "destroyed", "missing"):
+                terminal[rid] = s
+                log_line(current, f"  [{s.upper():8}] range={rid}")
+            else:
+                still_pending.append(rid)
+        pending = still_pending
+        if pending:
+            log_line(current, f"  still pending: {len(pending)}")
+    for rid in pending:
+        terminal[rid] = "timeout"
+    return terminal
+
+
+def run_one_batch(
+    ssm, ec2, instance_id: str, state: State, batch_num: int, args: argparse.Namespace
+) -> tuple[int, int]:
+    """Trigger the next batch, wait for terminal state, record outcomes.
+
+    Returns (successes, failures) for this batch.
+    """
+    current: list[str] = []
+    log_line(current, f"=== batch {batch_num}: fetch up to {args.batch_size} unprovisioned ===")
+
+    fetched = fetch_unprovisioned(
+        ssm, instance_id, args.event_id, args.batch_size, args.email_regex
+    )
+    batch = fetched["batch"]
+    log_line(
+        current,
+        f"unprovisioned remaining: {fetched['total_unprovisioned']}; batch size: {len(batch)}",
+    )
+    if not batch:
+        return (0, 0)
+
+    _register_initial_outcomes(state, batch, batch_num)
+    save_state(state)
+    write_status_doc(state, current)
+
+    pids = [p["participant_id"] for p in batch]
+    log_line(current, f"triggering provision for pids: {pids}")
+    trig = trigger_batch(ssm, instance_id, pids)
+
+    range_ids = _record_trigger_results(state, batch, trig, current)
+    save_state(state)
+    write_status_doc(state, current)
+
+    if not range_ids:
+        log_line(current, "no ranges triggered successfully; skipping wait")
+        return (
+            0,
+            sum(1 for p in batch if state.outcomes[p["participant_id"]].status == "trigger_error"),
+        )
+
+    if args.wave_ec2_gate:
+        return _run_wave_ec2_mode(state, batch, range_ids, args, ec2, current, batch_num)
+
+    if args.sleep_only > 0:
+        return _run_sleep_only_mode(state, batch, args, current, batch_num)
+
+    terminal = _wait_for_terminal(ssm, instance_id, range_ids, args, current)
+    successes, failures = _finalize_batch_outcomes(state, batch, terminal)
     save_state(state)
     write_status_doc(state, current)
     log_line(current, f"batch {batch_num} done: successes={successes} failures={failures}")
-    return (successes, failures)
+    return successes, failures
+
+
+def _trigger_retry_and_collect_range_ids(
+    state: State, retry_pids: list[str], ssm, instance_id: str
+) -> list[str]:
+    """Re-trigger provision for `retry_pids`; mutate state and return ranges to wait on."""
+    trig = trigger_batch(ssm, instance_id, retry_pids)
+    range_ids: list[str] = []
+    for pid in retry_pids:
+        t = trig.get(pid, {})
+        if "error" in t:
+            state.outcomes[pid].status = "trigger_error"
+            state.outcomes[pid].error = t["error"]
+            state.outcomes[pid].finished_at = now_iso()
+            continue
+        rid = t.get("range_instance_id")
+        if rid:
+            state.outcomes[pid].range_instance_id = str(rid)
+            range_ids.append(str(rid))
+    return range_ids
+
+
+def _finalize_retry_outcomes(
+    state: State, retry_pids: list[str], terminal: dict[str, str]
+) -> None:
+    """Map terminal range statuses back onto the retry participants."""
+    for pid in retry_pids:
+        o = state.outcomes[pid]
+        if o.status == "trigger_error":
+            continue
+        rid = o.range_instance_id
+        s = terminal.get(rid, "unknown")
+        o.finished_at = now_iso()
+        if s == "ready":
+            o.status = "ready"
+        else:
+            o.status = "failed"
+            o.error = f"retry terminal status={s}"
 
 
 def retry_failures(
@@ -587,9 +673,13 @@ def retry_failures(
 
     # Before retry, the DB may already have range_instance_id set on some
     # participants (partial provision). Skip those by re-querying.
-    fetched = fetch_unprovisioned(ssm, instance_id, args.event_id, limit=len(failed) + 5, email_regex=args.email_regex)
+    fetched = fetch_unprovisioned(
+        ssm, instance_id, args.event_id, limit=len(failed) + 5, email_regex=args.email_regex
+    )
     still_unprovisioned = {p["participant_id"] for p in fetched["batch"]}
-    retry_pids = [o.participant_id for o in failed if o.participant_id in still_unprovisioned]
+    retry_pids = [
+        o.participant_id for o in failed if o.participant_id in still_unprovisioned
+    ]
     log_line(current, f"retry pids (after DB re-check): {retry_pids}")
 
     if not retry_pids:
@@ -597,61 +687,20 @@ def retry_failures(
         write_status_doc(state, current)
         return
 
-    # Mark retrying
     for pid in retry_pids:
         state.outcomes[pid].status = "retrying"
         state.outcomes[pid].error = None
     save_state(state)
     write_status_doc(state, current)
 
-    # Trigger + wait
-    trig = trigger_batch(ssm, instance_id, retry_pids)
-    range_ids: list[str] = []
-    for pid in retry_pids:
-        t = trig.get(pid, {})
-        if "error" in t:
-            state.outcomes[pid].status = "trigger_error"
-            state.outcomes[pid].error = t["error"]
-            state.outcomes[pid].finished_at = now_iso()
-        else:
-            rid = t.get("range_instance_id")
-            if rid:
-                state.outcomes[pid].range_instance_id = str(rid)
-                range_ids.append(str(rid))
+    range_ids = _trigger_retry_and_collect_range_ids(state, retry_pids, ssm, instance_id)
     save_state(state)
     write_status_doc(state, current)
 
     if range_ids:
         log_line(current, f"waiting on {len(range_ids)} retry range(s)...")
-        deadline = time.monotonic() + args.batch_timeout * 60
-        terminal: dict[str, str] = {}
-        while range_ids and time.monotonic() < deadline:
-            time.sleep(args.poll_interval)
-            statuses = check_range_status(ssm, instance_id, range_ids)
-            still = []
-            for rid in range_ids:
-                s = statuses.get(rid, {}).get("status", "?")
-                if s in ("ready", "failed", "destroyed", "missing"):
-                    terminal[rid] = s
-                    log_line(current, f"  [{s.upper():8}] range={rid}")
-                else:
-                    still.append(rid)
-            range_ids = still
-        for rid in range_ids:
-            terminal[rid] = "timeout"
-
-        for pid in retry_pids:
-            o = state.outcomes[pid]
-            if o.status == "trigger_error":
-                continue
-            rid = o.range_instance_id
-            s = terminal.get(rid, "unknown")
-            o.finished_at = now_iso()
-            if s == "ready":
-                o.status = "ready"
-            else:
-                o.status = "failed"
-                o.error = f"retry terminal status={s}"
+        terminal = _wait_for_terminal(ssm, instance_id, range_ids, args, current)
+        _finalize_retry_outcomes(state, retry_pids, terminal)
 
     save_state(state)
     write_status_doc(state, current)
@@ -692,6 +741,37 @@ def parse_args() -> argparse.Namespace:
     return p.parse_args()
 
 
+def _run_batch_loop(
+    ssm, ec2, instance_id: str, state: State, args: argparse.Namespace
+) -> int:
+    """Run batches until the queue empties, a threshold trips, or max_batches hits."""
+    total_failures = sum(
+        1 for o in state.outcomes.values() if o.status in ("failed", "trigger_error")
+    )
+    for batch_num in range(state.batches_completed + 1, args.max_batches + 1):
+        succ, fail = run_one_batch(ssm, ec2, instance_id, state, batch_num, args)
+        state.batches_completed = batch_num
+        total_failures += fail
+        save_state(state)
+
+        if succ == 0 and fail == 0:
+            break
+        if fail >= args.batch_fail_threshold:
+            state.halted = True
+            state.halt_reason = (
+                f"batch {batch_num} had {fail} failures (threshold {args.batch_fail_threshold})"
+            )
+            break
+        if total_failures >= args.total_fail_threshold:
+            state.halted = True
+            state.halt_reason = (
+                f"cumulative failures {total_failures} reached threshold "
+                f"{args.total_fail_threshold}"
+            )
+            break
+    return total_failures
+
+
 def main() -> int:
     args = parse_args()
     session = boto3.Session(profile_name=args.profile, region_name=args.region)
@@ -701,9 +781,12 @@ def main() -> int:
     instance_id = find_portal_instance(ec2)
     print(f"portal instance: {instance_id}")
 
-    # Dry run: fetch + show
-    first = fetch_unprovisioned(ssm, instance_id, args.event_id, args.batch_size, args.email_regex)
-    print(f"unprovisioned: {first['total_unprovisioned']} total; next batch of {len(first['batch'])}:")
+    first = fetch_unprovisioned(
+        ssm, instance_id, args.event_id, args.batch_size, args.email_regex
+    )
+    print(
+        f"unprovisioned: {first['total_unprovisioned']} total; next batch of {len(first['batch'])}:"
+    )
     for p in first["batch"]:
         print(f"  {p['email']}  (participant_id={p['participant_id']}, user_id={p['user_id']})")
 
@@ -714,7 +797,10 @@ def main() -> int:
         return 0
 
     if not args.yes:
-        ans = input(f"\nproceed with batches of {args.batch_size} (abort at {args.batch_fail_threshold}/batch or {args.total_fail_threshold} total)? [yes/NO] ").strip()
+        ans = input(
+            f"\nproceed with batches of {args.batch_size} (abort at "
+            f"{args.batch_fail_threshold}/batch or {args.total_fail_threshold} total)? [yes/NO] "
+        ).strip()
         if ans.lower() not in ("yes", "y"):
             print("aborted.")
             return 1
@@ -727,33 +813,12 @@ def main() -> int:
     )
     save_state(state)
 
-    total_failures = sum(1 for o in state.outcomes.values() if o.status in ("failed", "trigger_error"))
-    for batch_num in range(state.batches_completed + 1, args.max_batches + 1):
-        succ, fail = run_one_batch(ssm, ec2, instance_id, state, batch_num, args)
-        state.batches_completed = batch_num
-        total_failures += fail
-        save_state(state)
+    _run_batch_loop(ssm, ec2, instance_id, state, args)
 
-        if succ == 0 and fail == 0:
-            # nothing to do
-            break
-
-        if fail >= args.batch_fail_threshold:
-            state.halted = True
-            state.halt_reason = f"batch {batch_num} had {fail} failures (threshold {args.batch_fail_threshold})"
-            break
-        if total_failures >= args.total_fail_threshold:
-            state.halted = True
-            state.halt_reason = f"cumulative failures {total_failures} reached threshold {args.total_fail_threshold}"
-            break
-
-    # In wave/EC2-gate mode, the last wave just finished EC2 launch. Give
-    # everything time to complete docker-compose bootstrap before wrap up.
     if args.wave_ec2_gate and args.final_wait > 0 and not state.halted:
         print(f"final wait: {args.final_wait} min to let last wave finish provisioning...")
         time.sleep(args.final_wait * 60)
 
-    # Retry pass (even if halted, give them one more chance)
     retry_failures(ssm, ec2, instance_id, state, args)
 
     state.finished_at = now_iso()

--- a/shifter/engine/provisioner/components/tags.py
+++ b/shifter/engine/provisioner/components/tags.py
@@ -33,6 +33,37 @@ logger = logging.getLogger(__name__)
 UnitType = Literal["subnet", "instance"]
 
 
+def _validate_common_tag_inputs(
+    user_id: object,
+    environment: object,
+    request_uuid: object,
+    unit_type: object,
+    unit_uuid: object,
+) -> None:
+    """Reject the missing/wrong-type combinations `build_common_tags` cannot tolerate."""
+    if user_id is None:
+        raise ValueError("user_id is required")
+    if not isinstance(user_id, int) or user_id < 0:
+        raise ValueError(f"user_id must be a non-negative integer, got {user_id!r}")
+
+    if not environment:
+        raise ValueError("environment is required")
+    if not isinstance(environment, str):
+        raise ValueError(f"environment must be a string, got {type(environment).__name__}")
+
+    if not request_uuid:
+        raise ValueError("request_uuid is required")
+    if not isinstance(request_uuid, str):
+        raise ValueError(f"request_uuid must be a string, got {type(request_uuid).__name__}")
+
+    if unit_type is not None and not unit_uuid:
+        raise ValueError(f"unit_uuid is required when unit_type is set (unit_type={unit_type!r})")
+    if unit_uuid is not None and not unit_type:
+        raise ValueError(f"unit_type is required when unit_uuid is set (unit_uuid={unit_uuid!r})")
+    if unit_type is not None and unit_type not in ("subnet", "instance"):
+        raise ValueError(f"unit_type must be 'subnet' or 'instance', got {unit_type!r}")
+
+
 def build_common_tags(
     user_id: int,
     environment: str,
@@ -87,29 +118,7 @@ def build_common_tags(
             component="ngfw",
         )
     """
-    # Input validation
-    if user_id is None:
-        raise ValueError("user_id is required")
-    if not isinstance(user_id, int) or user_id < 0:
-        raise ValueError(f"user_id must be a non-negative integer, got {user_id!r}")
-
-    if not environment:
-        raise ValueError("environment is required")
-    if not isinstance(environment, str):
-        raise ValueError(f"environment must be a string, got {type(environment).__name__}")
-
-    if not request_uuid:
-        raise ValueError("request_uuid is required")
-    if not isinstance(request_uuid, str):
-        raise ValueError(f"request_uuid must be a string, got {type(request_uuid).__name__}")
-
-    # Validate unit_type and unit_uuid together
-    if unit_type is not None and not unit_uuid:
-        raise ValueError(f"unit_uuid is required when unit_type is set (unit_type={unit_type!r})")
-    if unit_uuid is not None and not unit_type:
-        raise ValueError(f"unit_type is required when unit_uuid is set (unit_uuid={unit_uuid!r})")
-    if unit_type is not None and unit_type not in ("subnet", "instance"):
-        raise ValueError(f"unit_type must be 'subnet' or 'instance', got {unit_type!r}")
+    _validate_common_tag_inputs(user_id, environment, request_uuid, unit_type, unit_uuid)
 
     # Build base tags (always present)
     tags: dict[str, str] = {

--- a/shifter/engine/provisioner/executors/ssh_executor.py
+++ b/shifter/engine/provisioner/executors/ssh_executor.py
@@ -162,64 +162,8 @@ class SSHExecutor:
             channel.send("exit\n")
             channel.shutdown_write()
 
-            # Read output until channel closes naturally
-            # We send 'exit' and shutdown_write(), so PAN-OS will close the channel
-            # when all commands complete. This is more reliable than prompt detection
-            # since commits can take 30+ seconds.
-            #
-            # IMPORTANT: We must wait for eof_received, NOT exit_status_ready.
-            # exit_status_ready() can return True before all data arrives, causing
-            # truncated output. eof_received is the authoritative signal that the
-            # server has finished sending all data.
-            output = ""
-            start_time = time.time()
-            chunk_count = 0
-
-            logger.info("Reading output until channel EOF")
-
-            while True:
-                # Read any available data
-                if channel.recv_ready():
-                    chunk = channel.recv(4096).decode("utf-8", errors="replace")
-                    chunk_count += 1
-                    logger.info("Chunk %d: %d bytes", chunk_count, len(chunk))
-                    logger.debug("Chunk %d content: %r", chunk_count, chunk)
-                    output += chunk
-
-                # Check if channel EOF (server finished sending all data)
-                # This is the ONLY reliable way to know all output has been received
-                if channel.eof_received:
-                    logger.info("Channel EOF received - draining remaining data")
-                    drained, drain_chunks = self._drain_channel(channel, chunk_count)
-                    output += drained
-                    chunk_count += drain_chunks
-                    break
-
-                # Overall timeout check
-                elapsed = time.time() - start_time
-                if elapsed > timeout_seconds:
-                    logger.error(
-                        "Command timed out after %.1fs (received %d chunks, %d bytes)",
-                        elapsed,
-                        chunk_count,
-                        len(output),
-                    )
-                    raise TimeoutError(f"Command timed out after {timeout_seconds}s")
-
-                time.sleep(0.1)
-
-            # Get exit code - wait briefly if not ready yet
-            # After EOF, exit status should arrive shortly
-            exit_code = -1
-            for _ in range(10):  # Wait up to 1 second
-                if channel.exit_status_ready():
-                    exit_code = channel.recv_exit_status()
-                    logger.info("Exit code: %s", exit_code)
-                    break
-                time.sleep(0.1)
-            else:
-                logger.info("Exit status not ready after 1s - using -1")
-
+            output, chunk_count, start_time = self._read_until_eof(channel, timeout_seconds)
+            exit_code = self._wait_for_exit_status(channel)
             elapsed = time.time() - start_time
             logger.info(
                 "Command completed in %.1fs, received %d bytes in %d chunks",
@@ -249,6 +193,55 @@ class SSHExecutor:
             raise TimeoutError(f"SSH command timed out on {host}: {e}") from e
         finally:
             client.close()
+
+    def _read_until_eof(self, channel, timeout_seconds: int) -> tuple[str, int, float]:
+        """Read from `channel` until EOF or timeout.
+
+        PAN-OS closes the channel when our `exit` finishes; `eof_received` is
+        the authoritative signal that all data has arrived (exit-status can
+        flip ready before output finishes draining, leading to truncation).
+        Returns `(output, chunk_count, start_time)`; raises TimeoutError on
+        overall timeout.
+        """
+        output = ""
+        start_time = time.time()
+        chunk_count = 0
+        logger.info("Reading output until channel EOF")
+        while True:
+            if channel.recv_ready():
+                chunk = channel.recv(4096).decode("utf-8", errors="replace")
+                chunk_count += 1
+                logger.info("Chunk %d: %d bytes", chunk_count, len(chunk))
+                logger.debug("Chunk %d content: %r", chunk_count, chunk)
+                output += chunk
+            if channel.eof_received:
+                logger.info("Channel EOF received - draining remaining data")
+                drained, drain_chunks = self._drain_channel(channel, chunk_count)
+                output += drained
+                chunk_count += drain_chunks
+                return output, chunk_count, start_time
+            elapsed = time.time() - start_time
+            if elapsed > timeout_seconds:
+                logger.error(
+                    "Command timed out after %.1fs (received %d chunks, %d bytes)",
+                    elapsed,
+                    chunk_count,
+                    len(output),
+                )
+                raise TimeoutError(f"Command timed out after {timeout_seconds}s")
+            time.sleep(0.1)
+
+    @staticmethod
+    def _wait_for_exit_status(channel) -> int:
+        """Poll briefly for the SSH channel's exit status; return -1 if not delivered."""
+        for _ in range(10):  # Wait up to 1 second
+            if channel.exit_status_ready():
+                exit_code = channel.recv_exit_status()
+                logger.info("Exit code: %s", exit_code)
+                return exit_code
+            time.sleep(0.1)
+        logger.info("Exit status not ready after 1s - using -1")
+        return -1
 
     def _drain_channel(self, channel, prior_chunk_count: int) -> tuple[str, int]:
         """Drain remaining data from an EOF'd channel until close or timeout.

--- a/shifter/engine/provisioner/executors/ssm_executor.py
+++ b/shifter/engine/provisioner/executors/ssm_executor.py
@@ -147,53 +147,62 @@ class SSMExecutor:
             logger.info(f"Command {command_id} status: {status} (elapsed={elapsed:.1f}s)")
 
             if status in self.TERMINAL_STATUSES:
-                exit_code = result.get("ResponseCode", -1)
-                stdout = result.get("StandardOutputContent", "")
-                stderr = result.get("StandardErrorContent", "")
-
-                # Truncate very long outputs
-                max_output = 50000
-                if len(stdout) > max_output:
-                    stdout = stdout[:max_output] + "\n... (truncated)"
-                if len(stderr) > max_output:
-                    stderr = stderr[:max_output] + "\n... (truncated)"
-
-                if status == "Success":
-                    elapsed = time.time() - start_time
-                    logger.info(f"SSM command completed in {elapsed:.1f}s on {instance_id}")
-                    return CommandResult(
-                        success=True,
-                        exit_code=exit_code,
-                        stdout=stdout,
-                        stderr=stderr,
-                    )
-                elif status == "Cancelled":
-                    raise CommandError(
-                        f"Command was cancelled on {instance_id}",
-                        exit_code=exit_code,
-                        stderr=stderr,
-                    )
-                elif status == "TimedOut":
-                    raise TimeoutError(f"Command timed out on {instance_id} (SSM timeout)")
-                else:  # Failed
-                    # Check if it's an instance termination
-                    if "not in a valid state" in stderr.lower():
-                        raise InstanceTerminatedError(f"Instance {instance_id} is not in a valid state")
-                    # Include both stdout and stderr - PowerShell Write-Host goes to stdout
-                    # SSM often returns generic errors in stderr, so always include stdout
-                    error_parts = []
-                    if stdout:
-                        error_parts.append(f"stdout={stdout[:2000]}")
-                    if stderr:
-                        error_parts.append(f"stderr={stderr[:500]}")
-                    error_details = " | ".join(error_parts) if error_parts else "no output"
-                    raise CommandError(
-                        f"Command failed on {instance_id}",
-                        exit_code=exit_code,
-                        stderr=error_details,
-                    )
+                return self._build_terminal_result(instance_id, result, start_time)
 
             time.sleep(self._poll_interval)
+
+    @staticmethod
+    def _truncate_output(text: str, max_output: int = 50000) -> str:
+        """Cap a single SSM stream to `max_output` chars with a marker."""
+        if len(text) <= max_output:
+            return text
+        return text[:max_output] + "\n... (truncated)"
+
+    def _build_terminal_result(self, instance_id: str, result: dict, start_time: float) -> CommandResult:
+        """Translate a terminal SSM invocation result into `CommandResult` or raise.
+
+        Owns the status-branch dispatch (`Success` / `Cancelled` / `TimedOut` /
+        `Failed`) so `run_command` stays under the per-function complexity ceiling.
+        """
+        status = result.get("Status", "")
+        exit_code = result.get("ResponseCode", -1)
+        stdout = self._truncate_output(result.get("StandardOutputContent", ""))
+        stderr = self._truncate_output(result.get("StandardErrorContent", ""))
+
+        if status == "Success":
+            elapsed = time.time() - start_time
+            logger.info(f"SSM command completed in {elapsed:.1f}s on {instance_id}")
+            return CommandResult(
+                success=True,
+                exit_code=exit_code,
+                stdout=stdout,
+                stderr=stderr,
+            )
+        if status == "Cancelled":
+            raise CommandError(
+                f"Command was cancelled on {instance_id}",
+                exit_code=exit_code,
+                stderr=stderr,
+            )
+        if status == "TimedOut":
+            raise TimeoutError(f"Command timed out on {instance_id} (SSM timeout)")
+
+        # status == "Failed". Detect instance-termination, then combine streams
+        # into a single error envelope. PowerShell Write-Host goes to stdout;
+        # SSM often returns a generic error in stderr, so include both.
+        if "not in a valid state" in stderr.lower():
+            raise InstanceTerminatedError(f"Instance {instance_id} is not in a valid state")
+        error_parts = []
+        if stdout:
+            error_parts.append(f"stdout={stdout[:2000]}")
+        if stderr:
+            error_parts.append(f"stderr={stderr[:500]}")
+        error_details = " | ".join(error_parts) if error_parts else "no output"
+        raise CommandError(
+            f"Command failed on {instance_id}",
+            exit_code=exit_code,
+            stderr=error_details,
+        )
 
     def wait_for_agent(
         self,
@@ -336,7 +345,6 @@ class SSMExecutor:
             InstanceTerminatedError: If instance is terminated
             SSMExecutorError: If readiness probe fails
         """
-        # Initiate reboot
         try:
             self._ec2_client.reboot_instances(InstanceIds=[instance_id])
         except ClientError as e:
@@ -345,12 +353,9 @@ class SSMExecutor:
                 raise InstanceNotFoundError(f"Instance {instance_id} not found") from e
             raise SSMExecutorError(f"Failed to reboot instance: {e}") from e
 
-        # Wait a moment for reboot to initiate
-        time.sleep(10)
-
+        time.sleep(10)  # let reboot initiate before we start polling
         start_time = time.time()
 
-        # Wait for instance to be running with status checks passing
         while True:
             elapsed = time.time() - start_time
             if elapsed > timeout_seconds:
@@ -358,45 +363,65 @@ class SSMExecutor:
                     f"Instance {instance_id} did not come back online after reboot within {timeout_seconds}s"
                 )
 
-            try:
-                response = self._ec2_client.describe_instance_status(
-                    InstanceIds=[instance_id],
-                    IncludeAllInstances=True,
-                )
-                statuses = response.get("InstanceStatuses", [])
-
-                if statuses:
-                    instance_status = statuses[0]
-                    state = instance_status.get("InstanceState", {}).get("Name", "")
-
-                    if state == "terminated":
-                        raise InstanceTerminatedError(f"Instance {instance_id} was terminated during reboot")
-
-                    if state == "running":
-                        # Check status checks
-                        instance_check = instance_status.get("InstanceStatus", {}).get("Status", "")
-                        system_check = instance_status.get("SystemStatus", {}).get("Status", "")
-
-                        if instance_check == "ok" and system_check == "ok":
-                            # Now wait for SSM agent ping status
-                            remaining_time = timeout_seconds - elapsed
-                            if remaining_time > 0:
-                                self.wait_for_agent(
-                                    instance_id,
-                                    timeout_seconds=int(remaining_time),
-                                )
-                                # Verify agent can actually execute commands
-                                # (PingStatus=Online doesn't mean document worker is ready)
-                                remaining_time = timeout_seconds - (time.time() - start_time)
-                                if remaining_time > 0:
-                                    return self.verify_agent_ready(
-                                        instance_id,
-                                        timeout_seconds=min(60, int(remaining_time)),
-                                        max_attempts=6,
-                                        document_name=document_name,
-                                    )
-                                return True  # No time left for probe, hope for the best
-            except ClientError:
-                pass  # Instance might be transitioning
+            finalized = self._maybe_finalize_reboot(instance_id, start_time, timeout_seconds, document_name)
+            if finalized is not None:
+                return finalized
 
             time.sleep(self._poll_interval)
+
+    def _maybe_finalize_reboot(
+        self,
+        instance_id: str,
+        start_time: float,
+        timeout_seconds: int,
+        document_name: str,
+    ) -> bool | None:
+        """One poll-iteration of `reboot_and_wait`.
+
+        Returns:
+            True/False if the reboot has reached a terminal outcome this
+            iteration (instance is up and SSM-ready, or proven ready in the
+            remaining time budget). None if the caller should continue polling.
+
+        Raises:
+            InstanceTerminatedError: if the instance was terminated mid-reboot.
+        """
+        try:
+            response = self._ec2_client.describe_instance_status(
+                InstanceIds=[instance_id],
+                IncludeAllInstances=True,
+            )
+        except ClientError:
+            return None  # Instance might be transitioning; retry.
+
+        statuses = response.get("InstanceStatuses", [])
+        if not statuses:
+            return None
+
+        instance_status = statuses[0]
+        state = instance_status.get("InstanceState", {}).get("Name", "")
+        if state == "terminated":
+            raise InstanceTerminatedError(f"Instance {instance_id} was terminated during reboot")
+        if state != "running":
+            return None
+
+        instance_check = instance_status.get("InstanceStatus", {}).get("Status", "")
+        system_check = instance_status.get("SystemStatus", {}).get("Status", "")
+        if instance_check != "ok" or system_check != "ok":
+            return None
+
+        remaining_time = timeout_seconds - (time.time() - start_time)
+        if remaining_time <= 0:
+            return True  # No time left for probe; declare ready optimistically.
+
+        # PingStatus=Online doesn't mean document worker is ready; do both.
+        self.wait_for_agent(instance_id, timeout_seconds=int(remaining_time))
+        remaining_time = timeout_seconds - (time.time() - start_time)
+        if remaining_time <= 0:
+            return True
+        return self.verify_agent_ready(
+            instance_id,
+            timeout_seconds=min(60, int(remaining_time)),
+            max_attempts=6,
+            document_name=document_name,
+        )

--- a/shifter/engine/provisioner/main.py
+++ b/shifter/engine/provisioner/main.py
@@ -285,6 +285,23 @@ def update_range_status(range_id: int, status: str, **kwargs: str | int | None) 
         conn.commit()
 
 
+def _assert_subnet_output(subnet_name: str, subnet_data: dict) -> None:
+    """Reject a Pulumi subnet record missing any required field."""
+    for field in ("uuid", "subnet_id", "subnet_cidr"):
+        if not subnet_data.get(field):
+            raise ValueError(f"Subnet '{subnet_name}' missing '{field}'")
+
+
+def _assert_instance_output(index: int, inst: dict) -> None:
+    """Reject a Pulumi instance record missing any required field."""
+    if not inst.get("uuid"):
+        raise ValueError(f"Instance[{index}] (role={inst.get('role')}) missing 'uuid'")
+    if not inst.get("instance_id"):
+        raise ValueError(f"Instance[{index}] missing 'instance_id'")
+    if not inst.get("private_ip"):
+        raise ValueError(f"Instance[{index}] (role={inst.get('role')}, os={inst.get('os')}) missing 'private_ip'")
+
+
 def _validate_provisioned_outputs(
     subnets: dict[str, dict],
     instances: list[dict],
@@ -300,41 +317,16 @@ def _validate_provisioned_outputs(
     Raises:
         ValueError: If required fields are missing or empty.
     """
-    # Validate subnet data
     for subnet_name, subnet_data in subnets.items():
-        subnet_uuid = subnet_data.get("uuid")
-        if not subnet_uuid:
-            raise ValueError(f"Subnet '{subnet_name}' missing required 'uuid'")
-
-        subnet_id = subnet_data.get("subnet_id")
-        if not subnet_id:
-            raise ValueError(f"Subnet '{subnet_name}' missing 'subnet_id'")
-
-        subnet_cidr = subnet_data.get("subnet_cidr")
-        if not subnet_cidr:
-            raise ValueError(f"Subnet '{subnet_name}' missing 'subnet_cidr'")
-
-    # Validate instance data
+        _assert_subnet_output(subnet_name, subnet_data)
     for i, inst in enumerate(instances):
-        instance_uuid = inst.get("uuid")
-        if not instance_uuid:
-            raise ValueError(f"Instance[{i}] (role={inst.get('role')}) missing 'uuid'")
+        _assert_instance_output(i, inst)
 
-        instance_id = inst.get("instance_id")
-        if not instance_id:
-            raise ValueError(f"Instance[{i}] missing 'instance_id'")
-
-        private_ip = inst.get("private_ip")
-        if not private_ip:
-            raise ValueError(f"Instance[{i}] (role={inst.get('role')}, os={inst.get('os')}) missing 'private_ip'")
-
-    # Validate expected subnets were created
     if expected_subnet_names:
         actual_subnets = set(subnets.keys())
         missing = expected_subnet_names - actual_subnets
         if missing:
             raise ValueError(f"Expected subnets not created: {missing}")
-
         extra = actual_subnets - expected_subnet_names
         if extra:
             logger.warning("Unexpected subnets in output: %s", extra)
@@ -2940,6 +2932,72 @@ def _install_dc_xdr(
     logger.info("No XDR agent URL provided for DC (not required)")
 
 
+def _remove_ngfw_attachments_for_destroy(user_id: int, range_id: int, range_spec: dict) -> None:
+    """Best-effort detach of NGFW subnets / range attachment before terraform destroy.
+
+    Failures are logged and swallowed; terraform destroy runs regardless.
+    """
+    spec_subnets = range_spec.get("subnets", [])
+    if not spec_subnets:
+        return
+    try:
+        ngfw_data = get_user_ngfw_data(user_id) if range_spec.get("ngfw", False) else None
+        remove_ngfw_subnets(user_id, spec_subnets, range_id)
+        if ngfw_data:
+            _remove_ngfw_range_attachment(
+                ngfw_request_id=ngfw_data["ngfw_request_id"],
+                ngfw_status=ngfw_data["status"],
+                range_id=range_id,
+            )
+    except Exception as e:
+        logger.warning("NGFW subnet removal failed (continuing): %s", e)
+
+
+def _recover_missing_subnet_cidrs(range_id: int, range_spec: dict) -> None:
+    """If range_spec lost its subnet CIDRs, repopulate from the allocation table."""
+    spec_subnets = range_spec.get("subnets", [])
+    if not spec_subnets or spec_subnets[0].get("cidr"):
+        return
+    logger.warning("range_config missing CIDRs for range %d, recovering from allocation table", range_id)
+    from components.network import get_allocated_cidrs
+
+    allocated = get_allocated_cidrs(range_id)
+    for i, subnet in enumerate(spec_subnets):
+        if i < len(allocated):
+            subnet["cidr"] = allocated[i]
+
+
+def _post_destroy_cleanup(request_id: str, range_id: int, user_id: int) -> None:
+    """Mark range destroyed, release subnet allocations, optionally pause NGFW.
+
+    Called only if terraform destroy succeeded. All steps are best-effort.
+    """
+    try:
+        mark_range_instances_destroyed(range_id)
+    except Exception as e:
+        logger.error("Failed to mark range %d as destroyed: %s", range_id, e)
+
+    try:
+        from components.network import release_subnet_allocations
+
+        release_subnet_allocations(request_id)
+    except Exception as e:
+        logger.warning("Failed to release subnet allocations: %s", e)
+
+
+def _maybe_pause_user_ngfw(user_id: int, range_id: int) -> None:
+    """If this range was the user's last active range, pause their AWS NGFW."""
+    try:
+        if user_has_active_ranges(user_id, range_id):
+            return
+        ngfw_data = get_user_ngfw_data(user_id)
+        if ngfw_data and ngfw_data["status"] == "ready" and ngfw_data.get("cloud_provider") == "aws":
+            logger.info("No other active ranges, pausing NGFW")
+            run_ngfw_operation("stop", ngfw_data["ngfw_request_id"])
+    except Exception as e:
+        logger.warning("Failed to pause NGFW (non-fatal): %s", e)
+
+
 def _run_terraform_destroy(
     request_id: str,
     range_id: int,
@@ -2947,78 +3005,31 @@ def _run_terraform_destroy(
     range_spec: dict,
 ) -> None:
     """Run Terraform destroy for range."""
-    # Pre-destroy validation
     try:
         range_data = get_range_data_by_request_id(request_id)
     except ValueError as e:
         logger.warning("Range not found for request %s, skipping destroy: %s", request_id, e)
         return
 
-    current_status = range_data.get("status")
-    if current_status == "destroyed":
+    if range_data.get("status") == "destroyed":
         logger.info("Range %d already destroyed, skipping", range_id)
         return
 
-    # Remove NGFW subnet config
-    spec_subnets = range_spec.get("subnets", [])
-    if spec_subnets:
-        try:
-            ngfw_data = get_user_ngfw_data(user_id) if range_spec.get("ngfw", False) else None
-            remove_ngfw_subnets(user_id, spec_subnets, range_id)
-            if ngfw_data:
-                _remove_ngfw_range_attachment(
-                    ngfw_request_id=ngfw_data["ngfw_request_id"],
-                    ngfw_status=ngfw_data["status"],
-                    range_id=range_id,
-                )
-        except Exception as e:
-            logger.warning("NGFW subnet removal failed (continuing): %s", e)
-
-    # Recover CIDRs from subnet allocations if missing from range_config
-    if spec_subnets and not spec_subnets[0].get("cidr"):
-        logger.warning("range_config missing CIDRs for range %d, recovering from allocation table", range_id)
-        from components.network import get_allocated_cidrs
-
-        allocated = get_allocated_cidrs(range_id)
-        for i, subnet in enumerate(spec_subnets):
-            if i < len(allocated):
-                subnet["cidr"] = allocated[i]
+    _remove_ngfw_attachments_for_destroy(user_id, range_id, range_spec)
+    _recover_missing_subnet_cidrs(range_id, range_spec)
 
     logger.info("Running terraform destroy for range...")
-
     terraform_succeeded = False
     try:
         tf_variables = _build_range_terraform_variables(request_id, range_id, user_id, range_spec)
         range_terraform_runner.destroy_range(request_id, variables=tf_variables)
         terraform_succeeded = True
-
         logger.info("Cleaning up Terraform state...")
         range_terraform_runner.cleanup_range_state(request_id)
-
     finally:
         if terraform_succeeded:
-            try:
-                mark_range_instances_destroyed(range_id)
-            except Exception as e:
-                logger.error("Failed to mark range %d as destroyed: %s", range_id, e)
-
-            # Release subnet allocations now that AWS subnets are gone (best-effort)
-            try:
-                from components.network import release_subnet_allocations
-
-                release_subnet_allocations(request_id)
-            except Exception as e:
-                logger.warning("Failed to release subnet allocations: %s", e)
-
-        # Auto-pause NGFW if no other active ranges
-        try:
-            if not user_has_active_ranges(user_id, range_id):
-                ngfw_data = get_user_ngfw_data(user_id)
-                if ngfw_data and ngfw_data["status"] == "ready" and ngfw_data.get("cloud_provider") == "aws":
-                    logger.info("No other active ranges, pausing NGFW")
-                    run_ngfw_operation("stop", ngfw_data["ngfw_request_id"])
-        except Exception as e:
-            logger.warning("Failed to pause NGFW (non-fatal): %s", e)
+            _post_destroy_cleanup(request_id, range_id, user_id)
+        _maybe_pause_user_ngfw(user_id, range_id)
 
     publish_destroyed(request_id=request_id, range_id=range_id, user_id=user_id)
 

--- a/shifter/engine/provisioner/ngfw_terraform.py
+++ b/shifter/engine/provisioner/ngfw_terraform.py
@@ -246,6 +246,65 @@ def _cleanup_ngfw_bootstrap_objects(instance_id: str) -> None:
         raise RuntimeError(f"Failed to delete NGFW bootstrap object(s): {', '.join(failed_keys)}") from failures[-1][1]
 
 
+def _build_ngfw_ssh_executor_from_output(output_data: dict[str, Any]) -> tuple[str, "NGFWExecutor"]:
+    """Resolve `management_ip` + load the SSH key from Secrets Manager.
+
+    Returns:
+        (management_ip, NGFWExecutor) ready to talk to the device.
+
+    Raises:
+        RuntimeError: if either output field is missing or the secret fetch fails.
+    """
+    management_ip = output_data.get("management_ip")
+    ssh_key_secret_arn = output_data.get("ssh_key_secret_arn")
+    if not ssh_key_secret_arn:
+        raise RuntimeError("NGFW provisioning output missing ssh_key_secret_arn")
+    if not management_ip:
+        raise RuntimeError("NGFW provisioning output missing management_ip")
+
+    from cloud import get_secrets_store
+
+    try:
+        private_key = get_secrets_store().get_secret(ssh_key_secret_arn)
+    except Exception as e:
+        raise RuntimeError(f"Failed to retrieve SSH key from Secrets Manager: {e}") from e
+
+    return management_ip, NGFWExecutor(private_key=private_key)
+
+
+def _short_circuit_local_dev_post_provision(
+    *,
+    request_id: str,
+    instance_id: str,
+    app_id: str,
+    output_data: dict[str, Any],
+    update_instance_state,
+) -> None:
+    """Mark a local-dev NGFW as ready-then-paused without touching the device.
+
+    Local dev mode (presence of `DB_PASSWORD` in the env) bypasses the live
+    PAN-OS SSH bring-up because it isn't reachable. We still emit the ready
+    and paused state transitions so the platform UI reflects the expected
+    lifecycle.
+    """
+    logger.info("LOCAL DEV MODE: Skipping post-infrastructure NGFW configuration")
+    update_instance_state(request_id, STATUS_READY, **output_data, **_build_provider_state(output_data))
+    publish_ngfw_event(
+        request_id=request_id,
+        instance_id=instance_id,
+        app_id=app_id,
+        status=STATUS_READY,
+    )
+    logger.info("LOCAL DEV MODE: Setting NGFW status to paused")
+    update_instance_state(request_id, "paused")
+    publish_ngfw_event(
+        request_id=request_id,
+        instance_id=instance_id,
+        app_id=app_id,
+        status="paused",
+    )
+
+
 def _run_pan_os_post_provision(
     *,
     request_id: str,
@@ -261,43 +320,19 @@ def _run_pan_os_post_provision(
         update_instance_state,
     )
 
-    # Skip post-infrastructure config in local dev mode.
     if os.environ.get("DB_PASSWORD"):
-        logger.info("LOCAL DEV MODE: Skipping post-infrastructure NGFW configuration")
-        update_instance_state(request_id, STATUS_READY, **output_data, **_build_provider_state(output_data))
-        publish_ngfw_event(
+        _short_circuit_local_dev_post_provision(
             request_id=request_id,
             instance_id=instance_id,
             app_id=app_id,
-            status=STATUS_READY,
-        )
-        logger.info("LOCAL DEV MODE: Setting NGFW status to paused")
-        update_instance_state(request_id, "paused")
-        publish_ngfw_event(
-            request_id=request_id,
-            instance_id=instance_id,
-            app_id=app_id,
-            status="paused",
+            output_data=output_data,
+            update_instance_state=update_instance_state,
         )
         return
 
     logger.info("Running post-infrastructure NGFW configuration...")
 
-    management_ip = output_data.get("management_ip")
-    ssh_key_secret_arn = output_data.get("ssh_key_secret_arn")
-    if not ssh_key_secret_arn:
-        raise RuntimeError("NGFW provisioning output missing ssh_key_secret_arn")
-    if not management_ip:
-        raise RuntimeError("NGFW provisioning output missing management_ip")
-
-    from cloud import get_secrets_store
-
-    try:
-        private_key = get_secrets_store().get_secret(ssh_key_secret_arn)
-    except Exception as e:
-        raise RuntimeError(f"Failed to retrieve SSH key from Secrets Manager: {e}") from e
-
-    ssh_executor = NGFWExecutor(private_key=private_key)
+    management_ip, ssh_executor = _build_ngfw_ssh_executor_from_output(output_data)
 
     # Wait for SSH availability (VM-Series can take 15-25 min to boot).
     ssh_timeout = int(os.environ.get("NGFW_SSH_WAIT_TIMEOUT", NGFW_SSH_WAIT_TIMEOUT_DEFAULT))

--- a/shifter/engine/provisioner/range_ops.py
+++ b/shifter/engine/provisioner/range_ops.py
@@ -369,6 +369,74 @@ def pause_ngfw_for_range(request_id: str, range_data: dict) -> None:
     )
 
 
+def _wait_for_ngfw_pause_to_complete(ngfw_info: dict) -> None:
+    """If the NGFW is mid-`pausing`, block until EC2 reports stopped before resuming."""
+    logger.info("ensure_ngfw_running: NGFW is pausing, waiting for paused...")
+    executor = AWSExecutor()
+    wait_result = executor.wait_for_stopped(ngfw_info["ec2_instance_id"])
+    if not wait_result.success:
+        raise RuntimeError(f"NGFW failed to reach paused state: {wait_result.stderr}")
+    logger.info("ensure_ngfw_running: NGFW is now paused, proceeding to resume")
+
+
+def _publish_ngfw_status(ngfw_info: dict, status: str) -> None:
+    """Persist `status` and emit the matching event for an NGFW lifecycle transition."""
+    _update_ngfw_status(ngfw_info["ngfw_instance_id"], status)
+    publish_ngfw_event(
+        request_id=ngfw_info["ngfw_request_id"],
+        instance_id=ngfw_info["instance_uuid"],
+        app_id=ngfw_info["app_id"],
+        status=status,
+    )
+
+
+def _run_ngfw_start_with_retry(ngfw_info: dict, request_id: str) -> None:
+    """Run NGFWStartPlan with bounded retries; raise RuntimeError on permanent failure.
+
+    Returns early without raising if a parallel resume marks the NGFW ready
+    between attempts.
+    """
+    executor = AWSExecutor()
+    orchestrator = OpsOrchestrator(executor)
+    plan = NGFWStartPlan()
+
+    class _InstanceRef:
+        def __init__(self, instance_id: str):
+            self.instance_id = instance_id
+
+    context = plan.get_context(_InstanceRef(ngfw_info["ec2_instance_id"]))
+
+    for attempt in range(NGFW_START_MAX_RETRIES):
+        result = orchestrator.orchestrate(ngfw_info["ec2_instance_id"], plan, context)
+        if result.success:
+            return
+
+        if attempt == NGFW_START_MAX_RETRIES - 1:
+            error_msg = result.error or "NGFW start failed"
+            logger.error("ensure_ngfw_running: %s", error_msg)
+            _publish_ngfw_status(ngfw_info, "failed")
+            raise RuntimeError(error_msg)
+
+        delay = NGFW_START_RETRY_DELAYS[attempt]
+        logger.warning(
+            "ensure_ngfw_running: attempt %d/%d failed, retrying in %ds request_id=%s error=%s",
+            attempt + 1,
+            NGFW_START_MAX_RETRIES,
+            delay,
+            request_id,
+            result.error,
+        )
+        time.sleep(delay)
+
+        refreshed = get_range_ngfw_info(request_id)
+        if refreshed and refreshed["status"] == "ready":
+            logger.info(
+                "ensure_ngfw_running: NGFW became ready during retry wait, request_id=%s",
+                request_id,
+            )
+            return
+
+
 def ensure_ngfw_running(request_id: str) -> None:
     """Ensure NGFW is running before resuming range instances.
 
@@ -385,119 +453,33 @@ def ensure_ngfw_running(request_id: str) -> None:
     """
     logger.info("ensure_ngfw_running: starting request_id=%s", request_id)
 
-    # Get NGFW info
     ngfw_info = get_range_ngfw_info(request_id)
     if not ngfw_info:
         logger.info("ensure_ngfw_running: no NGFW attached, skipping")
         return
 
     status = ngfw_info["status"]
-
-    # Already running
     if status == "ready":
         logger.info("ensure_ngfw_running: NGFW already ready, skipping")
         return
-
-    # Failed state - cannot proceed
     if status == "failed":
         raise RuntimeError("NGFW is in failed state, cannot resume range")
-
-    # Resuming - wait for it (another resume may have triggered it)
     if status == "resuming":
         logger.info("ensure_ngfw_running: NGFW is resuming, waiting...")
-        # For now, proceed with the start operation which will wait
-        # The AWSExecutor.wait_for_running will handle this
-
-    # If pausing, wait for EC2 stop to complete before resuming
+        # Fall through; AWSExecutor.wait_for_running will block.
     if status == "pausing":
-        logger.info("ensure_ngfw_running: NGFW is pausing, waiting for paused...")
-        executor = AWSExecutor()
-        wait_result = executor.wait_for_stopped(ngfw_info["ec2_instance_id"])
-        if not wait_result.success:
-            raise RuntimeError(f"NGFW failed to reach paused state: {wait_result.stderr}")
-        logger.info("ensure_ngfw_running: NGFW is now paused, proceeding to resume")
+        _wait_for_ngfw_pause_to_complete(ngfw_info)
+    if status not in ("paused", "pausing", "resuming"):
+        return
 
-    # Paused or pausing - need to resume
-    if status in ("paused", "pausing", "resuming"):
-        # Update status to resuming
-        _update_ngfw_status(ngfw_info["ngfw_instance_id"], "resuming")
-
-        # Publish event
-        publish_ngfw_event(
-            request_id=ngfw_info["ngfw_request_id"],
-            instance_id=ngfw_info["instance_uuid"],
-            app_id=ngfw_info["app_id"],
-            status="resuming",
-        )
-
-        # Execute start plan with retry
-        executor = AWSExecutor()
-        orchestrator = OpsOrchestrator(executor)
-        plan = NGFWStartPlan()
-
-        # Create a simple object with instance_id attribute for get_context
-        class InstanceRef:
-            def __init__(self, instance_id: str):
-                self.instance_id = instance_id
-
-        context = plan.get_context(InstanceRef(ngfw_info["ec2_instance_id"]))
-
-        for attempt in range(NGFW_START_MAX_RETRIES):
-            result = orchestrator.orchestrate(ngfw_info["ec2_instance_id"], plan, context)
-
-            if result.success:
-                break
-
-            # Last attempt - fail permanently
-            if attempt == NGFW_START_MAX_RETRIES - 1:
-                error_msg = result.error or "NGFW start failed"
-                logger.error("ensure_ngfw_running: %s", error_msg)
-                _update_ngfw_status(ngfw_info["ngfw_instance_id"], "failed")
-                publish_ngfw_event(
-                    request_id=ngfw_info["ngfw_request_id"],
-                    instance_id=ngfw_info["instance_uuid"],
-                    app_id=ngfw_info["app_id"],
-                    status="failed",
-                )
-                raise RuntimeError(error_msg)
-
-            # Not the last attempt - log, sleep, re-query status, and retry
-            delay = NGFW_START_RETRY_DELAYS[attempt]
-            logger.warning(
-                "ensure_ngfw_running: attempt %d/%d failed, retrying in %ds request_id=%s error=%s",
-                attempt + 1,
-                NGFW_START_MAX_RETRIES,
-                delay,
-                request_id,
-                result.error,
-            )
-            time.sleep(delay)
-
-            # Re-query NGFW status before retrying
-            refreshed = get_range_ngfw_info(request_id)
-            if refreshed and refreshed["status"] == "ready":
-                logger.info(
-                    "ensure_ngfw_running: NGFW became ready during retry wait, request_id=%s",
-                    request_id,
-                )
-                return
-
-        # Update status to ready
-        _update_ngfw_status(ngfw_info["ngfw_instance_id"], "ready")
-
-        # Publish success event
-        publish_ngfw_event(
-            request_id=ngfw_info["ngfw_request_id"],
-            instance_id=ngfw_info["instance_uuid"],
-            app_id=ngfw_info["app_id"],
-            status="ready",
-        )
-
-        logger.info(
-            "ensure_ngfw_running: NGFW resumed ec2=%s request_id=%s",
-            ngfw_info["ec2_instance_id"],
-            request_id,
-        )
+    _publish_ngfw_status(ngfw_info, "resuming")
+    _run_ngfw_start_with_retry(ngfw_info, request_id)
+    _publish_ngfw_status(ngfw_info, "ready")
+    logger.info(
+        "ensure_ngfw_running: NGFW resumed ec2=%s request_id=%s",
+        ngfw_info["ec2_instance_id"],
+        request_id,
+    )
 
 
 def _execute_instance_operation(

--- a/shifter/installation/schema.py
+++ b/shifter/installation/schema.py
@@ -54,7 +54,8 @@ def _validate_deployment_name(value: str) -> str:
     return value
 
 
-def _validate_domain(value: str) -> str:
+def _assert_domain_surface(value: str) -> None:
+    """Reject whole-string formatting problems: empty/whitespace/case/trailing-dot/IP."""
     if not value or value != value.strip():
         raise ValueError("must be a non-empty hostname with no surrounding whitespace")
     if value != value.lower():
@@ -64,10 +65,12 @@ def _validate_domain(value: str) -> str:
     try:
         ipaddress.ip_address(value)
     except ValueError:
-        pass
-    else:
-        raise ValueError("must be a DNS hostname, not an IP address")
-    labels = value.split(".")
+        return
+    raise ValueError("must be a DNS hostname, not an IP address")
+
+
+def _assert_domain_labels(value: str, labels: list[str]) -> None:
+    """Reject label-shape problems: too few labels, oversize total, malformed labels, invalid TLD."""
     if len(labels) < 2:
         raise ValueError("must be a fully qualified hostname with at least two labels (e.g. shifter.example.com)")
     if len(value) > _MAX_DOMAIN_LEN:
@@ -84,6 +87,11 @@ def _validate_domain(value: str) -> str:
             f"the rightmost label {tld!r} is not a valid public DNS suffix; the hostname must end in a "
             "registry-style TLD (e.g. shifter.example.com)"
         )
+
+
+def _validate_domain(value: str) -> str:
+    _assert_domain_surface(value)
+    _assert_domain_labels(value, value.split("."))
     return value
 
 

--- a/shifter/shifter_platform/cms/experiments/services.py
+++ b/shifter/shifter_platform/cms/experiments/services.py
@@ -157,6 +157,43 @@ def initiate_script_upload(user: User, name: str, filename: str, file_size: int)
         raise
 
 
+def _inspect_uploaded_script_body(user: User, s3_key: str, max_size: int) -> None:
+    """Read the full S3 object and reject if it isn't valid UTF-8 / has a binary signature.
+
+    Scripts are capped at 1 MB, so we inspect the entire body, not just a header,
+    which blocks the "valid text prefix + binary tail" bypass. Cleans up the
+    rejected object on failure (best-effort).
+    """
+    try:
+        body = read_script_header(s3_key, max_size)
+    except S3Error as e:
+        logger.exception(
+            "complete_script_upload: body read failed s3_key=%s: %s",
+            safe_log(s3_key),
+            safe_log(str(e)),
+        )
+        raise ScriptUploadError("Upload content inspection failed") from e
+
+    try:
+        _validate_script_text_header(body, complete=True)
+    except _ScriptInspectionError as e:
+        logger.warning(
+            "complete_script_upload: header inspection rejected upload user_id=%s s3_key=%s reason=%s",
+            user.pk,
+            safe_log(s3_key),
+            e,
+        )
+        try:
+            delete_s3_object(s3_key)
+        except S3Error as delete_exc:
+            logger.exception(
+                "complete_script_upload: delete after inspection failure also failed s3_key=%s: %s",
+                safe_log(s3_key),
+                safe_log(str(delete_exc)),
+            )
+        raise ScriptUploadError("Uploaded content is not a valid script (binary or non-UTF-8 header)") from e
+
+
 def complete_script_upload(user: User, upload_token: str) -> ScriptAsset:
     """Finalize script upload: verify token, verify S3 object, create DB record.
 
@@ -218,34 +255,7 @@ def complete_script_upload(user: User, upload_token: str) -> ScriptAsset:
         # require it to be valid UTF-8 with no binary signature anywhere in
         # the stream. This blocks the "valid text prefix + binary tail" bypass
         # the bounded-header check by itself cannot detect.
-        try:
-            body = read_script_header(s3_key, max_size)
-        except S3Error as e:
-            logger.exception(
-                "complete_script_upload: body read failed s3_key=%s: %s",
-                safe_log(s3_key),
-                safe_log(str(e)),
-            )
-            raise ScriptUploadError("Upload content inspection failed") from e
-
-        try:
-            _validate_script_text_header(body, complete=True)
-        except _ScriptInspectionError as e:
-            logger.warning(
-                "complete_script_upload: header inspection rejected upload user_id=%s s3_key=%s reason=%s",
-                user.pk,
-                safe_log(s3_key),
-                e,
-            )
-            try:
-                delete_s3_object(s3_key)
-            except S3Error as delete_exc:
-                logger.exception(
-                    "complete_script_upload: delete after inspection failure also failed s3_key=%s: %s",
-                    safe_log(s3_key),
-                    safe_log(str(delete_exc)),
-                )
-            raise ScriptUploadError("Uploaded content is not a valid script (binary or non-UTF-8 header)") from e
+        _inspect_uploaded_script_body(user, s3_key, max_size)
 
         script = ScriptAsset(
             user=user,
@@ -387,6 +397,47 @@ def get_experiment(user: User, experiment_id: int) -> Experiment:
         raise
 
 
+def _resolve_experiment_scenario(scenario_id, user):
+    """Verify access and load the scenario template; raise ExperimentValidationError on either failure."""
+    try:
+        check_scenario_access(scenario_id, user)
+        return load_scenario_template(scenario_id)
+    except ValueError as e:
+        logger.warning("create_experiment: invalid scenario_id=%s: %s", scenario_id, e)
+        raise ExperimentValidationError(f"Invalid scenario: {e}") from e
+
+
+def _validate_script_assignments(scripts, scenario, user, scenario_id):
+    """Reject assignments that don't match an existing instance or aren't owned scripts."""
+    instance_names = {inst.name for inst in scenario.instances}
+    for script_input in scripts:
+        if script_input.instance_name not in instance_names:
+            raise ExperimentValidationError(
+                f"Instance '{script_input.instance_name}' not found in scenario '{scenario_id}'"
+            )
+    script_ids = [s.script_id for s in scripts if s.script_id]
+    if not script_ids:
+        return
+    existing_scripts = set(ScriptAsset.objects.filter(pk__in=script_ids, user=user).values_list("pk", flat=True))
+    missing = set(script_ids) - existing_scripts
+    if missing:
+        raise ExperimentValidationError(f"Script(s) not found: {missing}")
+
+
+def _resolve_experiment_agent(agent_id, user):
+    """Return the user's agent or None; raise ExperimentValidationError if the id is unknown."""
+    if not agent_id:
+        return None
+    from cms.models import AgentConfig
+
+    try:
+        agent = AgentConfig.objects.get(pk=agent_id, user=user)
+    except AgentConfig.DoesNotExist:
+        raise ExperimentValidationError(f"Agent not found: {agent_id}") from None
+    _check_result_type(agent, AgentConfig, "create_experiment")
+    return agent
+
+
 def create_experiment(user: User, data: ExperimentCreateInput) -> Experiment:
     """Create an experiment with script assignments.
 
@@ -403,45 +454,9 @@ def create_experiment(user: User, data: ExperimentCreateInput) -> Experiment:
     _validate_user(user, "create_experiment")
     logger.debug("create_experiment called for user_id=%s scenario=%s", user.id, data.scenario_id)
     try:
-        # Validate scenario exists and user has access
-        try:
-            check_scenario_access(data.scenario_id, user)
-            scenario = load_scenario_template(data.scenario_id)
-        except ValueError as e:
-            logger.warning("create_experiment: invalid scenario_id=%s: %s", data.scenario_id, e)
-            raise ExperimentValidationError(f"Invalid scenario: {e}") from e
-
-        # Validate script assignments reference real instances
-        instance_names = {inst.name for inst in scenario.instances}
-        for script_input in data.scripts:
-            if script_input.instance_name not in instance_names:
-                raise ExperimentValidationError(
-                    f"Instance '{script_input.instance_name}' not found in scenario '{data.scenario_id}'"
-                )
-
-        # Validate referenced script assets exist and belong to user
-        script_ids = [s.script_id for s in data.scripts if s.script_id]
-        if script_ids:
-            existing_scripts = set(
-                ScriptAsset.objects.filter(
-                    pk__in=script_ids,
-                    user=user,
-                ).values_list("pk", flat=True)
-            )
-            missing = set(script_ids) - existing_scripts
-            if missing:
-                raise ExperimentValidationError(f"Script(s) not found: {missing}")
-
-        # Validate agent exists if specified
-        agent = None
-        if data.agent_id:
-            from cms.models import AgentConfig
-
-            try:
-                agent = AgentConfig.objects.get(pk=data.agent_id, user=user)
-            except AgentConfig.DoesNotExist:
-                raise ExperimentValidationError(f"Agent not found: {data.agent_id}") from None
-            _check_result_type(agent, AgentConfig, "create_experiment")
+        scenario = _resolve_experiment_scenario(data.scenario_id, user)
+        _validate_script_assignments(data.scripts, scenario, user, data.scenario_id)
+        agent = _resolve_experiment_agent(data.agent_id, user)
 
         with transaction.atomic():
             experiment = Experiment(

--- a/shifter/shifter_platform/cms/handlers/range_events.py
+++ b/shifter/shifter_platform/cms/handlers/range_events.py
@@ -14,6 +14,28 @@ from shared.messages.events import EVENT_TYPE_STATUS_UPDATED
 logger = logging.getLogger(__name__)
 
 
+def _lookup_range_instance(request_id, range_id):
+    """Resolve a `RangeInstance` from request_id (new pattern) or range_id (legacy).
+
+    Returns the instance or None; the caller is responsible for short-circuiting
+    when this returns None (it has already logged the reason).
+    """
+    if request_id:
+        try:
+            return RangeInstance.objects.get(request__request_id=request_id)
+        except RangeInstance.DoesNotExist:
+            logger.warning("RangeInstance not found: request_id=%s", request_id)
+            return None
+    if range_id is not None:
+        try:
+            return RangeInstance.objects.get(range_id=range_id)
+        except RangeInstance.DoesNotExist:
+            logger.warning("RangeInstance not found: range_id=%s", range_id)
+            return None
+    logger.warning("Missing both request_id and range_id in event")
+    return None
+
+
 def process_range_event(message: str | dict) -> None:
     """Process range event from SNS/SQS - updates RangeInstance.status.
 
@@ -57,22 +79,8 @@ def process_range_event(message: str | dict) -> None:
         logger.error("Invalid status value: %s (range_id=%s)", new_status, range_id)
         return
 
-    # Look up RangeInstance - prefer request_id (new pattern), fall back to range_id (legacy)
-    instance = None
-    try:
-        if request_id:
-            instance = RangeInstance.objects.get(request__request_id=request_id)
-        elif range_id is not None:
-            instance = RangeInstance.objects.get(range_id=range_id)
-        else:
-            logger.warning("Missing both request_id and range_id in event")
-            return
-    except RangeInstance.DoesNotExist:
-        logger.warning(
-            "RangeInstance not found: request_id=%s range_id=%s",
-            request_id,
-            range_id,
-        )
+    instance = _lookup_range_instance(request_id, range_id)
+    if instance is None:
         return
 
     if instance.user_id != user_id:

--- a/shifter/shifter_platform/cms/scenario_editor/views.py
+++ b/shifter/shifter_platform/cms/scenario_editor/views.py
@@ -109,6 +109,58 @@ def scenario_detail_view(request, scenario_id):
 # =============================================================================
 
 
+def _parse_scenario_form_post(request, *, require_id: bool) -> tuple[dict, list[str]]:
+    """Extract scenario fields from a form POST; return (fields, errors).
+
+    `require_id` toggles the scenario-id field validation (creation needs it;
+    edit takes the id from the URL).
+    """
+    scenario_id = request.POST.get("scenario_id", "").strip()
+    name = request.POST.get("name", "").strip()
+    description = request.POST.get("description", "").strip()
+    ngfw = request.POST.get("ngfw") == "on"
+    instances_json = request.POST.get("instances_json", "[]")
+    subnets_json = request.POST.get("subnets_json", "[]")
+
+    errors: list[str] = []
+    if require_id:
+        if not scenario_id:
+            errors.append("Scenario ID is required")
+        elif not SLUG_RE.match(scenario_id):
+            errors.append("Scenario ID must contain only lowercase letters, numbers, hyphens, and underscores")
+    if not name:
+        errors.append("Name is required")
+    if not description:
+        errors.append("Description is required")
+
+    try:
+        instances = json.loads(instances_json)
+    except json.JSONDecodeError:
+        instances = []
+        errors.append("Invalid instances JSON")
+
+    try:
+        subnets = json.loads(subnets_json)
+    except json.JSONDecodeError:
+        subnets = []
+        errors.append("Invalid subnets JSON")
+
+    if not instances:
+        errors.append("At least one instance is required")
+
+    return (
+        {
+            "id": scenario_id,
+            "name": name,
+            "description": description,
+            "ngfw": ngfw,
+            "instances": instances,
+            "subnets": subnets,
+        },
+        errors,
+    )
+
+
 @threat_research_required
 @require_http_methods(["GET", "POST"])
 def scenario_create_form(request):
@@ -125,38 +177,13 @@ def scenario_create_form(request):
                 },
             )
 
-        # POST - handle form submission
-        scenario_id = request.POST.get("scenario_id", "").strip()
-        name = request.POST.get("name", "").strip()
-        description = request.POST.get("description", "").strip()
-        ngfw = request.POST.get("ngfw") == "on"
-        instances_json = request.POST.get("instances_json", "[]")
-        subnets_json = request.POST.get("subnets_json", "[]")
-
-        errors = []
-        if not scenario_id:
-            errors.append("Scenario ID is required")
-        elif not SLUG_RE.match(scenario_id):
-            errors.append("Scenario ID must contain only lowercase letters, numbers, hyphens, and underscores")
-        if not name:
-            errors.append("Name is required")
-        if not description:
-            errors.append("Description is required")
-
-        try:
-            instances = json.loads(instances_json)
-        except json.JSONDecodeError:
-            instances = []
-            errors.append("Invalid instances JSON")
-
-        try:
-            subnets = json.loads(subnets_json)
-        except json.JSONDecodeError:
-            subnets = []
-            errors.append("Invalid subnets JSON")
-
-        if not instances:
-            errors.append("At least one instance is required")
+        fields, errors = _parse_scenario_form_post(request, require_id=True)
+        scenario_id = fields["id"]
+        name = fields["name"]
+        description = fields["description"]
+        ngfw = fields["ngfw"]
+        instances = fields["instances"]
+        subnets = fields["subnets"]
 
         if errors:
             return render(
@@ -262,33 +289,12 @@ def scenario_edit_form(request, scenario_id):
                 },
             )
 
-        # POST - handle form submission
-        name = request.POST.get("name", "").strip()
-        description = request.POST.get("description", "").strip()
-        ngfw = request.POST.get("ngfw") == "on"
-        instances_json = request.POST.get("instances_json", "[]")
-        subnets_json = request.POST.get("subnets_json", "[]")
-
-        errors = []
-        if not name:
-            errors.append("Name is required")
-        if not description:
-            errors.append("Description is required")
-
-        try:
-            instances = json.loads(instances_json)
-        except json.JSONDecodeError:
-            instances = []
-            errors.append("Invalid instances JSON")
-
-        try:
-            subnets = json.loads(subnets_json)
-        except json.JSONDecodeError:
-            subnets = []
-            errors.append("Invalid subnets JSON")
-
-        if not instances:
-            errors.append("At least one instance is required")
+        fields, errors = _parse_scenario_form_post(request, require_id=False)
+        name = fields["name"]
+        description = fields["description"]
+        ngfw = fields["ngfw"]
+        instances = fields["instances"]
+        subnets = fields["subnets"]
 
         if errors:
             scenario.update(

--- a/shifter/shifter_platform/ctf/services/challenge.py
+++ b/shifter/shifter_platform/ctf/services/challenge.py
@@ -650,6 +650,49 @@ def create_challenge(event_id: UUID, challenge_data: dict[str, Any], *, actor_id
     return challenge
 
 
+def _build_safe_update_payload(data: dict[str, Any], challenge: CTFChallenge) -> dict[str, Any]:
+    """Resolve `next_challenge`, hash any new `flag`, then filter to allowed fields.
+
+    Mass-assignment safety: only `_CHALLENGE_MUTABLE_FIELDS` is allowed, plus
+    explicit pass-throughs for `flag_hash` and `next_challenge` (which are kept
+    out of the generic allowlist so JSON callers can't crash FK assignment).
+    """
+    if "next_challenge" in data:
+        data["next_challenge"] = _resolve_next_challenge(
+            data["next_challenge"],
+            event=challenge.event,
+            self_id=challenge.pk,
+        )
+    if "flag" in data:
+        plaintext_flag = data.pop("flag")
+        data["flag_hash"] = hash_flag(plaintext_flag)
+
+    safe_data = {k: v for k, v in data.items() if k in _CHALLENGE_MUTABLE_FIELDS}
+    if "flag_hash" in data:
+        safe_data["flag_hash"] = data["flag_hash"]
+    if "next_challenge" in data:
+        safe_data["next_challenge"] = data["next_challenge"]
+    return safe_data
+
+
+def _apply_optional_challenge_associations(
+    challenge: CTFChallenge,
+    flags_list,
+    tag_names,
+    topic_names,
+    actor_id: int,
+) -> None:
+    """Apply optional flag/tag/topic updates inside the existing transaction."""
+    if flags_list is not None:
+        challenge.flags.all().delete()
+        for i, fd in enumerate(flags_list):
+            add_flag(challenge.id, {**fd, "order": fd.get("order", i)}, actor_id=actor_id)
+    if tag_names is not None:
+        challenge.tags.set(_resolve_tags(challenge.event, tag_names))
+    if topic_names is not None:
+        challenge.topics.set(_resolve_topics(topic_names))
+
+
 def update_challenge(challenge_id: UUID, challenge_data: dict[str, Any], *, actor_id: int) -> CTFChallenge:
     """Update an existing challenge.
 
@@ -695,51 +738,13 @@ def update_challenge(challenge_id: UUID, challenge_data: dict[str, Any], *, acto
     tag_names = data.pop("tags", None)
     topic_names = data.pop("topics", None)
 
-    # Resolve next_challenge before allowlist filtering (codex cycle 6).
-    if "next_challenge" in data:
-        data["next_challenge"] = _resolve_next_challenge(
-            data["next_challenge"],
-            event=challenge.event,
-            self_id=challenge.pk,
-        )
-
-    # Hash new flag if provided
-    if "flag" in data:
-        plaintext_flag = data.pop("flag")
-        data["flag_hash"] = hash_flag(plaintext_flag)
-
-    # Filter to allowed fields only — prevent mass assignment of event,
-    # id, timestamps, etc.
-    safe_data = {k: v for k, v in data.items() if k in _CHALLENGE_MUTABLE_FIELDS}
-    if "flag_hash" in data:
-        safe_data["flag_hash"] = data["flag_hash"]
-    # next_challenge: same explicit pass-through as create_challenge — kept
-    # OUT of the generic allowlist so JSON callers can't crash FK
-    # assignment with a 500.
-    if "next_challenge" in data:
-        safe_data["next_challenge"] = data["next_challenge"]
+    safe_data = _build_safe_update_payload(data, challenge)
 
     with transaction.atomic():
         for key, value in safe_data.items():
             setattr(challenge, key, value)
         challenge.save()
-
-        # Replace flags if provided
-        if flags_list is not None:
-            challenge.flags.all().delete()
-            for i, fd in enumerate(flags_list):
-                add_flag(challenge.id, {**fd, "order": fd.get("order", i)}, actor_id=actor_id)
-
-        # Update tags if provided
-        if tag_names is not None:
-            tag_objects = _resolve_tags(challenge.event, tag_names)
-            challenge.tags.set(tag_objects)
-
-        # Update topics if provided
-        if topic_names is not None:
-            topic_objects = _resolve_topics(topic_names)
-            challenge.topics.set(topic_objects)
-
+        _apply_optional_challenge_associations(challenge, flags_list, tag_names, topic_names, actor_id)
         logger.info("Updated challenge %s", challenge_id)
 
     _sync_release_task(challenge)

--- a/shifter/shifter_platform/ctf/services/submission.py
+++ b/shifter/shifter_platform/ctf/services/submission.py
@@ -53,6 +53,80 @@ def _count_attempts_in_current_window(
     return count
 
 
+def _check_attempt_limit_or_raise(all_submissions, event, challenge, challenge_id) -> int:
+    """Enforce per-challenge max-attempts (timeout or lockout mode); return the count to record.
+
+    Returns the attempt count that the eventual `CTFSubmission` row should be
+    one-based against. Raises `CTFRateLimitError` if the participant is over
+    the cap. `challenge.max_attempts <= 0` disables the check.
+    """
+    total_attempt_count = all_submissions.count()
+    if not (challenge.max_attempts > 0 and event.attempt_limit_mode == "timeout"):
+        if challenge.max_attempts > 0 and total_attempt_count >= challenge.max_attempts:
+            raise CTFRateLimitError(
+                f"Maximum attempts ({challenge.max_attempts}) exceeded",
+                details={
+                    "challenge_id": str(challenge_id),
+                    "max_attempts": challenge.max_attempts,
+                    "attempts_used": total_attempt_count,
+                    "attempt_limit_mode": "lockout",
+                },
+            )
+        return total_attempt_count
+
+    # Timeout mode: count only submissions in the current window.
+    attempt_cooldown = event.attempt_limit_cooldown_seconds
+    attempt_count = _count_attempts_in_current_window(all_submissions, attempt_cooldown)
+    if attempt_count < challenge.max_attempts:
+        return attempt_count
+
+    last_submission_time = all_submissions.order_by("-submitted_at").values_list("submitted_at", flat=True).first()
+    if last_submission_time is None:
+        # Defensive: should be unreachable since attempt_count > 0
+        return 0
+    elapsed = (timezone.now() - last_submission_time).total_seconds()
+    retry_after = int(attempt_cooldown - elapsed) + 1
+    raise CTFRateLimitError(
+        f"Maximum attempts ({challenge.max_attempts}) reached. Try again in {retry_after} seconds.",
+        details={
+            "challenge_id": str(challenge_id),
+            "max_attempts": challenge.max_attempts,
+            "attempts_used": attempt_count,
+            "retry_after_seconds": retry_after,
+            "attempt_limit_mode": "timeout",
+        },
+    )
+
+
+def _check_submission_cooldown_or_raise(participant, challenge, challenge_id) -> None:
+    """Enforce the time-based submission cooldown; raise `CTFRateLimitError` if active."""
+    cooldown = participant.event.submission_cooldown_seconds
+    if cooldown <= 0:
+        return
+    last_submission_time = (
+        CTFSubmission.objects.filter(participant=participant, challenge=challenge)
+        .order_by("-submitted_at")
+        .values_list("submitted_at", flat=True)
+        .first()
+    )
+    if last_submission_time is None:
+        return
+    elapsed = (timezone.now() - last_submission_time).total_seconds()
+    if elapsed >= cooldown:
+        return
+    retry_after = int(cooldown - elapsed) + 1
+    retry_at = last_submission_time + timedelta(seconds=cooldown)
+    raise CTFRateLimitError(
+        f"Please wait {retry_after} seconds before submitting again (retry at {retry_at.isoformat()})",
+        details={
+            "challenge_id": str(challenge_id),
+            "retry_after_seconds": retry_after,
+            "retry_at": retry_at.isoformat(),
+            "cooldown_seconds": cooldown,
+        },
+    )
+
+
 def submit_flag(
     participant_id: UUID,
     challenge_id: UUID,
@@ -123,79 +197,12 @@ def submit_flag(
             details={"challenge_id": str(challenge_id)},
         )
 
-    # Check attempt limit
     all_submissions = CTFSubmission.objects.filter(
         participant=participant,
         challenge=challenge,
     )
-    total_attempt_count = all_submissions.count()
-
-    if challenge.max_attempts > 0 and event.attempt_limit_mode == "timeout":
-        # Timeout mode: count only submissions in the current window.
-        # A gap >= cooldown between submissions resets the window.
-        attempt_cooldown = event.attempt_limit_cooldown_seconds
-        attempt_count = _count_attempts_in_current_window(all_submissions, attempt_cooldown)
-
-        if attempt_count >= challenge.max_attempts:
-            last_submission_time = (
-                all_submissions.order_by("-submitted_at").values_list("submitted_at", flat=True).first()
-            )
-            if last_submission_time is None:
-                # Defensive: should be unreachable since attempt_count > 0
-                attempt_count = 0
-            else:
-                elapsed = (timezone.now() - last_submission_time).total_seconds()
-                retry_after = int(attempt_cooldown - elapsed) + 1
-                raise CTFRateLimitError(
-                    f"Maximum attempts ({challenge.max_attempts}) reached. Try again in {retry_after} seconds.",
-                    details={
-                        "challenge_id": str(challenge_id),
-                        "max_attempts": challenge.max_attempts,
-                        "attempts_used": attempt_count,
-                        "retry_after_seconds": retry_after,
-                        "attempt_limit_mode": "timeout",
-                    },
-                )
-    else:
-        attempt_count = total_attempt_count
-        if challenge.max_attempts > 0 and attempt_count >= challenge.max_attempts:
-            # Lockout mode — permanent block
-            raise CTFRateLimitError(
-                f"Maximum attempts ({challenge.max_attempts}) exceeded",
-                details={
-                    "challenge_id": str(challenge_id),
-                    "max_attempts": challenge.max_attempts,
-                    "attempts_used": total_attempt_count,
-                    "attempt_limit_mode": "lockout",
-                },
-            )
-
-    # Check submission rate limit (time-based cooldown)
-    cooldown = participant.event.submission_cooldown_seconds
-    if cooldown > 0:
-        last_submission_time = (
-            CTFSubmission.objects.filter(
-                participant=participant,
-                challenge=challenge,
-            )
-            .order_by("-submitted_at")
-            .values_list("submitted_at", flat=True)
-            .first()
-        )
-        if last_submission_time is not None:
-            elapsed = (timezone.now() - last_submission_time).total_seconds()
-            if elapsed < cooldown:
-                retry_after = int(cooldown - elapsed) + 1
-                retry_at = last_submission_time + timedelta(seconds=cooldown)
-                raise CTFRateLimitError(
-                    f"Please wait {retry_after} seconds before submitting again (retry at {retry_at.isoformat()})",
-                    details={
-                        "challenge_id": str(challenge_id),
-                        "retry_after_seconds": retry_after,
-                        "retry_at": retry_at.isoformat(),
-                        "cooldown_seconds": cooldown,
-                    },
-                )
+    attempt_count = _check_attempt_limit_or_raise(all_submissions, event, challenge, challenge_id)
+    _check_submission_cooldown_or_raise(participant, challenge, challenge_id)
 
     # Calculate hint penalty
     from ctf.services.hint import get_total_hint_penalty

--- a/shifter/shifter_platform/ctf/views.py
+++ b/shifter/shifter_platform/ctf/views.py
@@ -1099,28 +1099,21 @@ def admin_event_detail(request: HttpRequest, event_id: UUID) -> HttpResponse:
     if event.created_by_id != request.user.pk:
         return HttpResponse("Forbidden: You do not have access to this event", status=403)
 
-    # Handle status change POST
     if request.method == "POST":
         status_form = EventStatusForm(request.POST, event=event)
         if status_form.is_valid():
             action = status_form.cleaned_data["action"]
-            success = False
-
-            if action == "schedule":
-                success = schedule_event(event)
-            elif action == "activate":
-                success = activate_event(event)
-            elif action == "pause":
-                success = pause_event(event)
-            elif action == "resume":
-                success = resume_event(event)
-            elif action == "complete":
-                success = complete_event(event)
-            elif action == "archive":
-                success = archive_event(event)
-            elif action == "cancel":
-                success = cancel_event(event)
-
+            action_table = {
+                "schedule": schedule_event,
+                "activate": activate_event,
+                "pause": pause_event,
+                "resume": resume_event,
+                "complete": complete_event,
+                "archive": archive_event,
+                "cancel": cancel_event,
+            }
+            handler = action_table.get(action)
+            success = handler(event) if handler else False
             if success:
                 logger.info(
                     "User %s changed event %s status via action: %s",
@@ -2364,6 +2357,44 @@ def api_event_list(request: HttpRequest) -> JsonResponse:
         return JsonResponse({"error": "; ".join(e.messages)}, status=400)
 
 
+def _event_detail_payload(event) -> dict:
+    """Render the GET-event JSON payload for `api_event_detail`."""
+    return {
+        "id": str(event.id),
+        "name": event.name,
+        "description": event.description,
+        "status": event.status,
+        "event_start": event.event_start.isoformat(),
+        "event_end": event.event_end.isoformat(),
+        "registration_deadline": event.registration_deadline.isoformat() if event.registration_deadline else None,
+        "scenario_id": event.scenario_id,
+        "auto_cleanup": event.auto_cleanup,
+        "cleanup_delay_hours": event.cleanup_delay_hours,
+        "max_participants": event.max_participants,
+        "team_mode": event.team_mode,
+        "team_size_limit": event.team_size_limit,
+        "range_config": event.range_config,
+        "range_spinup_minutes": event.range_spinup_minutes,
+        "submission_cooldown_seconds": event.submission_cooldown_seconds,
+        "attempt_limit_mode": event.attempt_limit_mode,
+        "attempt_limit_cooldown_seconds": event.attempt_limit_cooldown_seconds,
+        "rating_visibility": event.rating_visibility,
+        "scoreboard_visible": event.scoreboard_visible,
+        "scoreboard_freeze_at": event.scoreboard_freeze_at.isoformat() if event.scoreboard_freeze_at else None,
+    }
+
+
+def _coerce_event_datetime_fields(body: dict) -> None:
+    """In-place: parse ISO datetime strings on the four scheduling fields."""
+    from django.utils.dateparse import parse_datetime
+
+    for field in ("event_start", "event_end", "registration_deadline", "scoreboard_freeze_at"):
+        if field in body and isinstance(body[field], str):
+            parsed = parse_datetime(body[field])
+            if parsed:
+                body[field] = parsed
+
+
 @login_required
 @ctf_organizer_required
 @require_http_methods(["GET", "PUT", "DELETE"])
@@ -2388,33 +2419,7 @@ def api_event_detail(request: HttpRequest, event_id: UUID) -> JsonResponse:
     from ctf.services import delete_event, update_event
 
     if request.method == "GET":
-        return JsonResponse(
-            {
-                "id": str(event.id),
-                "name": event.name,
-                "description": event.description,
-                "status": event.status,
-                "event_start": event.event_start.isoformat(),
-                "event_end": event.event_end.isoformat(),
-                "registration_deadline": event.registration_deadline.isoformat()
-                if event.registration_deadline
-                else None,
-                "scenario_id": event.scenario_id,
-                "auto_cleanup": event.auto_cleanup,
-                "cleanup_delay_hours": event.cleanup_delay_hours,
-                "max_participants": event.max_participants,
-                "team_mode": event.team_mode,
-                "team_size_limit": event.team_size_limit,
-                "range_config": event.range_config,
-                "range_spinup_minutes": event.range_spinup_minutes,
-                "submission_cooldown_seconds": event.submission_cooldown_seconds,
-                "attempt_limit_mode": event.attempt_limit_mode,
-                "attempt_limit_cooldown_seconds": event.attempt_limit_cooldown_seconds,
-                "rating_visibility": event.rating_visibility,
-                "scoreboard_visible": event.scoreboard_visible,
-                "scoreboard_freeze_at": event.scoreboard_freeze_at.isoformat() if event.scoreboard_freeze_at else None,
-            }
-        )
+        return JsonResponse(_event_detail_payload(event))
 
     if request.method == "DELETE":
         delete_event(event_id)
@@ -2425,16 +2430,7 @@ def api_event_detail(request: HttpRequest, event_id: UUID) -> JsonResponse:
         body = _parse_body_object(request)
     except _BodyParseError as e:
         return JsonResponse({"error": str(e)}, status=400)
-
-    # Parse datetime strings to datetime objects for the service layer
-    from django.utils.dateparse import parse_datetime
-
-    for field in ("event_start", "event_end", "registration_deadline", "scoreboard_freeze_at"):
-        if field in body and isinstance(body[field], str):
-            parsed = parse_datetime(body[field])
-            if parsed:
-                body[field] = parsed
-
+    _coerce_event_datetime_fields(body)
     try:
         updated = update_event(event_id, body)
         return JsonResponse(
@@ -3342,6 +3338,49 @@ def api_notification_send(request: HttpRequest, notification_id: UUID) -> HttpRe
 @login_required
 @ctf_organizer_required
 @require_http_methods(["GET", "PUT", "DELETE"])
+def _handle_get_email_template(event, notification_type: str) -> JsonResponse:
+    """Return the per-event custom template or 404."""
+    from ctf.models import CTFEmailTemplate
+
+    template = CTFEmailTemplate.objects.filter(event=event, notification_type=notification_type).first()
+    if template is None:
+        return JsonResponse({"error": "No custom template"}, status=404)
+    return JsonResponse(
+        {
+            "id": str(template.id),
+            "notification_type": template.notification_type,
+            "subject": template.subject,
+            "html_body": template.html_body,
+            "text_body": template.text_body,
+        }
+    )
+
+
+def _handle_delete_email_template(event, notification_type: str) -> JsonResponse:
+    """Soft-delete the per-event template; revert to default."""
+    from ctf.models import CTFEmailTemplate
+
+    template = CTFEmailTemplate.objects.filter(event=event, notification_type=notification_type).first()
+    if template is None:
+        return JsonResponse({"error": "No custom template to delete"}, status=404)
+    template.delete(soft=True)
+    return JsonResponse({"status": "reverted_to_default"})
+
+
+def _validate_template_bodies(html_body: str, text_body: str) -> JsonResponse | None:
+    """Validate the two template bodies; return a 400 JsonResponse or None on success."""
+    if not html_body or not text_body:
+        return JsonResponse({"error": "html_body and text_body are required"}, status=400)
+    from django.template import Template, TemplateSyntaxError
+
+    for label, source in (("html_body", html_body), ("text_body", text_body)):
+        try:
+            Template(source)
+        except TemplateSyntaxError as exc:
+            return JsonResponse({"error": f"Invalid template syntax in {label}: {exc}"}, status=400)
+    return None
+
+
 def api_event_email_template(request: HttpRequest, event_id: UUID, notification_type: str) -> JsonResponse:
     """API: Get, update, or delete a per-event email template override.
 
@@ -3372,25 +3411,9 @@ def api_event_email_template(request: HttpRequest, event_id: UUID, notification_
         return JsonResponse({"error": "Forbidden"}, status=403)
 
     if request.method == "GET":
-        template = CTFEmailTemplate.objects.filter(event=event, notification_type=notification_type).first()
-        if template is None:
-            return JsonResponse({"error": "No custom template"}, status=404)
-        return JsonResponse(
-            {
-                "id": str(template.id),
-                "notification_type": template.notification_type,
-                "subject": template.subject,
-                "html_body": template.html_body,
-                "text_body": template.text_body,
-            }
-        )
-
+        return _handle_get_email_template(event, notification_type)
     if request.method == "DELETE":
-        template = CTFEmailTemplate.objects.filter(event=event, notification_type=notification_type).first()
-        if template is None:
-            return JsonResponse({"error": "No custom template to delete"}, status=404)
-        template.delete(soft=True)
-        return JsonResponse({"status": "reverted_to_default"})
+        return _handle_delete_email_template(event, notification_type)
 
     # PUT — create or update
     try:
@@ -3401,17 +3424,9 @@ def api_event_email_template(request: HttpRequest, event_id: UUID, notification_
     except _BodyParseError as e:
         return JsonResponse({"error": str(e)}, status=400)
 
-    if not html_body or not text_body:
-        return JsonResponse({"error": "html_body and text_body are required"}, status=400)
-
-    # Validate Django template syntax before saving
-    from django.template import Template, TemplateSyntaxError
-
-    for label, source in [("html_body", html_body), ("text_body", text_body)]:
-        try:
-            Template(source)
-        except TemplateSyntaxError as exc:
-            return JsonResponse({"error": f"Invalid template syntax in {label}: {exc}"}, status=400)
+    syntax_error = _validate_template_bodies(html_body, text_body)
+    if syntax_error is not None:
+        return syntax_error
 
     template, _created = CTFEmailTemplate.objects.update_or_create(
         event=event,

--- a/shifter/shifter_platform/documentation/views.py
+++ b/shifter/shifter_platform/documentation/views.py
@@ -84,6 +84,24 @@ def _title_from_filename(filename: str) -> str:
     return filename.replace("-", " ").replace("_", " ").title()
 
 
+def _partition_nav_entries(base_path: Path) -> tuple[list[Path], list[Path]]:
+    """Sort directory entries into (folders, markdown files), filtering hidden / excluded."""
+    try:
+        entries = sorted(base_path.iterdir())
+    except (PermissionError, FileNotFoundError):
+        return [], []
+    folders: list[Path] = []
+    files: list[Path] = []
+    for entry in entries:
+        if entry.name in EXCLUDED_FOLDERS or entry.name.startswith("."):
+            continue
+        if entry.is_dir():
+            folders.append(entry)
+        elif entry.suffix == ".md":
+            files.append(entry)
+    return folders, files
+
+
 def _build_nav_tree(base_path: Path, current_path: str = "") -> list[dict]:
     """Build navigation tree from directory structure.
 
@@ -101,30 +119,8 @@ def _build_nav_tree(base_path: Path, current_path: str = "") -> list[dict]:
     - Empty folders (no .md files)
     """
     items: list[dict[str, object]] = []
+    folders, files = _partition_nav_entries(base_path)
 
-    try:
-        entries = sorted(base_path.iterdir())
-    except (PermissionError, FileNotFoundError):
-        return items
-
-    # Separate folders and files
-    folders = []
-    files = []
-
-    for entry in entries:
-        # Skip excluded folders
-        if entry.name in EXCLUDED_FOLDERS:
-            continue
-        # Skip hidden files/folders
-        if entry.name.startswith("."):
-            continue
-
-        if entry.is_dir():
-            folders.append(entry)
-        elif entry.suffix == ".md":
-            files.append(entry)
-
-    # Process folders first
     for folder in folders:
         folder_path = f"{current_path}/{folder.name}" if current_path else folder.name
         children = _build_nav_tree(folder, folder_path)
@@ -138,7 +134,6 @@ def _build_nav_tree(base_path: Path, current_path: str = "") -> list[dict]:
                 }
             )
 
-    # Process markdown files
     for md_file in files:
         # Skip index.md from direct listing - it's the folder's landing page
         if md_file.name == "index.md":

--- a/shifter/shifter_platform/risk_register/management/commands/audit_archive.py
+++ b/shifter/shifter_platform/risk_register/management/commands/audit_archive.py
@@ -51,6 +51,118 @@ class Command(BaseCommand):
             help="Number of records to process per batch (default: 10000)",
         )
 
+    def _resolve_archive_bucket(self) -> str | None:
+        """Resolve the destination S3 bucket name. Emit an error to stdout on miss."""
+        bucket_name = (
+            getattr(settings, "LOGS_BUCKET_NAME", None)
+            or os.environ.get("LOGS_BUCKET_NAME")
+            or getattr(settings, "AUDIT_ARCHIVE_BUCKET", None)
+            or os.environ.get("AUDIT_ARCHIVE_BUCKET")
+        )
+        if not bucket_name:
+            self.stdout.write(
+                self.style.ERROR("LOGS_BUCKET_NAME not configured. Set via Terraform log-aggregation module output.")
+            )
+        return bucket_name
+
+    def _resolve_expected_bucket_owner(self) -> str:
+        """Return the AWS account ID to pass as `ExpectedBucketOwner`, or ''.
+
+        Defence-in-depth against a bucket-name collision where an attacker
+        pre-creates a bucket with the same name in a different account.
+        Explicit env var wins; STS fallback discovers the caller's account
+        at runtime; on failure we log a warning and skip the check — never
+        hard-fail the archive on this defence-in-depth knob.
+        """
+        expected_bucket_owner = os.environ.get("AWS_ACCOUNT_ID", "")
+        if expected_bucket_owner:
+            return expected_bucket_owner
+        try:
+            import boto3
+
+            sts_client = boto3.client("sts")
+            return sts_client.get_caller_identity()["Account"]
+        except Exception as e:
+            self.stdout.write(
+                self.style.WARNING(f"  ExpectedBucketOwner check disabled (STS GetCallerIdentity failed: {e})")
+            )
+            return ""
+
+    @staticmethod
+    def _serialize_batch(batch) -> tuple[bytes, list[int]]:
+        """Render a batch into compressed JSONL bytes; also return the record ids."""
+        lines = []
+        record_ids = []
+        for record in batch:
+            record_ids.append(record.id)
+            lines.append(
+                json.dumps(
+                    {
+                        "id": record.id,
+                        "entity_type": record.entity_type,
+                        "entity_id": record.entity_id,
+                        "action": record.action,
+                        "actor_type": record.actor_type,
+                        "actor_id": record.actor_id,
+                        "timestamp": record.timestamp.isoformat(),
+                        "previous_state": record.previous_state,
+                        "new_state": record.new_state,
+                        "context": record.context,
+                        "source_ip": record.source_ip,
+                        "user_agent": record.user_agent,
+                        "request_id": record.request_id,
+                    },
+                    default=str,
+                )
+            )
+        return gzip.compress("\n".join(lines).encode("utf-8")), record_ids
+
+    def _archive_one_batch(
+        self,
+        s3_client,
+        batch,
+        bucket_name: str,
+        expected_bucket_owner: str,
+        batch_num: int,
+        no_delete: bool,
+    ) -> tuple[int, int, bool]:
+        """Compress + upload one batch; optionally delete the source rows.
+
+        Returns (archived, deleted, ok). `ok=False` signals the caller should
+        break out of the loop because S3 upload failed.
+        """
+        from botocore.exceptions import ClientError
+
+        first_ts = batch[0].timestamp
+        last_ts = batch[-1].timestamp
+        s3_key = (
+            f"audit-archive/{first_ts.year}/{first_ts.month:02d}/"
+            f"audit_{first_ts.strftime('%Y%m%d_%H%M%S')}_"
+            f"{last_ts.strftime('%Y%m%d_%H%M%S')}.jsonl.gz"
+        )
+        compressed, record_ids = self._serialize_batch(batch)
+        put_kwargs = {
+            "Bucket": bucket_name,
+            "Key": s3_key,
+            "Body": compressed,
+            "ContentType": "application/x-ndjson",
+            "ContentEncoding": "gzip",
+        }
+        if expected_bucket_owner:
+            put_kwargs["ExpectedBucketOwner"] = expected_bucket_owner
+        try:
+            s3_client.put_object(**put_kwargs)
+        except ClientError as e:
+            self.stdout.write(self.style.ERROR(f"  Batch {batch_num}: S3 upload failed: {e}"))
+            return 0, 0, False
+        self.stdout.write(f"  Batch {batch_num}: Uploaded {len(batch)} records to s3://{bucket_name}/{s3_key}")
+        deleted = 0
+        if not no_delete:
+            AuditLog.objects.filter(id__in=record_ids).delete()
+            deleted = len(record_ids)
+            self.stdout.write(f"  Batch {batch_num}: Deleted {deleted} records from database")
+        return len(batch), deleted, True
+
     def handle(self, *args, **options):
         dry_run = options["dry_run"]
         retention_days = options["retention_days"]
@@ -58,17 +170,14 @@ class Command(BaseCommand):
         batch_size = options["batch_size"]
 
         cutoff_date = timezone.now() - timedelta(days=retention_days)
-
         self.stdout.write("Audit log archive started")
         self.stdout.write(f"  Retention: {retention_days} days")
         self.stdout.write(f"  Cutoff date: {cutoff_date.isoformat()}")
         self.stdout.write(f"  Dry run: {dry_run}")
         self.stdout.write(f"  Delete after archive: {not no_delete}")
 
-        # Count records to archive
         queryset = AuditLog.objects.filter(timestamp__lt=cutoff_date)
         total_count = queryset.count()
-
         if total_count == 0:
             self.stdout.write(self.style.SUCCESS("No audit logs to archive"))
             return
@@ -76,7 +185,6 @@ class Command(BaseCommand):
         self.stdout.write(f"  Records to archive: {total_count}")
 
         if dry_run:
-            # Show sample of what would be archived
             sample = queryset.order_by("timestamp")[:5]
             self.stdout.write("\nSample records that would be archived:")
             for record in sample:
@@ -86,126 +194,39 @@ class Command(BaseCommand):
             self.stdout.write(self.style.WARNING("\nDry run - no changes made"))
             return
 
-        # Get S3 bucket from settings or environment
-        # Uses the existing logs bucket from log-aggregation infrastructure
-        # Falls back to AUDIT_ARCHIVE_BUCKET for backward compatibility
-        bucket_name = (
-            getattr(settings, "LOGS_BUCKET_NAME", None)
-            or os.environ.get("LOGS_BUCKET_NAME")
-            or getattr(settings, "AUDIT_ARCHIVE_BUCKET", None)
-            or os.environ.get("AUDIT_ARCHIVE_BUCKET")
-        )
-
+        bucket_name = self._resolve_archive_bucket()
         if not bucket_name:
-            self.stdout.write(
-                self.style.ERROR("LOGS_BUCKET_NAME not configured. Set via Terraform log-aggregation module output.")
-            )
             return
 
         try:
             import boto3
-            from botocore.exceptions import ClientError
-
-            s3_client = boto3.client("s3")
         except ImportError:
             self.stdout.write(self.style.ERROR("boto3 not installed. Install with: pip install boto3"))
             return
+        s3_client = boto3.client("s3")
+        expected_bucket_owner = self._resolve_expected_bucket_owner()
 
-        # Resolve the AWS account ID so every put_object call can pass
-        # ExpectedBucketOwner. Defence-in-depth against a bucket-name
-        # collision where an attacker pre-creates a bucket with the same
-        # name in a different account: without this, audit logs could be
-        # silently written to the attacker's bucket.
-        # Strategy: explicit env var wins (simple to pin for tests), STS
-        # fallback discovers the caller's account at runtime. If both
-        # fail we log a warning and skip the ExpectedBucketOwner check —
-        # we never hard-fail the archive on this defence-in-depth knob.
-        expected_bucket_owner = os.environ.get("AWS_ACCOUNT_ID", "")
-        if not expected_bucket_owner:
-            try:
-                sts_client = boto3.client("sts")
-                expected_bucket_owner = sts_client.get_caller_identity()["Account"]
-            except Exception as e:
-                self.stdout.write(
-                    self.style.WARNING(f"  ExpectedBucketOwner check disabled (STS GetCallerIdentity failed: {e})")
-                )
-                expected_bucket_owner = ""
-
-        # Process in batches
         archived_count = 0
         deleted_count = 0
         batch_num = 0
-
         while True:
             batch = list(queryset.order_by("timestamp")[:batch_size])
             if not batch:
                 break
-
             batch_num += 1
-            first_ts = batch[0].timestamp
-            last_ts = batch[-1].timestamp
-
-            # Generate S3 key based on date range
-            s3_key = (
-                f"audit-archive/{first_ts.year}/{first_ts.month:02d}/"
-                f"audit_{first_ts.strftime('%Y%m%d_%H%M%S')}_"
-                f"{last_ts.strftime('%Y%m%d_%H%M%S')}.jsonl.gz"
+            archived, deleted, ok = self._archive_one_batch(
+                s3_client,
+                batch,
+                bucket_name,
+                expected_bucket_owner,
+                batch_num,
+                no_delete,
             )
-
-            # Convert to JSON Lines format
-            lines = []
-            record_ids = []
-            for record in batch:
-                record_ids.append(record.id)
-                lines.append(
-                    json.dumps(
-                        {
-                            "id": record.id,
-                            "entity_type": record.entity_type,
-                            "entity_id": record.entity_id,
-                            "action": record.action,
-                            "actor_type": record.actor_type,
-                            "actor_id": record.actor_id,
-                            "timestamp": record.timestamp.isoformat(),
-                            "previous_state": record.previous_state,
-                            "new_state": record.new_state,
-                            "context": record.context,
-                            "source_ip": record.source_ip,
-                            "user_agent": record.user_agent,
-                            "request_id": record.request_id,
-                        },
-                        default=str,
-                    )
-                )
-
-            # Compress and upload
-            content = "\n".join(lines).encode("utf-8")
-            compressed = gzip.compress(content)
-
-            try:
-                put_kwargs = {
-                    "Bucket": bucket_name,
-                    "Key": s3_key,
-                    "Body": compressed,
-                    "ContentType": "application/x-ndjson",
-                    "ContentEncoding": "gzip",
-                }
-                if expected_bucket_owner:
-                    put_kwargs["ExpectedBucketOwner"] = expected_bucket_owner
-                s3_client.put_object(**put_kwargs)
-                archived_count += len(batch)
-                self.stdout.write(f"  Batch {batch_num}: Uploaded {len(batch)} records to s3://{bucket_name}/{s3_key}")
-            except ClientError as e:
-                self.stdout.write(self.style.ERROR(f"  Batch {batch_num}: S3 upload failed: {e}"))
+            archived_count += archived
+            deleted_count += deleted
+            if not ok:
                 break
 
-            # Delete from database if not --no-delete
-            if not no_delete:
-                AuditLog.objects.filter(id__in=record_ids).delete()
-                deleted_count += len(record_ids)
-                self.stdout.write(f"  Batch {batch_num}: Deleted {len(record_ids)} records from database")
-
-        # Summary
         self.stdout.write("")
         self.stdout.write(self.style.SUCCESS("Archive complete:"))
         self.stdout.write(f"  Records archived: {archived_count}")


### PR DESCRIPTION
## Summary

Fourth milestone on #1236. Clears 35 `python:FunctionComplexity` findings — every function ruff flags at McCabe > 10 outside the diffs already owned by open PRs #1238 and #1239.

All changes are pure structural refactors: cohesive sub-blocks extracted into named helpers, control flow unchanged. No SonarCloud finding suppressed; no `# noqa: C901` added.

## Functions cleared (35 across 18 files)

**`scripts/polaris-aws-range/`**
- `apply_kali_bedrock_shard.py::main` (25) → `_resolve_targets`, `_group_by_shard`, `_print_shard_layout`, `_bump_imds_hop_limit`, `_send_shard_batches`, `_print_summary`
- `orchestrate_provisioning.py::run_one_batch` (22), `retry_failures` (15), `main` (12) → outcome-recording, wave/sleep mode, terminal-wait, batch-loop helpers (shared `_wait_for_terminal`)
- `cleanup_non_keepers.py::main` (14) → `_summarize_events` + `_check_event_sanity`
- `check_range_health.py::ok` (12), `issues` (12) → `ok` collapses to `not issues()`; `issues` split into 6 per-category helpers

**`shifter/engine/provisioner/`**
- `executors/ssm_executor.py::run_command` (15), `reboot_and_wait` (12) → `_build_terminal_result`, `_truncate_output`, `_maybe_finalize_reboot`
- `executors/ssh_executor.py::run_command` (11) → `_read_until_eof`, `_wait_for_exit_status`
- `main.py::_run_terraform_destroy` (15), `_validate_provisioned_outputs` (12) → NGFW-detach / CIDR-recover / post-destroy / NGFW-pause helpers; per-row subnet/instance asserts
- `components/tags.py::build_common_tags` (15) → `_validate_common_tag_inputs`
- `ngfw_terraform.py::_run_pan_os_post_provision` (11) → `_short_circuit_local_dev_post_provision`, `_build_ngfw_ssh_executor_from_output`
- `range_ops.py::ensure_ngfw_running` (13) → `_wait_for_ngfw_pause_to_complete`, `_publish_ngfw_status`, `_run_ngfw_start_with_retry`

**`shifter/shifter_platform/`**
- `cms/experiments/services.py::complete_script_upload` (11), `create_experiment` (13)
- `cms/handlers/range_events.py::process_range_event` (11)
- `cms/scenario_editor/views.py::scenario_create_form` (12), `scenario_edit_form` (12) → shared `_parse_scenario_form_post`
- `ctf/services/challenge.py::update_challenge` (12)
- `ctf/services/submission.py::submit_flag` (12) → `_check_attempt_limit_or_raise`, `_check_submission_cooldown_or_raise`
- `ctf/views.py::admin_event_detail` (13), `api_event_detail` (11), `api_event_email_template` (12)
- `documentation/views.py::_build_nav_tree` (11)
- `risk_register/management/commands/audit_archive.py::handle` (14)

**`scripts/`** + **`shifter/installation/`**
- `check_tf_sg_cidrs/check_tf_sg_cidrs.py::check_file` (17) → `_collect_cidr_violations_on_line` + `_ParserState`
- `adr_guard/adr_guard.py::check_adr_registry` (12) → `_check_adr_entry` + `_registry_violation` (noted in `complexity-backlog.md` per ADR-002-R1, since adr_guard.py is a guardrail file)
- `installation/schema.py::_validate_domain` (11) → `_assert_domain_surface`, `_assert_domain_labels`

## Pre-push hook fix included context

While rebasing #1238 earlier in this effort, the global pre-push signature hook was found to verify every commit between the remote tip and local on force-push — catching GitHub squash-merge commits whose signatures aren't in the local keyring. That fix (`git rev-list <local> --not --remotes`) is a local `~/.git-hooks/pre-push` change, not part of this PR.

## Test plan

- [x] `provisioner` full suite: 688 passed, 8 skipped
- [x] `shifter_platform` cms + ctf suites: 1627 passed
- [x] `adr_guard` suite: 170 passed
- [x] `risk_register` suite: 16 passed
- [x] ruff `--select C901 --config 'lint.mccabe.max-complexity=10'` clean on every touched file
- [x] Pre-commit hooks pass (ruff, ruff-format, mypy, per-package suites, ADR guard)
- [ ] SonarCloud `python:FunctionComplexity` HIGH count drops by 35 on the next analysis cycle

## Scope note

The 16 `python:FunctionComplexity` findings ruff still reports on `dev` all live inside the diff of an already-open PR — #1238 (`scripts/bootstrap/deploy.py`, `scripts/polaris-aws-range/apply_splice_watcher.py`) and #1239 (`shifter/shifter_platform/cms/services.py`). They are refactored on those branches; this PR was scoped to avoid touching the same files so the branches do not conflict.
