### PR TITLE
ci: gate quality jobs by changed subsystem

### DIFF
--- a/.github/workflows/_quality.yml
+++ b/.github/workflows/_quality.yml
@@ -8,6 +8,66 @@ on:
         required: false
         type: boolean
         default: false
+      core:
+        required: false
+        type: boolean
+        default: false
+      range:
+        required: false
+        type: boolean
+        default: false
+      shifter_engine:
+        required: false
+        type: boolean
+        default: false
+      shifter_platform:
+        required: false
+        type: boolean
+        default: false
+      shifter_app:
+        required: false
+        type: boolean
+        default: false
+      shifter_platform_app:
+        required: false
+        type: boolean
+        default: false
+      mcp:
+        required: false
+        type: boolean
+        default: false
+      packer:
+        required: false
+        type: boolean
+        default: false
+      bootstrap:
+        required: false
+        type: boolean
+        default: false
+      check_layer_imports:
+        required: false
+        type: boolean
+        default: false
+      check_rds_pending_modifications:
+        required: false
+        type: boolean
+        default: false
+      installation:
+        required: false
+        type: boolean
+        default: false
+      gcp:
+        required: false
+        type: boolean
+        default: false
+      guardrails:
+        required: false
+        type: boolean
+        default: false
+      quality_workflow:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   # ===========================================================================
@@ -18,6 +78,16 @@ jobs:
     permissions:
       contents: read
     name: Architecture (adr conformance)
+    if: |
+      inputs.guardrails ||
+      inputs.quality_workflow ||
+      inputs.core ||
+      inputs.range ||
+      inputs.shifter_engine ||
+      inputs.shifter_platform ||
+      inputs.shifter_app ||
+      inputs.shifter_platform_app ||
+      inputs.gcp
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
@@ -60,6 +130,7 @@ jobs:
     permissions:
       contents: read
     name: Lint (GitHub Actions)
+    if: inputs.guardrails || inputs.quality_workflow
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
@@ -69,6 +140,14 @@ jobs:
     permissions:
       contents: read
     name: Lint (terraform)
+    if: |
+      inputs.guardrails ||
+      inputs.quality_workflow ||
+      inputs.core ||
+      inputs.range ||
+      inputs.shifter_engine ||
+      inputs.shifter_platform ||
+      inputs.gcp
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
@@ -87,6 +166,11 @@ jobs:
     permissions:
       contents: read
     name: Lint (shifter_platform)
+    if: |
+      inputs.quality_workflow ||
+      inputs.shifter_platform_app ||
+      inputs.shifter_platform ||
+      inputs.gcp
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
@@ -108,6 +192,11 @@ jobs:
     permissions:
       contents: read
     name: Lint JavaScript/CSS (shifter_platform)
+    if: |
+      inputs.quality_workflow ||
+      inputs.shifter_platform_app ||
+      inputs.shifter_platform ||
+      inputs.gcp
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
@@ -135,6 +224,10 @@ jobs:
     permissions:
       contents: read
     name: Lint (provisioner)
+    if: |
+      inputs.quality_workflow ||
+      inputs.shifter_engine ||
+      inputs.gcp
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
@@ -153,6 +246,7 @@ jobs:
     permissions:
       contents: read
     name: Lint (packer)
+    if: inputs.quality_workflow || inputs.packer
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
@@ -171,6 +265,7 @@ jobs:
     permissions:
       contents: read
     name: Lint (bootstrap)
+    if: inputs.quality_workflow || inputs.bootstrap
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
@@ -189,6 +284,7 @@ jobs:
     permissions:
       contents: read
     name: Lint (gcp scripts)
+    if: inputs.quality_workflow || inputs.gcp
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
@@ -207,6 +303,7 @@ jobs:
     permissions:
       contents: read
     name: Lint (check_layer_imports)
+    if: inputs.quality_workflow || inputs.check_layer_imports
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
@@ -225,6 +322,7 @@ jobs:
     permissions:
       contents: read
     name: Lint (check_rds_pending_modifications)
