### PR TITLE
fix: localize step number labels

### DIFF
--- a/shifter/shifter_platform/templates/ctf/participant/walkthrough.html
+++ b/shifter/shifter_platform/templates/ctf/participant/walkthrough.html
@@ -149,7 +149,7 @@
         {# Step 1 #}
         <div class="wt-step">
             <div class="wt-step-header">
-                <span class="wt-step-num">1</span>
+                <span class="wt-step-num">{% trans "1" %}</span>
                 <span class="wt-step-title">{% trans "Reconnaissance" %}</span>
             </div>
             <div class="wt-step-body">
@@ -177,7 +177,7 @@
         {# Step 2 #}
         <div class="wt-step">
             <div class="wt-step-header">
-                <span class="wt-step-num">2</span>
+                <span class="wt-step-num">{% trans "2" %}</span>
                 <span class="wt-step-title">{% trans "Find the Vulnerability" %}</span>
             </div>
             <div class="wt-step-body">
@@ -208,7 +208,7 @@
         {# Step 3 #}
         <div class="wt-step">
             <div class="wt-step-header">
-                <span class="wt-step-num">3</span>
+                <span class="wt-step-num">{% trans "3" %}</span>
                 <span class="wt-step-title">{% trans "Get User Access" %}</span>
             </div>
             <div class="wt-step-body">
@@ -239,7 +239,7 @@
         {# Step 4 #}
         <div class="wt-step">
             <div class="wt-step-header">
-                <span class="wt-step-num">4</span>
+                <span class="wt-step-num">{% trans "4" %}</span>
                 <span class="wt-step-title">{% trans "Get Root" %}</span>
             </div>
             <div class="wt-step-body">

--- a/shifter/shifter_platform/templates/mission_control/ngfw/wizard.html
+++ b/shifter/shifter_platform/templates/mission_control/ngfw/wizard.html
@@ -19,19 +19,19 @@
         <!-- Step Indicator -->
         <div class="wizard-steps">
             <div class="wizard-step active" data-step="1">
-                <span class="step-number">1</span>
+                <span class="step-number">{% trans "1" %}</span>
                 <span class="step-label">{% trans "Name & Profile" %}</span>
             </div>
             <div class="wizard-step" data-step="2">
-                <span class="step-number">2</span>
+                <span class="step-number">{% trans "2" %}</span>
                 <span class="step-label">{% trans "Registration" %}</span>
             </div>
             <div class="wizard-step" data-step="3">
-                <span class="step-number">3</span>
+                <span class="step-number">{% trans "3" %}</span>
                 <span class="step-label">{% trans "Confirm" %}</span>
             </div>
             <div class="wizard-step" data-step="4">
-                <span class="step-number">4</span>
+                <span class="step-number">{% trans "4" %}</span>
                 <span class="step-label">{% trans "Provision" %}</span>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- wrap CTF walkthrough step numbers in Django translation tags
- wrap NGFW wizard step numbers in Django translation tags
- targets the 8 new Sonar BUG findings causing the reliability rating failure on PR #1255

## Checks
- git diff --check
- python3 scripts/adr_guard/adr_guard.py --files shifter/shifter_platform/templates/ctf/participant/walkthrough.html shifter/shifter_platform/templates/mission_control/ngfw/wizard.html --level fast
- cd shifter/shifter_platform && uv run pytest tests/config/test_i18n_configuration.py