### PR TITLE
ci: exempt dev promotion PRs from title lint

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -20,12 +20,12 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Skip conventional title on dev PRs
-        if: github.base_ref == 'dev'
+        if: github.base_ref == 'dev' || github.head_ref == 'dev'
         run: |
-          echo "PRs targeting dev are exempt from conventional title lint."
+          echo "PRs to or from dev are exempt from conventional title lint."
 
       - name: Validate conventional-commit title
-        if: github.base_ref != 'dev'
+        if: github.base_ref != 'dev' && github.head_ref != 'dev'
         # amannn/action-semantic-pull-request v5.5.3
         uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017
         env:

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -43,9 +43,9 @@ Current mechanisms:
   `security-events: write`, `actions: read`); no `pull_request_target`.
 - `.github/workflows/pr-title-lint.yml`: pull-request title validation
   against the conventional-commit shape used by towncrier and the
-  release-drafter conventions. PRs targeting the `dev` integration
-  branch are exempt; PRs targeting release/environment branches are
-  validated. Allowed types: `security`, `added`, `changed`,
+  release-drafter conventions. PRs to or from the `dev` integration
+  branch are exempt; release/environment promotion PRs that do not
+  involve `dev` are validated. Allowed types: `security`, `added`, `changed`,
   `deprecated`, `removed`, `fixed`, `feat`, `fix`, `chore`, `docs`,
   `refactor`, `test`, `ci`, `build`, `perf`, `revert`. Subject must
   start with a lowercase letter.


### PR DESCRIPTION
## Summary
- exempt PRs where dev is either the base branch or the head branch
- fixes dev -> main promotion PRs still failing title lint because head_ref was dev but base_ref was main
- update ADR enforcement docs for the corrected exemption scope

## Checks
- actionlint
- git diff --check
- python3 scripts/adr_guard/adr_guard.py --all --level ci