+    if: inputs.quality_workflow || inputs.check_rds_pending_modifications
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
@@ -243,6 +341,7 @@ jobs:
     permissions:
       contents: read
     name: Lint (installation)
+    if: inputs.quality_workflow || inputs.installation
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
@@ -261,6 +360,7 @@ jobs:
     permissions:
       contents: read
     name: Lint (k8s manifests)
+    if: inputs.guardrails || inputs.quality_workflow || inputs.gcp
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
@@ -312,6 +412,7 @@ jobs:
     permissions:
       contents: read
     name: Lint (k8s schemas)
+    if: inputs.guardrails || inputs.quality_workflow || inputs.gcp
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
@@ -362,7 +463,12 @@ jobs:
     permissions:
       contents: read
     name: Type Check (shifter_platform)
-    if: ${{ !inputs.skip_tests }}
+    if: |
+      !inputs.skip_tests &&
+      (inputs.quality_workflow ||
+       inputs.shifter_platform_app ||
+       inputs.shifter_platform ||
+       inputs.gcp)
     runs-on: self-hosted
     continue-on-error: true  # Non-blocking - quality signal only
     steps:
@@ -385,7 +491,11 @@ jobs:
     permissions:
       contents: read
     name: Type Check (provisioner)
-    if: ${{ !inputs.skip_tests }}
+    if: |
+      !inputs.skip_tests &&
+      (inputs.quality_workflow ||
+       inputs.shifter_engine ||
+       inputs.gcp)
     runs-on: self-hosted
     continue-on-error: true  # Non-blocking - quality signal only
     steps:
@@ -412,6 +522,10 @@ jobs:
     permissions:
       contents: read
     name: Architecture (layer imports)
+    if: |
+      inputs.quality_workflow ||
+      inputs.shifter_platform_app ||
+      inputs.check_layer_imports
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
@@ -431,6 +545,11 @@ jobs:
     permissions:
       contents: read
     name: Architecture (import linter)
+    if: |
+      inputs.quality_workflow ||
+      inputs.shifter_platform_app ||
+      inputs.shifter_platform ||
+      inputs.gcp
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
@@ -464,6 +583,11 @@ jobs:
     permissions:
       contents: read
     name: SAST (shifter_platform)
+    if: |
+      inputs.quality_workflow ||
+      inputs.shifter_platform_app ||
+      inputs.shifter_platform ||
+      inputs.gcp
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
@@ -480,6 +604,10 @@ jobs:
     permissions:
       contents: read
     name: SAST (provisioner)
+    if: |
+      inputs.quality_workflow ||
+      inputs.shifter_engine ||
+      inputs.gcp
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
@@ -498,6 +626,7 @@ jobs:
     permissions:
       contents: read
     name: SAST (packer)
+    if: inputs.quality_workflow || inputs.packer
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
@@ -514,6 +643,7 @@ jobs:
     permissions:
       contents: read
     name: SAST (bootstrap)
+    if: inputs.quality_workflow || inputs.bootstrap
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
@@ -530,6 +660,7 @@ jobs:
     permissions:
       contents: read
     name: SAST (gcp scripts)
+    if: inputs.quality_workflow || inputs.gcp
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
@@ -546,6 +677,7 @@ jobs:
     permissions:
       contents: read
     name: SAST (check_layer_imports)
+    if: inputs.quality_workflow || inputs.check_layer_imports
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
@@ -563,6 +695,7 @@ jobs:
     permissions:
       contents: read
     name: SAST (installation)
+    if: inputs.quality_workflow || inputs.installation
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
@@ -583,7 +716,12 @@ jobs:
     permissions:
       contents: read
     name: Tests (shifter_platform)
-    if: ${{ !inputs.skip_tests }}
+    if: |
+      !inputs.skip_tests &&
+      (inputs.quality_workflow ||
+       inputs.shifter_platform_app ||
+       inputs.shifter_platform ||
+       inputs.gcp)
     needs: [shifter-platform-lint, shifter-platform-lint-js, shifter-platform-sast]
     runs-on: self-hosted
     services:
