### PR TITLE
ci: exempt dev PRs from title lint

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -19,7 +19,13 @@ jobs:
     name: Lint PR title
     runs-on: self-hosted
     steps:
+      - name: Skip conventional title on dev PRs
+        if: github.base_ref == 'dev'
+        run: |
+          echo "PRs targeting dev are exempt from conventional title lint."
+
       - name: Validate conventional-commit title
+        if: github.base_ref != 'dev'
         # amannn/action-semantic-pull-request v5.5.3
         uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017
         env:

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -38,10 +38,12 @@ Current mechanisms:
   `security-events: write`, `actions: read`); no `pull_request_target`.
 - `.github/workflows/pr-title-lint.yml`: pull-request title validation
   against the conventional-commit shape used by towncrier and the
-  release-drafter conventions. Allowed types: `security`, `added`,
-  `changed`, `deprecated`, `removed`, `fixed`, `feat`, `fix`, `chore`,
-  `docs`, `refactor`, `test`, `ci`, `build`, `perf`, `revert`. Subject
-  must start with a lowercase letter.
+  release-drafter conventions. PRs targeting the `dev` integration
+  branch are exempt; PRs targeting release/environment branches are
+  validated. Allowed types: `security`, `added`, `changed`,
+  `deprecated`, `removed`, `fixed`, `feat`, `fix`, `chore`, `docs`,
+  `refactor`, `test`, `ci`, `build`, `perf`, `revert`. Subject must
+  start with a lowercase letter.
 - `.github/dependabot.yml`: weekly dependency PRs across every uv,
   npm, github-actions, and pre-commit package root in the repo; every
   block targets the `dev` integration branch.


### PR DESCRIPTION
## Summary
- skip conventional PR title validation for PRs targeting dev while keeping the check job successful
- document the dev exemption in the ADR guardrail README

## Checks
- actionlint
- git diff --cached --check
- python3 scripts/adr_guard/adr_guard.py --all --level ci