### PR TITLE
Clean up README by removing logo and badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,3 @@
-<p align="center">
-  <img src="assets/logo-wide-short.png" alt="Shifter">
-</p>
-
-[![Deploy](https://github.com/Brad-Edwards/shifter/actions/workflows/deploy.yml/badge.svg)](https://github.com/Brad-Edwards/shifter/actions/workflows/deploy.yml)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=Brad-Edwards_shifter&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=Brad-Edwards_shifter)
-[![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=Brad-Edwards_shifter&metric=vulnerabilities)](https://sonarcloud.io/summary/new_code?id=Brad-Edwards_shifter)
-[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=Brad-Edwards_shifter&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=Brad-Edwards_shifter)
-
 # Shifter
 
 Self-service agentic cyber range platform. Users provision isolated attack


### PR DESCRIPTION
Removed logo and badge sections from README.

## Summary

- What changed:
- Why:

## ADR Impact

- [ ] No ADR impact
- [ ] Existing ADRs updated
- [ ] New ADR added
- [ ] Temporary exception added to `docs/adr/exceptions.yaml`

ADRs touched:

Exceptions added or renewed:

## Guardrail Changes

- [ ] No guardrail files changed
- [ ] Guardrail files changed and matching docs were updated

Guardrail files changed:

## Verification

- [ ] `python3 scripts/adr_guard/adr_guard.py --all --level ci`
- [ ] Relevant stack-native checks passed (`lint-imports`, `actionlint`, `tflint`, `gitleaks`) where applicable
- [ ] Relevant tests
- [ ] Docs updated where behavior or enforcement changed