@@ -629,7 +767,11 @@ jobs:
     permissions:
       contents: read
     name: Tests (provisioner)
-    if: ${{ !inputs.skip_tests }}
+    if: |
+      !inputs.skip_tests &&
+      (inputs.quality_workflow ||
+       inputs.shifter_engine ||
+       inputs.gcp)
     needs: [provisioner-lint, provisioner-sast]
     runs-on: self-hosted
     steps:
@@ -652,7 +794,7 @@ jobs:
     permissions:
       contents: read
     name: Tests (packer)
-    if: ${{ !inputs.skip_tests }}
+    if: ${{ !inputs.skip_tests && (inputs.quality_workflow || inputs.packer) }}
     needs: [packer-lint]
     runs-on: self-hosted
     steps:
@@ -673,7 +815,7 @@ jobs:
     permissions:
       contents: read
     name: Tests (bootstrap)
-    if: ${{ !inputs.skip_tests }}
+    if: ${{ !inputs.skip_tests && (inputs.quality_workflow || inputs.bootstrap) }}
     needs: [bootstrap-lint]
     runs-on: self-hosted
     steps:
@@ -694,7 +836,7 @@ jobs:
     permissions:
       contents: read
     name: Tests (gcp scripts)
-    if: ${{ !inputs.skip_tests }}
+    if: ${{ !inputs.skip_tests && (inputs.quality_workflow || inputs.gcp) }}
     needs: [gcp-scripts-lint]
     runs-on: self-hosted
     steps:
@@ -715,7 +857,7 @@ jobs:
     permissions:
       contents: read
     name: Tests (check_layer_imports)
-    if: ${{ !inputs.skip_tests }}
+    if: ${{ !inputs.skip_tests && (inputs.quality_workflow || inputs.check_layer_imports) }}
     needs: [check-layer-imports-lint]
     runs-on: self-hosted
     steps:
@@ -736,7 +878,7 @@ jobs:
     permissions:
       contents: read
     name: Tests (check_rds_pending_modifications)
-    if: ${{ !inputs.skip_tests }}
+    if: ${{ !inputs.skip_tests && (inputs.quality_workflow || inputs.check_rds_pending_modifications) }}
     needs: [check-rds-pending-modifications-lint]
     runs-on: self-hosted
     steps:
@@ -757,7 +899,7 @@ jobs:
     permissions:
       contents: read
     name: Tests (installation)
-    if: ${{ !inputs.skip_tests }}
+    if: ${{ !inputs.skip_tests && (inputs.quality_workflow || inputs.installation) }}
     needs: [installation-lint]
     runs-on: self-hosted
     steps:
@@ -778,7 +920,7 @@ jobs:
     permissions:
       contents: read
     name: Tests (adr_guard)
-    if: ${{ !inputs.skip_tests }}
+    if: ${{ !inputs.skip_tests && (inputs.guardrails || inputs.quality_workflow) }}
     needs: [adr-conformance]
     runs-on: self-hosted
     steps:
@@ -802,7 +944,12 @@ jobs:
     permissions:
       contents: read
     name: Tests JavaScript (shifter_platform)
-    if: ${{ !inputs.skip_tests }}
+    if: |
+      !inputs.skip_tests &&
+      (inputs.quality_workflow ||
+       inputs.shifter_platform_app ||
+       inputs.shifter_platform ||
+       inputs.gcp)
     needs: [shifter-platform-lint-js]
     runs-on: self-hosted
     steps:
@@ -831,6 +978,7 @@ jobs:
     permissions:
       contents: read
     name: Lint JavaScript (mcp/${{ matrix.package }})
+    if: inputs.quality_workflow || inputs.mcp
     runs-on: self-hosted
     strategy:
       fail-fast: false
@@ -858,7 +1006,7 @@ jobs:
     permissions:
       contents: read
     name: Tests JavaScript (mcp/${{ matrix.package }})
-    if: ${{ !inputs.skip_tests }}
+    if: ${{ !inputs.skip_tests && (inputs.quality_workflow || inputs.mcp) }}
     needs: [mcp-lint]
     runs-on: self-hosted
     strategy:
@@ -891,6 +1039,14 @@ jobs:
     permissions:
       contents: read
     name: Security (IaC)
+    if: |
+      inputs.guardrails ||
+      inputs.quality_workflow ||
+      inputs.core ||
+      inputs.range ||
+      inputs.shifter_engine ||
+      inputs.shifter_platform ||
+      inputs.gcp
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
@@ -917,6 +1073,7 @@ jobs:
     permissions:
       contents: read
     name: Security (k8s)
+    if: inputs.guardrails || inputs.quality_workflow || inputs.gcp
     runs-on: self-hosted
     continue-on-error: true  # Soft-fail until manifest remediation complete
     steps:
@@ -973,6 +1130,11 @@ jobs:
     permissions:
       contents: read
     name: Architecture (model FKs)
+    if: |
+      inputs.quality_workflow ||
+      inputs.shifter_platform_app ||
+      inputs.shifter_platform ||
+      inputs.gcp
     runs-on: self-hosted
     services:
       postgres:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,8 +38,16 @@ jobs:
       shifter_engine: ${{ steps.filter.outputs.shifter_engine }}
       shifter_platform: ${{ steps.filter.outputs.shifter_platform }}
       shifter_app: ${{ steps.filter.outputs.shifter_app }}
+      shifter_platform_app: ${{ steps.filter.outputs.shifter_platform_app }}
       mcp: ${{ steps.filter.outputs.mcp }}
+      packer: ${{ steps.filter.outputs.packer }}
+      bootstrap: ${{ steps.filter.outputs.bootstrap }}
+      check_layer_imports: ${{ steps.filter.outputs.check_layer_imports }}
+      check_rds_pending_modifications: ${{ steps.filter.outputs.check_rds_pending_modifications }}
+      installation: ${{ steps.filter.outputs.installation }}
       gcp: ${{ steps.filter.outputs.gcp }}
+      guardrails: ${{ steps.filter.outputs.guardrails }}
+      quality_workflow: ${{ steps.filter.outputs.quality_workflow }}
       aws_environment: ${{ steps.env.outputs.aws_environment }}
       aws_is_dev: ${{ steps.env.outputs.aws_is_dev }}
       gcp_environment: ${{ steps.env.outputs.gcp_environment }}
@@ -82,9 +90,37 @@ jobs:
               - '.github/workflows/_shifter-platform.yml'
             shifter_app:
               - 'shifter/**'
+            shifter_platform_app:
+              - 'shifter/shifter_platform/**'
             mcp:
               - 'mcp/**'
+            packer:
+              - 'shifter/packer/**'
+            bootstrap:
+              - 'scripts/bootstrap/**'
+            check_layer_imports:
+              - 'scripts/check_layer_imports/**'
+            check_rds_pending_modifications:
+              - 'scripts/check_rds_pending_modifications/**'
+            installation:
+              - 'shifter/installation/**'
+            guardrails:
+              - '.github/workflows/**'
+              - '.github/CODEOWNERS'
+              - '.github/pull_request_template.md'
+              - '.github/copilot-instructions.md'
+              - '.pre-commit-config.yaml'
+              - '.importlinter'
+              - '.tflint.hcl'
+              - '.gitleaks.toml'
+              - '.kube-linter.yaml'
+              - '.claude/settings.json'
+              - '.claude/hooks/**'
+              - 'scripts/adr_guard/**'
+              - 'docs/adr/**'
+            quality_workflow:
               - '.github/workflows/_quality.yml'
+              - '.github/workflows/deploy.yml'
             gcp:
               - 'platform/terraform/gcp/**'
               - 'platform/k8s/gcp/**'
@@ -219,12 +255,35 @@ jobs:
        needs.changes.outputs.shifter_engine == 'true' ||
        needs.changes.outputs.shifter_platform == 'true' ||
        needs.changes.outputs.shifter_app == 'true' ||
+       needs.changes.outputs.shifter_platform_app == 'true' ||
        needs.changes.outputs.mcp == 'true' ||
+       needs.changes.outputs.packer == 'true' ||
+       needs.changes.outputs.bootstrap == 'true' ||
+       needs.changes.outputs.check_layer_imports == 'true' ||
+       needs.changes.outputs.check_rds_pending_modifications == 'true' ||
+       needs.changes.outputs.installation == 'true' ||
        needs.changes.outputs.gcp == 'true' ||
+       needs.changes.outputs.guardrails == 'true' ||
+       needs.changes.outputs.quality_workflow == 'true' ||
        github.event_name == 'workflow_dispatch')
     uses: ./.github/workflows/_quality.yml
     with:
       skip_tests: ${{ needs.changes.outputs.skip_tests == 'true' }}
+      core: ${{ needs.changes.outputs.core == 'true' }}
+      range: ${{ needs.changes.outputs.range == 'true' }}
+      shifter_engine: ${{ needs.changes.outputs.shifter_engine == 'true' }}
+      shifter_platform: ${{ needs.changes.outputs.shifter_platform == 'true' }}
+      shifter_app: ${{ needs.changes.outputs.shifter_app == 'true' }}
+      shifter_platform_app: ${{ needs.changes.outputs.shifter_platform_app == 'true' }}
+      mcp: ${{ needs.changes.outputs.mcp == 'true' }}
+      packer: ${{ needs.changes.outputs.packer == 'true' }}
+      bootstrap: ${{ needs.changes.outputs.bootstrap == 'true' }}
+      check_layer_imports: ${{ needs.changes.outputs.check_layer_imports == 'true' }}
+      check_rds_pending_modifications: ${{ needs.changes.outputs.check_rds_pending_modifications == 'true' }}
+      installation: ${{ needs.changes.outputs.installation == 'true' }}
+      gcp: ${{ needs.changes.outputs.gcp == 'true' }}
+      guardrails: ${{ needs.changes.outputs.guardrails == 'true' }}
+      quality_workflow: ${{ needs.changes.outputs.quality_workflow == 'true' || github.event_name == 'workflow_dispatch' }}
 
   gcp-dev:
     name: GCP Dev

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -30,7 +30,12 @@ Current mechanisms:
   - `check-tf-iam-ec2-scope`: local Terraform IAM hardening check that
     keeps engine-provisioner EC2 instance lifecycle actions scoped to
     Shifter-owned, Terraform-managed instances.
-- `.github/workflows/_quality.yml`: CI architecture gate
+- `.github/workflows/deploy.yml` and `.github/workflows/_quality.yml`:
+  CI quality gate. `deploy.yml` owns path detection and passes subsystem
+  booleans into `_quality.yml`; `_quality.yml` gates lint, SAST, type,
+  architecture, and test jobs by the relevant subsystem so unrelated
+  package checks do not fan out on every PR. Guardrail and quality-workflow
+  edits still run the enforcement jobs needed to validate the guardrails.
 - `.github/workflows/codeql-analysis.yml`: GitHub CodeQL static analysis
   with the `security-extended` query suite for Python and JavaScript;
   runs on push to `dev`, on pull requests against `dev`, and on a


### PR DESCRIPTION
## Summary
- pass deploy path-filter outputs into the reusable Quality workflow
- gate lint, SAST, type, architecture, and test jobs by the subsystem they validate
- keep the broad shifter_app trigger required by ADR guard, but add shifter_platform_app for platform-only jobs
- document the path-gated quality workflow behavior in ADR enforcement docs

## Checks
- actionlint
- git diff --check
- python3 scripts/adr_guard/adr_guard.py --all --level ci